### PR TITLE
Issue #252 - BraintreeFragment with child FragmentManager.

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/internal/IntegrationType.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/internal/IntegrationType.java
@@ -1,18 +1,18 @@
 package com.braintreepayments.api.internal;
 
-import android.app.Activity;
+import android.content.Context;
 
 public class IntegrationType {
 
-    public static String get(Activity activity) {
+    public static String get(Context context) {
         try {
-            if (Class.forName("com.braintreepayments.api.BraintreePaymentActivity").isInstance(activity)) {
+            if (Class.forName("com.braintreepayments.api.BraintreePaymentActivity").isInstance(context)) {
                 return "dropin";
             }
         } catch (ClassNotFoundException ignored) {}
 
         try {
-            if (Class.forName("com.braintreepayments.api.dropin.DropInActivity").isInstance(activity)) {
+            if (Class.forName("com.braintreepayments.api.dropin.DropInActivity").isInstance(context)) {
                 return "dropin2";
             }
         } catch (ClassNotFoundException ignored) {}

--- a/Braintree/src/test/java/com/braintreepayments/api/BraintreeFragmentUnitTest.java
+++ b/Braintree/src/test/java/com/braintreepayments/api/BraintreeFragmentUnitTest.java
@@ -60,6 +60,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 
 import static com.braintreepayments.api.internal.AnalyticsDatabaseTestUtils.verifyAnalyticsEvent;
 import static com.braintreepayments.testutils.FixturesHelper.stringFromFixture;
@@ -141,7 +142,12 @@ public class BraintreeFragmentUnitTest {
 
     @Test(expected = InvalidArgumentException.class)
     public void newInstance_throwsAnExceptionWhenActivityIsNull() throws InvalidArgumentException {
-        BraintreeFragment.newInstance(null, TOKENIZATION_KEY);
+        BraintreeFragment.newInstance((AppCompatActivity) null, TOKENIZATION_KEY);
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void newInstance_throwsAnExceptionWhenFragmentIsNull() throws InvalidArgumentException {
+        BraintreeFragment.newInstance((Fragment) null, TOKENIZATION_KEY);
     }
 
     @Test(expected = InvalidArgumentException.class)


### PR DESCRIPTION
Solution for issue #252 , attaching BraintreeFragment to a child FragmentManager so that the instance can stay in the scope of a Fragment hosted by an Activity.