### PR TITLE
V4 Elo Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Add `setCountryCode` to `GooglePayRequest`
+* Add Google Pay support for Elo cards. 
 * Breaking Changes
   * Make `AmericanExpressRewardsBalance#fromJson()` package-private
   * Make `TYPE` and `API_RESOURCE_KEY` in `CardNonce` package-private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Add `setCountryCode` to `GooglePayRequest`
 * Breaking Changes
   * Make `AmericanExpressRewardsBalance#fromJson()` package-private
   * Make `TYPE` and `API_RESOURCE_KEY` in `CardNonce` package-private

--- a/GooglePay/src/main/java/com/braintreepayments/api/BraintreeWalletConstants.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/BraintreeWalletConstants.java
@@ -1,0 +1,15 @@
+package com.braintreepayments.api;
+
+import com.google.android.gms.wallet.WalletConstants;
+
+/**
+ * Collection of constant values used by the Braintree SDK Google Payment module. Extends upon
+ * com.google.android.gms.wallet.WalletConstants.
+ */
+public class BraintreeWalletConstants {
+
+    /**
+     * Card network Elo.
+     */
+    public static final int CARD_NETWORK_ELO = WalletConstants.CARD_NETWORK_OTHER + 1;
+}

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -40,6 +40,7 @@ public class GooglePayClient {
     private static final String MASTERCARD_NETWORK = "mastercard";
     private static final String AMEX_NETWORK = "amex";
     private static final String DISCOVER_NETWORK = "discover";
+    private static final String ELO_NETWORK = "elo";
 
     private static final String CARD_PAYMENT_TYPE = "CARD";
     private static final String PAYPAL_PAYMENT_TYPE = "PAYPAL";
@@ -308,6 +309,9 @@ public class GooglePayClient {
                 case DISCOVER_NETWORK:
                     allowedNetworks.add(WalletConstants.CARD_NETWORK_DISCOVER);
                     break;
+                case ELO_NETWORK:
+                    allowedNetworks.add(BraintreeWalletConstants.CARD_NETWORK_ELO);
+                    break;
                 default:
                     break;
             }
@@ -335,6 +339,10 @@ public class GooglePayClient {
                     break;
                 case WalletConstants.CARD_NETWORK_VISA:
                     cardNetworkStrings.put("VISA");
+                    break;
+                case BraintreeWalletConstants.CARD_NETWORK_ELO:
+                    cardNetworkStrings.put("ELO");
+                    cardNetworkStrings.put("ELO_DEBIT");
                     break;
             }
         }

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
@@ -40,6 +40,7 @@ public class GooglePayRequest implements Parcelable {
     private String mEnvironment;
     private String mGoogleMerchantId;
     private String mGoogleMerchantName;
+    private String mCountryCode;
 
     public GooglePayRequest() {
     }
@@ -214,6 +215,17 @@ public class GooglePayRequest implements Parcelable {
     }
 
     /**
+     * ISO 3166-1 alpha-2 country code where the transaction is processed. This is required for
+     * merchants based in European Economic Area (EEA) countries.
+     * @param countryCode
+     * @return {@link GooglePayRequest}
+     */
+    public GooglePayRequest setCountryCode(String countryCode) {
+        mCountryCode = countryCode;
+        return this;
+    }
+
+    /**
      * Assemble all declared parts of a GooglePayRequest to a JSON string
      * for use in making requests against Google
      * @return String
@@ -245,6 +257,10 @@ public class GooglePayRequest implements Parcelable {
                     .put("totalPriceStatus", totalPriceStatus)
                     .put("totalPrice", transactionInfo.getTotalPrice())
                     .put("currencyCode", transactionInfo.getCurrencyCode());
+
+            if (mCountryCode != null) {
+                transactionInfoJson.put("countryCode", mCountryCode);
+            }
 
         } catch (JSONException ignored) {
         }

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
@@ -217,6 +217,9 @@ public class GooglePayRequest implements Parcelable {
     /**
      * ISO 3166-1 alpha-2 country code where the transaction is processed. This is required for
      * merchants based in European Economic Area (EEA) countries.
+     *
+     * NOTE: to support Elo cards, country code must be set to "BR"
+     *
      * @param countryCode
      * @return {@link GooglePayRequest}
      */

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
@@ -206,6 +206,7 @@ public class GooglePayRequestUnitTest {
                 .put("purchase_context", "{\"purchase_context\":{\"purchase_units\":[{\"payee\":{\"client_id\":\"FAKE_PAYPAL_CLIENT_ID\"},\"recurring_payment\":false}]}}");
 
         request.transactionInfo(info)
+                .setCountryCode("US")
                 .phoneNumberRequired(true)
                 .emailRequired(true)
                 .shippingAddressRequired(true)

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -1963,7 +1963,8 @@ object Fixtures {
           "transactionInfo": {
             "totalPriceStatus": "FINAL",
             "totalPrice": "12.24",
-            "currencyCode": "USD"
+            "currencyCode": "USD",
+            "countryCode": "US"
           }
         } 
     """


### PR DESCRIPTION
### Summary of changes

 - Add `ELO` and `ELO_DEBIT` to `allowedCardNetworks` when "elo" supported by Braintree gateway config
 - Add `setCountryCode` to `GooglePayRequest`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop
- @sshropshire 