### PR TITLE
Bump Google Play Services version to 8.1.0 or above

### DIFF
--- a/BraintreeApi/build.gradle
+++ b/BraintreeApi/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 dependencies {
     compile 'com.google.code.gson:gson:[2.2.4,3.0)'
-    compile 'com.google.android.gms:play-services-wallet:[7.5.0,8.0.0)'
+    compile 'com.google.android.gms:play-services-wallet:[8.1.0,9.0.0)'
 
     compile project(':BraintreeData')
     compile files('libs/' + paypalVersion)

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.google.android.gms:play-services-wallet:7.5.0'
+    compile 'com.google.android.gms:play-services-wallet:8.1.0'
 
     compile project(':Drop-In')
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     compile 'com.braintreepayments:card-form:2.0.1'
     compile project(':BraintreeApi')
-    compile 'com.google.android.gms:play-services-wallet:[7.5.0,8.0.0)'
+    compile 'com.google.android.gms:play-services-wallet:[8.1.0,9.0.0)'
 
     androidTestCompile project(':TestUtils')
 }


### PR DESCRIPTION
In reference to https://code.google.com/p/android/issues/detail?id=187483, clients depending on both Google Play Services 8.1.0 and on libraries who depend on Google Play Services < 8.1.0 will fail building, giving the dex error:

```
Unknown source file : Uncaught translation error: com.android.dx.cf.code.SimException: com.android.dx.rop.cst.CstMethodRef cannot be cast to com.android.dx.rop.cst.CstInterfaceMethodRef
Unknown source file : Uncaught translation error: com.android.dx.cf.code.SimException: com.android.dx.rop.cst.CstMethodRef cannot be cast to com.android.dx.rop.cst.CstInterfaceMethodRef
Unknown source file : 2 errors; aborting
```

This pull request is bumping up the gms wallet version in the Android Braintree SDK from 7.8.0 to 8.1.0. At first glance, it looks like this update is completely stable, and there don't seem to be any breaking changes.