### PR TITLE
Reprocess mechanism of PayPal authorization within browser.

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeBrowserSwitchActivity.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeBrowserSwitchActivity.java
@@ -1,25 +1,11 @@
 package com.braintreepayments.api;
 
 import android.app.Activity;
-import android.content.Intent;
-import android.os.Bundle;
 
 /**
- * Helper Activity that captures the response when browser switch completes.
+ * @deprecated Replaced by {@link com.paypal.android.sdk.onetouch.core.browser.PayPalAuthorizeActivity}. This {@link Activity}
+ * remains defined for backwards compatibility for integrations that have defined it in their manifest. This
+ * {@link Activity} will never be started.
  */
-public class BraintreeBrowserSwitchActivity extends Activity {
-
-    static final String EXTRA_BROWSER_SWITCH = "com.braintreepayments.api.BROWSER_SWITCH";
-
-    static Intent sLastBrowserSwitchResponse;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        getWindow().setBackgroundDrawableResource(android.R.color.transparent);
-
-        sLastBrowserSwitchResponse = getIntent();
-
-        finish();
-    }
-}
+@Deprecated
+public class BraintreeBrowserSwitchActivity extends Activity {}

--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
@@ -52,8 +52,6 @@ public class BraintreeFragment extends Fragment {
     private static final String EXTRA_SESSION_ID = "com.braintreepayments.api.EXTRA_SESSION_ID";
 
     @VisibleForTesting
-    static final String EXTRA_BROWSER_SWITCHING = "com.braintreepayments.api.EXTRA_BROWSER_SWITCHING";
-    @VisibleForTesting
     static final String EXTRA_CACHED_PAYMENT_METHOD_NONCES =
             "com.braintreepayments.api.EXTRA_CACHED_PAYMENT_METHOD_NONCES";
     @VisibleForTesting
@@ -75,7 +73,6 @@ public class BraintreeFragment extends Fragment {
     private final Queue<QueuedCallback> mCallbackQueue = new ArrayDeque<>();
     private final List<PaymentMethodNonce> mCachedPaymentMethodNonces = new ArrayList<>();
     private boolean mHasFetchedPaymentMethodNonces = false;
-    private boolean mIsBrowserSwitching = false;
     private int mConfigurationRequestAttempts = 0;
     private String mSessionId;
 
@@ -159,7 +156,6 @@ public class BraintreeFragment extends Fragment {
             }
 
             mHasFetchedPaymentMethodNonces = savedInstanceState.getBoolean(EXTRA_FETCHED_PAYMENT_METHOD_NONCES);
-            mIsBrowserSwitching = savedInstanceState.getBoolean(EXTRA_BROWSER_SWITCHING);
             mSessionId = savedInstanceState.getString(EXTRA_SESSION_ID);
         } else {
             mSessionId = DeviceMetadata.getFormattedUUID();
@@ -187,19 +183,6 @@ public class BraintreeFragment extends Fragment {
                 !mGoogleApiClient.isConnecting()) {
             mGoogleApiClient.connect();
         }
-
-        if (mIsBrowserSwitching) {
-            int resultCode = Activity.RESULT_CANCELED;
-            if (BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse != null) {
-                resultCode = Activity.RESULT_OK;
-            }
-
-            onActivityResult(PayPal.PAYPAL_REQUEST_CODE, resultCode,
-                    BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse);
-
-            BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse = null;
-            mIsBrowserSwitching = false;
-        }
     }
 
     @Override
@@ -219,7 +202,6 @@ public class BraintreeFragment extends Fragment {
         outState.putParcelableArrayList(EXTRA_CACHED_PAYMENT_METHOD_NONCES,
                 (ArrayList<? extends Parcelable>) mCachedPaymentMethodNonces);
         outState.putBoolean(EXTRA_FETCHED_PAYMENT_METHOD_NONCES, mHasFetchedPaymentMethodNonces);
-        outState.putBoolean(EXTRA_BROWSER_SWITCHING, mIsBrowserSwitching);
         outState.putString(EXTRA_SESSION_ID, mSessionId);
     }
 
@@ -237,17 +219,6 @@ public class BraintreeFragment extends Fragment {
         super.onDestroy();
 
         mCrashReporter.tearDown();
-    }
-
-    @Override
-    public void startActivity(Intent intent) {
-        if (intent.hasExtra(BraintreeBrowserSwitchActivity.EXTRA_BROWSER_SWITCH)) {
-            BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse = null;
-            mIsBrowserSwitching = true;
-            getActivity().startActivity(intent);
-        } else {
-            super.startActivity(intent);
-        }
     }
 
     @Override

--- a/Braintree/src/test/java/com/braintreepayments/api/BraintreeFragmentUnitTest.java
+++ b/Braintree/src/test/java/com/braintreepayments/api/BraintreeFragmentUnitTest.java
@@ -207,7 +207,6 @@ public class BraintreeFragmentUnitTest {
 
         assertTrue(bundle.getParcelableArrayList(BraintreeFragment.EXTRA_CACHED_PAYMENT_METHOD_NONCES).isEmpty());
         assertFalse(bundle.getBoolean(BraintreeFragment.EXTRA_FETCHED_PAYMENT_METHOD_NONCES));
-        assertFalse(bundle.getBoolean(BraintreeFragment.EXTRA_BROWSER_SWITCHING));
     }
 
     @Test
@@ -682,16 +681,6 @@ public class BraintreeFragmentUnitTest {
     }
 
     @Test
-    public void startActivity_clearsLastBrowserSwitchResponseWhenBrowserSwitching() throws InvalidArgumentException {
-        BraintreeFragment fragment = BraintreeFragment.newInstance(mActivity, TOKENIZATION_KEY);
-        BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse = new Intent();
-
-        fragment.startActivity(new Intent().putExtra(BraintreeBrowserSwitchActivity.EXTRA_BROWSER_SWITCH, true));
-
-        assertNull(BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse);
-    }
-
-    @Test
     public void onResume_doesNothingIfNotBrowserSwitching() throws InvalidArgumentException {
         BraintreeFragment fragment = BraintreeFragment.newInstance(mActivity, TOKENIZATION_KEY);
         mockStatic(PayPal.class);
@@ -700,23 +689,6 @@ public class BraintreeFragmentUnitTest {
 
         verifyStatic(never());
         PayPal.onActivityResult(any(BraintreeFragment.class), anyInt(), any(Intent.class));
-    }
-
-    @Test
-    public void onResume_handlesBrowserSwitch() throws InvalidArgumentException {
-        BraintreeFragment fragment = BraintreeFragment.newInstance(mActivity, TOKENIZATION_KEY);
-        mockStatic(PayPal.class);
-        fragment.startActivity(new Intent().putExtra(BraintreeBrowserSwitchActivity.EXTRA_BROWSER_SWITCH, true));
-        Intent intent = new Intent();
-        BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse = intent;
-
-        fragment.onResume();
-
-        assertNull(BraintreeBrowserSwitchActivity.sLastBrowserSwitchResponse);
-        fragment.onResume();
-
-        verifyStatic(times(1));
-        PayPal.onActivityResult(fragment, Activity.RESULT_OK, intent);
     }
 
     /* helpers */

--- a/PayPalOneTouch/src/main/AndroidManifest.xml
+++ b/PayPalOneTouch/src/main/AndroidManifest.xml
@@ -3,4 +3,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <application>
+        <activity android:name="com.paypal.android.sdk.onetouch.core.browser.PayPalAuthorizeActivity"/>
+    </application>
+
 </manifest>

--- a/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeActivity.java
+++ b/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeActivity.java
@@ -1,0 +1,32 @@
+package com.paypal.android.sdk.onetouch.core.browser;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.FrameLayout;
+
+public class PayPalAuthorizeActivity extends Activity {
+
+    public static final String REDIRECT_URI_SCHEME_ARG = "PayPalAuthorizeActivity.RedirectUri";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        FrameLayout rootView = (FrameLayout) findViewById(android.R.id.content);
+
+        String uriScheme = getIntent().getStringExtra(REDIRECT_URI_SCHEME_ARG);
+
+        PayPalAuthorizeWebView payPalAuthorizeWebView = new PayPalAuthorizeWebView(this);
+        payPalAuthorizeWebView.init(this, uriScheme);
+        payPalAuthorizeWebView.loadUrl(getIntent().getData().toString());
+
+        rootView.addView(payPalAuthorizeWebView);
+    }
+
+    public void finishWithResult(String url) {
+        setResult(Activity.RESULT_OK,  new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        finish();
+    }
+}

--- a/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeWebClient.java
+++ b/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeWebClient.java
@@ -1,0 +1,24 @@
+package com.paypal.android.sdk.onetouch.core.browser;
+
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+public class PayPalAuthorizeWebClient extends WebViewClient {
+
+    private final PayPalAuthorizeActivity activity;
+    private final String uriScheme;
+
+    public PayPalAuthorizeWebClient(PayPalAuthorizeActivity activity, String uriScheme) {
+        this.activity = activity;
+        this.uriScheme = uriScheme;
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        if (!url.startsWith(uriScheme)) {
+            return false;
+        }
+        activity.finishWithResult(url);
+        return true;
+    }
+}

--- a/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeWebView.java
+++ b/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/browser/PayPalAuthorizeWebView.java
@@ -1,0 +1,44 @@
+package com.paypal.android.sdk.onetouch.core.browser;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import android.util.AttributeSet;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+@SuppressLint("SetJavaScriptEnabled")
+public class PayPalAuthorizeWebView extends WebView {
+
+    public PayPalAuthorizeWebView(Context context) {
+        super(context);
+    }
+
+    public PayPalAuthorizeWebView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public PayPalAuthorizeWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(VERSION_CODES.LOLLIPOP)
+    public PayPalAuthorizeWebView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    protected void init(PayPalAuthorizeActivity activity, String uriScheme) {
+        setId(android.R.id.widget_frame);
+
+        WebSettings settings = getSettings();
+        settings.setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+        settings.setSupportMultipleWindows(true);
+        settings.setJavaScriptEnabled(true);
+        settings.setBuiltInZoomControls(true);
+        settings.setDisplayZoomControls(false);
+
+        setWebViewClient(new PayPalAuthorizeWebClient(activity, uriScheme));
+    }
+
+}

--- a/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/sdk/BrowserSwitchHelper.java
+++ b/PayPalOneTouch/src/main/java/com/paypal/android/sdk/onetouch/core/sdk/BrowserSwitchHelper.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import com.paypal.android.sdk.onetouch.core.Request;
 import com.paypal.android.sdk.onetouch.core.Result;
 import com.paypal.android.sdk.onetouch.core.base.ContextInspector;
+import com.paypal.android.sdk.onetouch.core.browser.PayPalAuthorizeActivity;
 import com.paypal.android.sdk.onetouch.core.config.ConfigManager;
 import com.paypal.android.sdk.onetouch.core.config.OtcConfiguration;
 import com.paypal.android.sdk.onetouch.core.config.Recipe;
@@ -28,22 +29,18 @@ public class BrowserSwitchHelper {
     public static Intent getBrowserSwitchIntent(ContextInspector contextInspector,
             ConfigManager configManager, Request request) {
         OtcConfiguration configuration = configManager.getConfig();
+
         try {
             String url = request.getBrowserSwitchUrl(contextInspector.getContext(), configuration);
-
             request.persistRequiredFields(contextInspector);
 
             Recipe<?> recipe = request.getBrowserSwitchRecipe(configuration);
 
-            for (String allowedBrowserPackage : recipe.getTargetPackagesInReversePriorityOrder()) {
-                boolean canIntentBeResolved = Recipe.isValidBrowserTarget(contextInspector.getContext(), url,
-                        allowedBrowserPackage);
-                if (canIntentBeResolved) {
-                    request.trackFpti(contextInspector.getContext(), TrackingPoint.SwitchToBrowser,
-                            recipe.getProtocol());
-                    return Recipe.getBrowserIntent(url, allowedBrowserPackage);
-                }
-            }
+            Intent intent = new Intent(contextInspector.getContext(), PayPalAuthorizeActivity.class);
+            intent.putExtra(PayPalAuthorizeActivity.REDIRECT_URI_SCHEME_ARG, contextInspector.getContext().getPackageName() + ".braintree");
+            intent.setData(Uri.parse(url));
+            request.trackFpti(contextInspector.getContext(), TrackingPoint.SwitchToBrowser, recipe.getProtocol());
+            return intent;
         } catch (CertificateException | UnsupportedEncodingException | NoSuchPaddingException
                 | NoSuchAlgorithmException | IllegalBlockSizeException | JSONException
                 | BadPaddingException | InvalidEncryptionDataException

--- a/PayPalOneTouch/src/test/java/com/paypal/android/sdk/onetouch/core/sdk/BrowserSwitchHelperTest.java
+++ b/PayPalOneTouch/src/test/java/com/paypal/android/sdk/onetouch/core/sdk/BrowserSwitchHelperTest.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import com.paypal.android.sdk.onetouch.core.CheckoutRequest;
 import com.paypal.android.sdk.onetouch.core.Result;
 import com.paypal.android.sdk.onetouch.core.base.ContextInspector;
+import com.paypal.android.sdk.onetouch.core.browser.PayPalAuthorizeActivity;
 import com.paypal.android.sdk.onetouch.core.config.ConfigManager;
 import com.paypal.android.sdk.onetouch.core.enums.Protocol;
 import com.paypal.android.sdk.onetouch.core.enums.ResponseType;
@@ -74,9 +75,8 @@ public class BrowserSwitchHelperTest {
         verify(request).trackFpti(any(Context.class), eq(TrackingPoint.SwitchToBrowser),
                 any(Protocol.class));
 
-        assertEquals(Intent.ACTION_VIEW, intent.getAction());
+        assertEquals(PayPalAuthorizeActivity.class.getName(), intent.getComponent().getClassName());
         assertEquals("https://paypal.com/?token=test-token-key", intent.getData().toString());
-        assertEquals("com.android.chrome", intent.getPackage());
     }
 
     @Test


### PR DESCRIPTION
* Replace BraintreeBrowserSwitchActivity, authorizing with mobile browser tab with Authorize activity contains web view;
* Simplify development integration (Avoid adding need classes to developer manifest and excess checks for correctness);
* Fix bug with incorrect redirecting after PayPal authorization into developer main activity of application instead of start activity (in case of activity start from service)