### PR TITLE
[Proof of Concept] Create new BraintreeFragment when authorization string doesn't match

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
@@ -170,7 +170,8 @@ public class BraintreeFragment extends BrowserSwitchFragment {
         }
 
         BraintreeFragment braintreeFragment = (BraintreeFragment) fragmentManager.findFragmentByTag(TAG);
-        if (braintreeFragment == null) {
+        
+        if (braintreeFragment == null || !braintreeFragment.hasMatchingAuthorization(authorization)) {
             braintreeFragment = new BraintreeFragment();
             Bundle bundle = new Bundle();
 
@@ -187,6 +188,7 @@ public class BraintreeFragment extends BrowserSwitchFragment {
 
             try {
                 if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                    // TODO: where we use `add`, we might nee to use `replace` if an existing fragment for that TAG exists
                     try {
                         fragmentManager.beginTransaction().add(braintreeFragment, TAG).commitNow();
                     } catch (IllegalStateException | NullPointerException e) {
@@ -557,6 +559,10 @@ public class BraintreeFragment extends BrowserSwitchFragment {
      */
     public boolean hasFetchedPaymentMethodNonces() {
         return mHasFetchedPaymentMethodNonces;
+    }
+    
+    public boolean hasMatchingAuthorization(String authorization) {
+        return mAuthorization.toString() == authorization;
     }
 
     /**


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

Currently when we call `BraintreeFragment.newInstance()`, it can sometimes return a cached instance which is fine when all the other parameters are the same. However, when I call `BraintreeFragment.newInstance()` with a different `authorization` string, it should NOT returned the cached instance and instead create a new one with the new `authorization` string.

The PR below is untested and is more of a proof of concept.

I also noted that for FragmentTransactions, we would need to update `add` with `replace` when there's an existing fragment associated to `TAG`.

Example:

```kt
val activity = getAppCompatActivity()
val bf1 = BraintreeFragment.newInstance(activity, "123456")
val bf2 = BraintreeFragment.newInstance(activity, "abcedf")
```

Both calls would actually return an instance of `BraintreeFragment` where the `authorization` is `"123456"`

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
