### PR TITLE
Add Null Checks to onBrowserSwitchResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add `PayPalVaultRequest`
 * Add `tokenizePayPalAccount` method to `PayPalClient`
 * Add `requestBillingAgreement` to `PayPalCheckoutRequest`
+* Fix issue where `onBrowserSwitchResult` crashes if `browserSwitchResult` is null
 * Breaking Changes
   * Make `AmericanExpressRewardsBalance#fromJson()` package-private
   * Make `TYPE` and `API_RESOURCE_KEY` in `CardNonce` package-private

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -132,6 +132,10 @@ public class LocalPaymentClient {
      * @param callback {@link LocalPaymentBrowserSwitchResultCallback}
      */
     public void onBrowserSwitchResult(final Context context, BrowserSwitchResult browserSwitchResult, final LocalPaymentBrowserSwitchResultCallback callback) {
+        if (browserSwitchResult == null) {
+            callback.onResult(null, new BraintreeException("BrowserSwitchResult cannot be null"));
+            return;
+        }
         JSONObject metadata = browserSwitchResult.getRequestMetadata();
 
         final String paymentType = Json.optString(metadata, "payment-type", null);

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -552,6 +552,20 @@ public class LocalPaymentClientUnitTest {
         verify(braintreeClient).sendAnalyticsEvent("ideal.local-payment.webswitch.canceled");
     }
 
+    @Test
+    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToCallback() {
+        LocalPaymentClient sut = new LocalPaymentClient(braintreeClient, payPalDataCollector);
+
+        sut.onBrowserSwitchResult(activity, null, localPaymentBrowserSwitchResultCallback);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(localPaymentBrowserSwitchResultCallback).onResult((LocalPaymentNonce) isNull(), exceptionCaptor.capture());
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof BraintreeException);
+        assertEquals("BrowserSwitchResult cannot be null", exception.getMessage());
+    }
+
     private LocalPaymentRequest getIdealLocalPaymentRequest() {
         PostalAddress address = new PostalAddress()
                 .streetAddress("836486 of 22321 Park Lake")

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -200,6 +200,10 @@ public class PayPalClient {
      * @param callback {@link PayPalBrowserSwitchResultCallback}
      */
     public void onBrowserSwitchResult(BrowserSwitchResult browserSwitchResult, final PayPalBrowserSwitchResultCallback callback) {
+        if (browserSwitchResult == null) {
+            callback.onResult(null, new BraintreeException("BrowserSwitchResult cannot be null"));
+            return;
+        }
         JSONObject metadata = browserSwitchResult.getRequestMetadata();
         String clientMetadataId = Json.optString(metadata, "client-metadata-id", null);
         String merchantAccountId = Json.optString(metadata, "merchant-account-id", null);

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -579,4 +579,21 @@ public class PayPalClientUnitTest {
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));
     }
+
+    @Test
+    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToCallbak() {
+        TokenizationClient tokenizationClient = new MockTokenizationClientBuilder().build();
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+        PayPalClient sut = new PayPalClient(braintreeClient, tokenizationClient, payPalInternalClient);
+
+        sut.onBrowserSwitchResult(null, payPalBrowserSwitchResultCallback);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(payPalBrowserSwitchResultCallback).onResult((PayPalAccountNonce) isNull(), captor.capture());
+
+        Exception exception = captor.getValue();
+        assertTrue(exception instanceof BraintreeException);
+        assertEquals("BrowserSwitchResult cannot be null", exception.getMessage());
+    }
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -369,6 +369,10 @@ public class ThreeDSecureClient {
      */
     public void onBrowserSwitchResult(BrowserSwitchResult browserSwitchResult, final ThreeDSecureResultCallback callback) {
         // V1 flow
+        if (browserSwitchResult == null) {
+            callback.onResult(null, new BraintreeException("BrowserSwitchResult cannot be null"));
+            return;
+        }
         int status = browserSwitchResult.getStatus();
         switch (status) {
             case BrowserSwitchStatus.CANCELED:

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -296,4 +296,20 @@ public class ThreeDSecureClientUnitTest {
         assertEquals(422, error.getStatusCode());
         assertEquals("Failed to authenticate, please try a different form of payment.", error.getMessage());
     }
+
+    @Test
+    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToCallback() {
+        CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+
+        ThreeDSecureClient sut = new ThreeDSecureClient(braintreeClient, cardinalClient, browserSwitchHelper);
+        sut.onBrowserSwitchResult(null, threeDSecureResultCallback);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(threeDSecureResultCallback).onResult((CardNonce) isNull(), captor.capture());
+
+        Exception exception = captor.getValue();
+        assertTrue(exception instanceof BraintreeException);
+        assertEquals("BrowserSwitchResult cannot be null", exception.getMessage());
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - Add null checks to client `onBrowserSwitchResult` methods

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 