### PR TITLE
Do not open PayPal (browser) if Activity is destroyed (#295)

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
@@ -610,6 +610,15 @@ public class BraintreeFragment extends BrowserSwitchFragment {
         return Collections.unmodifiableList(mCachedPaymentMethodNonces);
     }
 
+    /**
+     * Check if this Braintree fragment is still active.
+     *
+     * @return {@code true} if still active and process can proceed, {@code false} otherwise.
+     */
+    public boolean isActive() {
+        return isAdded();
+    }
+
     public void sendAnalyticsEvent(final String eventFragment) {
         final AnalyticsEvent request = new AnalyticsEvent(mContext, getSessionId(), mIntegrationType, eventFragment);
         waitForConfiguration(new ConfigurationListener() {

--- a/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/BraintreeFragment.java
@@ -615,6 +615,7 @@ public class BraintreeFragment extends BrowserSwitchFragment {
      *
      * @return {@code true} if still active and process can proceed, {@code false} otherwise.
      */
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public boolean isActive() {
         return isAdded();
     }

--- a/Braintree/src/main/java/com/braintreepayments/api/PayPal.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/PayPal.java
@@ -340,6 +340,11 @@ public class PayPal {
         return new PayPalApprovalHandler() {
             @Override
             public void handleApproval(Request request, PayPalApprovalCallback paypalApprovalCallback) {
+                // Ensure that Activity is still running before proceeding
+                if (!fragment.isActive()) {
+                    return;
+                }
+
                 PendingRequest pendingRequest =
                         PayPalOneTouchCore.getStartIntent(fragment.getApplicationContext(), request);
 

--- a/Braintree/src/test/java/com/braintreepayments/api/MockFragmentBuilder.java
+++ b/Braintree/src/test/java/com/braintreepayments/api/MockFragmentBuilder.java
@@ -32,6 +32,7 @@ public class MockFragmentBuilder {
     private String mGraphQLSuccessResponse;
     private Exception mGraphQLErrorResponse;
     private String mIntegration;
+    private Boolean mIsActive = true;
 
     public MockFragmentBuilder() {
         mContext = RuntimeEnvironment.application;
@@ -90,6 +91,11 @@ public class MockFragmentBuilder {
         return this;
     }
 
+    public MockFragmentBuilder isActive(boolean isActive) {
+        mIsActive = isActive;
+        return this;
+    }
+
     public BraintreeFragment build() {
         BraintreeFragment fragment = mock(BraintreeFragment.class);
         when(fragment.getApplicationContext()).thenReturn(mContext);
@@ -97,6 +103,7 @@ public class MockFragmentBuilder {
         when(fragment.getSessionId()).thenReturn(mSessionId);
         when(fragment.getReturnUrlScheme()).thenReturn("com.braintreepayments.api.braintree");
         when(fragment.getIntegrationType()).thenReturn(mIntegration);
+        when(fragment.isActive()).thenReturn(mIsActive);
 
         doAnswer(new Answer() {
             @Override

--- a/Braintree/src/test/java/com/braintreepayments/api/PayPalUnitTest.java
+++ b/Braintree/src/test/java/com/braintreepayments/api/PayPalUnitTest.java
@@ -177,6 +177,18 @@ public class PayPalUnitTest {
     }
 
     @Test
+    public void requestBillingAgreement_fragmentNotActive_notStartsBrowser() {
+        BraintreeFragment fragment = mMockFragmentBuilder
+                .successResponse(stringFromFixture("paypal_hermes_billing_agreement_response.json"))
+                .isActive(false)
+                .build();
+
+        PayPal.requestBillingAgreement(fragment, new PayPalRequest());
+
+        verify(fragment, never()).browserSwitch(eq(BraintreeRequestCodes.PAYPAL), any(Intent.class));
+    }
+
+    @Test
     public void requestBillingAgreement_defaultPostParamsIncludeCorrectValues() throws JSONException {
         BraintreeFragment fragment = mMockFragmentBuilder.build();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Do not open PayPal (browser) if Activity has been destroyed (fixes #295)
+
 ## 3.10.0
 
 * Allow new BraintreeFragment instances to be created using FragmentActivity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Do not open PayPal (browser) if Activity has been destroyed (fixes #295)
+* Check if Fragment is active before handling Pay with PayPal result (fixes #295, thanks @brudaswen)
 
 ## 3.10.0
 


### PR DESCRIPTION
### Summary of changes

The network call to PayPal may return after the user exited the
Activity. In this case PayPal (browser) should not be opened.

- Check if the BraintreeFragment is still added to its Activity before proceeding.

 ### Checklist
 - [x] Added a changelog entry

### Authors
- brudaswen
