### PR TITLE
Spike -- Adding PayPal Checkout SDK To Braintree SDK

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation project(':VisaCheckout')
 
     implementation 'com.squareup.okio:okio:1.13.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.8.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0' // upgrade required to avoid an OkHttp error on initialization
     implementation 'com.google.code.gson:gson:2.8.1'
     implementation 'de.greenrobot:eventbus:2.4.1'
     implementation 'androidx.appcompat:appcompat:1.0.1'

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation project(':BraintreeDataCollector')
 
+    implementation('com.paypal.checkout:android-sdk:0.1.0') {
+        exclude group: 'com.paypal.android.sdk'
+    }
+
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'


### PR DESCRIPTION
### Summary of changes
Updated PayPalClient to launch the Checkout SDK for single transactions while retaining the current functionality for billing agreements. Looking forward to feedback to understand what is left to formalize this integration 🙏

 - Updated PayPalClient to launch Checkout experience.
 - Updated PayPalClient to tokenize the request similar to how the web experience works today.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @CodyEngel
