### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Braintree Android SDK
 
-[![Build Status](https://travis-ci.org/braintree/braintree_android.svg?branch=master)](https://travis-ci.org/braintree/braintree_android)
+[![Build Status](https://travis-ci.org/braintree/braintree_android.svg?branch=master)](https://travis-ci.org/braintree/braintree_android) [![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/braintreebraintreeandroid/)
 
 Welcome to Braintree's Android SDK. This library will help you accept card and alternative payments in your Android app.
 


### PR DESCRIPTION
### Summary of changes

- Adding a link (shield) to the README header. Dashboard describes overall project structure and dependencies. Will be useful for new developers looking to contribute to the project. Direct link: https://sourcespy.com/github/braintreebraintreeandroid/

 ### Checklist

 - [ ] Added a changelog entry (no code changes)

### Authors
- @alexkarezin
