### PR TITLE
Use `synchronized` when adding to callback queue

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
@@ -10,12 +10,6 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
 
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-
 import com.braintreepayments.api.exceptions.BraintreeException;
 import com.braintreepayments.api.exceptions.ConfigurationException;
 import com.braintreepayments.api.exceptions.GoogleApiClientException;
@@ -67,6 +61,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
 import java.util.UUID;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * Core Braintree class that handles network requests and managing callbacks.
@@ -761,7 +761,9 @@ public class BraintreeFragment extends BrowserSwitchFragment {
     @VisibleForTesting
     protected void postOrQueueCallback(QueuedCallback callback) {
         if (!callback.shouldRun()) {
-            mCallbackQueue.add(callback);
+            synchronized (mCallbackQueue) {
+                mCallbackQueue.add(callback);
+            }
         } else {
             callback.run();
         }


### PR DESCRIPTION
We have in production a lot of Fatal Exception (23 in 7 days):
```
 java.util.ConcurrentModificationException
    at java.util.ArrayDeque$DeqIterator.next + 625(ArrayDeque.java:625)
    at java.util.AbstractCollection.addAll + 343(AbstractCollection.java:343)
    at java.util.ArrayDeque.<init> + 197(ArrayDeque.java:197)
    at com.braintreepayments.api.BraintreeFragment.flushCallbacks + 726(BraintreeFragment.java:726)
   at com.braintreepayments.api.BraintreeFragment.onResume + 249(BraintreeFragment.java:249)
```
The only part where mCallbackQueue is **not** syncronized is **postOrQueueCallback**.
I suppose while make a copy of **mCallbackQueue** in **flushCallbacks** (line 726) an other thread call **postOrQueueCallback**

Regards
Stephan

