### PR TITLE
GooglePayCardNonce isThreeDSecureEligible Convenience Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `PaymentMethodType` enum
 * Add `PaymentMethodNonce#getType()` method
 * Add wallet enabled metadata tag to `AndroidManifest.xml` in `google-pay` module 
+* Add `GooglePayCardNonce#isThreeDSecureEligible()` method
 * Breaking Changes
   * Rename `DownForMaintenanceException` to `ServiceUnavailableException`
   * Remove `GoogleApiClientException`

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -176,6 +176,11 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
     }
 
     /**
+     * @return true if the card is eligible for 3D Secure verification, false otherwise.
+     */
+    public Boolean isThreeDSecureEligible() { return !isNetworkTokenized; }
+
+    /**
      * @return The user's billing address.
      */
     @Nullable

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
@@ -11,6 +11,7 @@ import org.robolectric.RobolectricTestRunner;
 import static com.braintreepayments.api.Assertions.assertBinDataEqual;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(RobolectricTestRunner.class)
 public class GooglePayCardNonceUnitTest {
@@ -111,6 +112,20 @@ public class GooglePayCardNonceUnitTest {
         assertPostalAddress(shippingPostalAddress, parceled.getShippingAddress());
 
         assertBinDataEqual(googlePayCardNonce.getBinData(), parceled.getBinData());
+    }
+
+    @Test
+    public void isThreeDSecureEligible_whenNonNetworkTokenized_returnsTrue() {
+        GooglePayCardNonce sut = new GooglePayCardNonce(
+                "Visa", "34", "1234", "sample@user.com", false, null, null, null, null, false);
+        assertTrue(sut.isThreeDSecureEligible());
+    }
+
+    @Test
+    public void isThreeDSecureEligible_whenIsNetworkTokenized_returnsFalse() {
+        GooglePayCardNonce sut = new GooglePayCardNonce(
+                "Visa", "78", "5678", "sample@user.com", true, null, null, null, null, false);
+        assertFalse(sut.isThreeDSecureEligible());
     }
 
     private PostalAddress getPostalAddressObject(JSONObject address) {


### PR DESCRIPTION
### Summary of changes

 - Adding a convenience method to check if a `GooglePayCardNonce` is 3D Secure eligible. This prevents merchants from having to know what network tokenized means.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop
- @sshropshire
