### PR TITLE
Migrate lint check to new PSI API

### DIFF
--- a/Lint/build.gradle
+++ b/Lint/build.gradle
@@ -11,7 +11,11 @@ configurations {
 }
 
 dependencies {
-    compile 'com.android.tools.lint:lint-api:25.1.3'
+    compile 'com.android.tools.lint:lint-api:25.2.0'
+    testCompile 'org.assertj:assertj-core:3.0.0'
+    testCompile 'com.android.tools.lint:lint:25.2.0'
+    testCompile 'com.android.tools.lint:lint-tests:25.2.0'
+    testCompile 'com.android.tools:testutils:25.2.0'
 
     lintChecks files(jar)
 }

--- a/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
+++ b/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
@@ -1,83 +1,50 @@
 package com.braintreepayments.lint;
 
-import com.android.annotations.NonNull;
-import com.android.annotations.Nullable;
 import com.android.tools.lint.detector.api.Category;
 import com.android.tools.lint.detector.api.Detector;
-import com.android.tools.lint.detector.api.Detector.JavaScanner;
 import com.android.tools.lint.detector.api.Implementation;
 import com.android.tools.lint.detector.api.Issue;
 import com.android.tools.lint.detector.api.JavaContext;
 import com.android.tools.lint.detector.api.Scope;
 import com.android.tools.lint.detector.api.Severity;
-import com.android.tools.lint.detector.api.Speed;
 import com.android.tools.lint.detector.api.TextFormat;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodCallExpression;
 
 import java.util.Collections;
 import java.util.List;
 
