### PR TITLE
Gradle Fixup: Rename google-payment to google-pay

### DIFF
--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -97,19 +97,19 @@ afterEvaluate {
                 artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
-                artifactId = 'google-payment'
+                artifactId = 'google-pay'
                 version = rootProject.versionName
 
                 pom {
-                    name = 'google-payment'
+                    name = 'google-pay'
                     packaging = 'aar'
                     description = 'Google Pay Module for Braintree\'s Android SDK.'
-                    url = 'https://github.com/braintree/braintree-android-google-payment'
+                    url = 'https://github.com/braintree/braintree_android'
 
                     scm {
-                        url = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
-                        connection = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
-                        developerConnection = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
+                        url = 'scm:git@github.com:braintree/braintree_android.git'
+                        connection = 'scm:git@github.com:braintree/braintree_android.git'
+                        developerConnection = 'scm:git@github.com:braintree/braintree_android.git'
                     }
 
                     developers {

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -99,12 +99,12 @@ afterEvaluate {
                     name = 'visa-checkout'
                     packaging = 'aar'
                     description = 'Visa Checkout Module for Braintree\'s Android SDK.'
-                    url = 'https://github.com/braintree/braintree-android-visa-checkout'
+                    url = 'https://github.com/braintree/braintree_android'
 
                     scm {
-                        url = 'scm:git@github.com:braintree/braintree-android-visa-checkout.git'
-                        connection = 'scm:git@github.com:braintree/braintree-android-visa-checkout.git'
-                        developerConnection = 'scm:git@github.com:braintree/braintree-android-visa-checkout.git'
+                        url = 'scm:git@github.com:braintree/braintree_android.git'
+                        connection = 'scm:git@github.com:braintree/braintree_android.git'
+                        developerConnection = 'scm:git@github.com:braintree/braintree_android.git'
                     }
 
                     developers {


### PR DESCRIPTION
### Summary of changes

 - This PR fixes a typo with `beta1` where the `google-pay` artifact was still named `google-payment`

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop
- @sshropshire 