-import lombok.ast.AstVisitor;
-import lombok.ast.MethodInvocation;
-import lombok.ast.Node;
+public class BetaDetector extends Detector implements Detector.JavaPsiScanner {
+  // This would normally be private final, but has exposed here for testing purposes, since there
+  // seems to be no way to inject it via the Detector constructor using LintDetectorTest
+  static List<String> METHODS = Collections.emptyList();
+  private static final Implementation IMPLEMENTATION = new Implementation(BetaDetector.class,
+      Scope.JAVA_FILE_SCOPE);
+  static final Issue ISSUE = Issue.create(
+      "com.braintreepayments.beta",
+      "API is in beta",
+      "This API is currently in beta and subject to change. Braintree makes no guarantees about " +
+          "future compatibility or existence of this API.",
+      Category.CORRECTNESS,
+      6,
+      Severity.ERROR,
+      IMPLEMENTATION);
 
-public class BetaDetector extends Detector implements JavaScanner {
+  public BetaDetector() {
+  }
 
-    private static final List<String> METHODS = Collections.emptyList();
+  @Override
+  public List<String> getApplicableMethodNames() {
+    return METHODS;
+  }
 
-    private static final Implementation IMPLEMENTATION = new Implementation(BetaDetector.class,
-            Scope.JAVA_FILE_SCOPE);
-
-    public static final Issue ISSUE = Issue.create(
-            "com.braintreepayments.beta",
-            "API is in beta",
-            "This API is currently in beta and subject to change. Braintree makes no guarantees about future compatibility or existence of this API.",
-            Category.CORRECTNESS,
-            6,
-            Severity.ERROR,
-            IMPLEMENTATION);
-
-    public BetaDetector() {}
-
-    @Override
-    public Speed getSpeed() {
-        return Speed.FAST;
+  @Override
+  public void visitMethod(JavaContext context, JavaElementVisitor visitor,
+      PsiMethodCallExpression node, PsiMethod method) {
+    if (METHODS.contains(method.getName())) {
+      context.report(ISSUE, node, context.getLocation(node), ISSUE.getBriefDescription(
+          TextFormat.TEXT));
     }
-
-    @Override
-    public List<String> getApplicableMethodNames() {
-        return METHODS;
-    }
-
-    @Override
-    public void visitMethod(@NonNull JavaContext context, @Nullable AstVisitor visitor,
-            @NonNull MethodInvocation node) {
-        if (METHODS.contains(node.astName().astValue())) {
-            context.report(ISSUE, node, context.getLocation(node), ISSUE.getBriefDescription(TextFormat.TEXT));
-        }
-    }
-
-    @Override
-    public AstVisitor createJavaVisitor(@NonNull JavaContext context) {
-        return null;
-    }
-
-    @Override
-    public List<Class<? extends Node>> getApplicableNodeTypes() {
-        return null;
-    }
-
-    @Override
-    public boolean appliesToResourceRefs() {
-        return false;
-    }
-
-    @Override
-    public void visitResourceReference(@NonNull JavaContext context, @Nullable AstVisitor visitor,
-            @NonNull Node node, @NonNull String type, @NonNull String name, boolean isFramework) {
-    }
-
-    @Override
-    public List<String> applicableSuperClasses() {
-        return null;
-    }
+  }
 }

--- a/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
+++ b/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
@@ -16,35 +16,35 @@ import java.util.Collections;
 import java.util.List;
 
 public class BetaDetector extends Detector implements Detector.JavaPsiScanner {
-  // This would normally be private final, but has exposed here for testing purposes, since there
-  // seems to be no way to inject it via the Detector constructor using LintDetectorTest
-  static List<String> METHODS = Collections.emptyList();
-  private static final Implementation IMPLEMENTATION = new Implementation(BetaDetector.class,
-      Scope.JAVA_FILE_SCOPE);
-  static final Issue ISSUE = Issue.create(
-      "com.braintreepayments.beta",
-      "API is in beta",
-      "This API is currently in beta and subject to change. Braintree makes no guarantees about " +
-          "future compatibility or existence of this API.",
-      Category.CORRECTNESS,
-      6,
-      Severity.ERROR,
-      IMPLEMENTATION);
+    // This would normally be private final, but has exposed here for testing purposes, since there
+    // seems to be no way to inject it via the Detector constructor using LintDetectorTest
+    static List<String> METHODS = Collections.emptyList();
+    private static final Implementation IMPLEMENTATION = new Implementation(BetaDetector.class,
+            Scope.JAVA_FILE_SCOPE);
+    static final Issue ISSUE = Issue.create(
+            "com.braintreepayments.beta",
+            "API is in beta",
+            "This API is currently in beta and subject to change. Braintree makes no guarantees about " +
+                    "future compatibility or existence of this API.",
+            Category.CORRECTNESS,
+            6,
+            Severity.ERROR,
+            IMPLEMENTATION);
 
-  public BetaDetector() {
-  }
-
-  @Override
-  public List<String> getApplicableMethodNames() {
-    return METHODS;
-  }
-
-  @Override
-  public void visitMethod(JavaContext context, JavaElementVisitor visitor,
-      PsiMethodCallExpression node, PsiMethod method) {
-    if (METHODS.contains(method.getName())) {
-      context.report(ISSUE, node, context.getLocation(node), ISSUE.getBriefDescription(
-          TextFormat.TEXT));
+    public BetaDetector() {
     }
-  }
+
+    @Override
+    public List<String> getApplicableMethodNames() {
+        return METHODS;
+    }
+
+    @Override
+    public void visitMethod(JavaContext context, JavaElementVisitor visitor,
+            PsiMethodCallExpression node, PsiMethod method) {
+        if (METHODS.contains(method.getName())) {
+            context.report(ISSUE, node, context.getLocation(node), ISSUE.getBriefDescription(
+                    TextFormat.TEXT));
+        }
+    }
 }

--- a/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
+++ b/Lint/src/main/java/com/braintreepayments/lint/BetaDetector.java
@@ -16,8 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class BetaDetector extends Detector implements Detector.JavaPsiScanner {
-    // This would normally be private final, but has exposed here for testing purposes, since there
-    // seems to be no way to inject it via the Detector constructor using LintDetectorTest
+
     static List<String> METHODS = Collections.emptyList();
     private static final Implementation IMPLEMENTATION = new Implementation(BetaDetector.class,
             Scope.JAVA_FILE_SCOPE);

--- a/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
+++ b/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
@@ -1,0 +1,64 @@
+package com.braintreepayments.lint;
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Issue;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BetaDetectorTest extends LintDetectorTest {
+  @Override
+  protected Detector getDetector() {
+    return new BetaDetector();
+  }
+
+  @Override
+  protected List<Issue> getIssues() {
+    return Collections.singletonList(BetaDetector.ISSUE);
+  }
+
+  public void testBetaMethod() throws Exception {
+    BetaDetector.METHODS = Collections.singletonList("fooBar");
+    String result = lintProject(
+        java("src/com/example/Foo.java", "package com.example;\n" +
+            "public class Foo {\n" +
+            "  public void someMethod() {\n" +
+            "    Baz baz = new Baz();\n" +
+            "    baz.fooBar();" +
+            "  }\n" +
+            "}"),
+        java("src/com/example/Baz.java", "package com.example;\n" +
+            "public class Baz {\n" +
+            "  public void fooBar() {\n" +
+            "  }\n" +
+            "}"));
+
+    assertThat(result).isEqualTo(
+        "src/com/example/Foo.java:5: Error: API is in beta [com.braintreepayments.beta]\n" +
+            "    baz.fooBar();  }\n" +
+            "    ~~~~~~~~~~~~\n" +
+            "1 errors, 0 warnings\n");
+  }
+
+  public void testNormalMethod() throws Exception {
+    BetaDetector.METHODS = Collections.singletonList("fooBar");
+    String result = lintProject(
+        java("src/com/example/Foo.java", "package com.example;\n" +
+            "public class Foo {\n" +
+            "  public void someMethod() {\n" +
+            "    Baz baz = new Baz();\n" +
+            "    baz.fooBarBaz();" +
+            "  }\n" +
+            "}"),
+        java("src/com/example/Baz.java", "package com.example;\n" +
+            "public class Baz {\n" +
+            "  public void fooBarBaz() {\n" +
+            "  }\n" +
+            "}"));
+
+    assertThat(result).isEqualTo("No warnings.");
+  }
+}

--- a/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
+++ b/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BetaDetectorTest extends LintDetectorTest {
+
     @Override
     protected Detector getDetector() {
         return new BetaDetector();

--- a/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
+++ b/Lint/src/test/java/com/braintreepayments/lint/BetaDetectorTest.java
@@ -10,55 +10,55 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BetaDetectorTest extends LintDetectorTest {
-  @Override
-  protected Detector getDetector() {
-    return new BetaDetector();
-  }
+    @Override
+    protected Detector getDetector() {
+        return new BetaDetector();
+    }
 
-  @Override
-  protected List<Issue> getIssues() {
-    return Collections.singletonList(BetaDetector.ISSUE);
-  }
+    @Override
+    protected List<Issue> getIssues() {
+        return Collections.singletonList(BetaDetector.ISSUE);
+    }
 
-  public void testBetaMethod() throws Exception {
-    BetaDetector.METHODS = Collections.singletonList("fooBar");
-    String result = lintProject(
-        java("src/com/example/Foo.java", "package com.example;\n" +
-            "public class Foo {\n" +
-            "  public void someMethod() {\n" +
-            "    Baz baz = new Baz();\n" +
-            "    baz.fooBar();" +
-            "  }\n" +
-            "}"),
-        java("src/com/example/Baz.java", "package com.example;\n" +
-            "public class Baz {\n" +
-            "  public void fooBar() {\n" +
-            "  }\n" +
-            "}"));
+    public void testBetaMethod() throws Exception {
+        BetaDetector.METHODS = Collections.singletonList("fooBar");
+        String result = lintProject(
+                java("src/com/example/Foo.java", "package com.example;\n" +
+                        "public class Foo {\n" +
+                        "  public void someMethod() {\n" +
+                        "    Baz baz = new Baz();\n" +
+                        "    baz.fooBar();" +
+                        "  }\n" +
+                        "}"),
+                java("src/com/example/Baz.java", "package com.example;\n" +
+                        "public class Baz {\n" +
+                        "  public void fooBar() {\n" +
+                        "  }\n" +
+                        "}"));
 
-    assertThat(result).isEqualTo(
-        "src/com/example/Foo.java:5: Error: API is in beta [com.braintreepayments.beta]\n" +
-            "    baz.fooBar();  }\n" +
-            "    ~~~~~~~~~~~~\n" +
-            "1 errors, 0 warnings\n");
-  }
+        assertThat(result).isEqualTo(
+                "src/com/example/Foo.java:5: Error: API is in beta [com.braintreepayments.beta]\n" +
+                        "    baz.fooBar();  }\n" +
+                        "    ~~~~~~~~~~~~\n" +
+                        "1 errors, 0 warnings\n");
+    }
 
-  public void testNormalMethod() throws Exception {
-    BetaDetector.METHODS = Collections.singletonList("fooBar");
-    String result = lintProject(
-        java("src/com/example/Foo.java", "package com.example;\n" +
-            "public class Foo {\n" +
-            "  public void someMethod() {\n" +
-            "    Baz baz = new Baz();\n" +
-            "    baz.fooBarBaz();" +
-            "  }\n" +
-            "}"),
-        java("src/com/example/Baz.java", "package com.example;\n" +
-            "public class Baz {\n" +
-            "  public void fooBarBaz() {\n" +
-            "  }\n" +
-            "}"));
+    public void testNormalMethod() throws Exception {
+        BetaDetector.METHODS = Collections.singletonList("fooBar");
+        String result = lintProject(
+                java("src/com/example/Foo.java", "package com.example;\n" +
+                        "public class Foo {\n" +
+                        "  public void someMethod() {\n" +
+                        "    Baz baz = new Baz();\n" +
+                        "    baz.fooBarBaz();" +
+                        "  }\n" +
+                        "}"),
+                java("src/com/example/Baz.java", "package com.example;\n" +
+                        "public class Baz {\n" +
+                        "  public void fooBarBaz() {\n" +
+                        "  }\n" +
+                        "}"));
 
-    assertThat(result).isEqualTo("No warnings.");
-  }
+        assertThat(result).isEqualTo("No warnings.");
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
 


### PR DESCRIPTION
Custom lint checks using the old and deprecated Lombok AST API cause an incompatibility between the Android lint and Retrolambda as described here https://github.com/evant/gradle-retrolambda/issues/96

Migrating to the new API fixes the issue.