### PR TITLE
Make PayPalRequest Parcelable

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Authorization.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Authorization.java
@@ -59,15 +59,15 @@ abstract class Authorization {
         return rawValue;
     }
 
-    private static boolean isTokenizationKey(String tokenizationKey) {
+    static boolean isTokenizationKey(String tokenizationKey) {
         return !TextUtils.isEmpty(tokenizationKey) && tokenizationKey.matches(TokenizationKey.MATCHER);
     }
 
-    private static boolean isPayPalUAT(String payPalUAT) {
+    static boolean isPayPalUAT(String payPalUAT) {
         return !TextUtils.isEmpty(payPalUAT) && payPalUAT.matches(PayPalUAT.MATCHER);
     }
 
-    private static boolean isClientToken(String clientToken) {
+    static boolean isClientToken(String clientToken) {
         return !TextUtils.isEmpty(clientToken) && clientToken.matches(ClientToken.BASE_64_MATCHER);
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Authorization.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Authorization.java
@@ -59,15 +59,15 @@ abstract class Authorization {
         return rawValue;
     }
 
-    static boolean isTokenizationKey(String tokenizationKey) {
+    private static boolean isTokenizationKey(String tokenizationKey) {
         return !TextUtils.isEmpty(tokenizationKey) && tokenizationKey.matches(TokenizationKey.MATCHER);
     }
 
-    static boolean isPayPalUAT(String payPalUAT) {
+    private static boolean isPayPalUAT(String payPalUAT) {
         return !TextUtils.isEmpty(payPalUAT) && payPalUAT.matches(PayPalUAT.MATCHER);
     }
 
-    static boolean isClientToken(String clientToken) {
+    private static boolean isClientToken(String clientToken) {
         return !TextUtils.isEmpty(clientToken) && clientToken.matches(ClientToken.BASE_64_MATCHER);
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## unreleased
 
-* Breaking Changes
-  * Make `PayPalRequest` and subclasses `Parcelable`
+* Make `PayPalRequest` and subclasses `Parcelable`
 
 ## 4.0.0-beta3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Breaking Changes
+  * Make `PayPalRequest` and subclasses `Parcelable`
+
 ## 4.0.0-beta3
 
 * Add `PaymentMethodType` enum

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -1,5 +1,7 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.TextUtils;
 
 import androidx.annotation.StringDef;
@@ -14,7 +16,7 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * Represents the parameters that are needed to start the PayPal Checkout flow
  */
-public class PayPalCheckoutRequest extends PayPalRequest {
+public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
 
     /**
      * The call-to-action in the PayPal Checkout flow
@@ -225,4 +227,42 @@ public class PayPalCheckoutRequest extends PayPalRequest {
         parameters.put(EXPERIENCE_PROFILE_KEY, experienceProfile);
         return parameters.toString();
     }
+
+    PayPalCheckoutRequest(Parcel in) {
+        super(in);
+        intent = in.readString();
+        userAction = in.readString();
+        amount = in.readString();
+        currencyCode = in.readString();
+        shouldRequestBillingAgreement = in.readByte() != 0;
+        shouldOfferPayLater = in.readByte() != 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(intent);
+        dest.writeString(userAction);
+        dest.writeString(amount);
+        dest.writeString(currencyCode);
+        dest.writeByte((byte) (shouldRequestBillingAgreement ? 1 : 0));
+        dest.writeByte((byte) (shouldOfferPayLater ? 1 : 0));
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<PayPalCheckoutRequest> CREATOR = new Creator<PayPalCheckoutRequest>() {
+        @Override
+        public PayPalCheckoutRequest createFromParcel(Parcel in) {
+            return new PayPalCheckoutRequest(in);
+        }
+
+        @Override
+        public PayPalCheckoutRequest[] newArray(int size) {
+            return new PayPalCheckoutRequest[size];
+        }
+    };
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -1,5 +1,8 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.StringDef;
 
@@ -9,7 +12,7 @@ import org.json.JSONObject;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-public class PayPalLineItem {
+public class PayPalLineItem implements Parcelable {
 
     /**
      * The type of PayPal line item.
@@ -182,4 +185,45 @@ public class PayPalLineItem {
 
         return new JSONObject();
     }
+
+    PayPalLineItem(Parcel in) {
+        description = in.readString();
+        kind = in.readString();
+        name = in.readString();
+        productCode = in.readString();
+        quantity = in.readString();
+        unitAmount = in.readString();
+        unitTaxAmount = in.readString();
+        url = in.readString();
+    }
+
+    public static final Creator<PayPalLineItem> CREATOR = new Creator<PayPalLineItem>() {
+        @Override
+        public PayPalLineItem createFromParcel(Parcel in) {
+            return new PayPalLineItem(in);
+        }
+
+        @Override
+        public PayPalLineItem[] newArray(int size) {
+            return new PayPalLineItem[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(description);
+        parcel.writeString(kind);
+        parcel.writeString(name);
+        parcel.writeString(productCode);
+        parcel.writeString(quantity);
+        parcel.writeString(unitAmount);
+        parcel.writeString(unitTaxAmount);
+        parcel.writeString(url);
+    }
+
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -55,22 +55,22 @@ public abstract class PayPalRequest implements Parcelable {
      */
     public static final String LANDING_PAGE_TYPE_LOGIN = "login";
 
-    private String mLocaleCode;
-    private String mBillingAgreementDescription;
-    private boolean mShippingAddressRequired;
-    private boolean mShippingAddressEditable = false;
-    private PostalAddress mShippingAddressOverride;
-    private String mLandingPageType;
-    private String mDisplayName;
-    private String mMerchantAccountId;
-    private final ArrayList<PayPalLineItem> mLineItems;
+    private String localeCode;
+    private String billingAgreementDescription;
+    private boolean shippingAddressRequired;
+    private boolean shippingAddressEditable = false;
+    private PostalAddress shippingAddressOverride;
+    private String landingPageType;
+    private String displayName;
+    private String merchantAccountId;
+    private final ArrayList<PayPalLineItem> lineItems;
 
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
      */
     public PayPalRequest() {
-        mShippingAddressRequired = false;
-        mLineItems = new ArrayList<>();
+        shippingAddressRequired = false;
+        lineItems = new ArrayList<>();
     }
 
     /**
@@ -79,7 +79,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param shippingAddressRequired Whether to hide the shipping address in the flow.
      */
     public void setShippingAddressRequired(boolean shippingAddressRequired) {
-        mShippingAddressRequired = shippingAddressRequired;
+        this.shippingAddressRequired = shippingAddressRequired;
     }
 
     /**
@@ -90,7 +90,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param shippingAddressEditable Whether to allow the the shipping address to be editable.
      */
     public void setShippingAddressEditable(boolean shippingAddressEditable) {
-        mShippingAddressEditable = shippingAddressEditable;
+        this.shippingAddressEditable = shippingAddressEditable;
     }
 
     /**
@@ -129,7 +129,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param localeCode A locale code to use for the transaction.
      */
     public void setLocaleCode(String localeCode) {
-        mLocaleCode = localeCode;
+        this.localeCode = localeCode;
     }
 
     /**
@@ -138,7 +138,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param displayName The name to be displayed in the PayPal flow.
      */
     public void setDisplayName(String displayName) {
-        mDisplayName = displayName;
+        this.displayName = displayName;
     }
 
     /**
@@ -147,7 +147,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param description The description to display.
      */
     public void setBillingAgreementDescription(String description) {
-        mBillingAgreementDescription = description;
+        billingAgreementDescription = description;
     }
 
     /**
@@ -156,7 +156,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param shippingAddressOverride a custom {@link PostalAddress}
      */
     public void setShippingAddressOverride(PostalAddress shippingAddressOverride) {
-        mShippingAddressOverride = shippingAddressOverride;
+        this.shippingAddressOverride = shippingAddressOverride;
     }
 
     /**
@@ -169,7 +169,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @see <a href="https://developer.paypal.com/docs/api/payments/v1/#definition-application_context">See "landing_page" under the "application_context" definition</a>
      */
     public void setLandingPageType(@PayPalLandingPageType String landingPageType) {
-        mLandingPageType = landingPageType;
+        this.landingPageType = landingPageType;
     }
 
     /**
@@ -178,7 +178,7 @@ public abstract class PayPalRequest implements Parcelable {
      * @param merchantAccountId the non-default merchant account Id.
      */
     public void setMerchantAccountId(String merchantAccountId) {
-        mMerchantAccountId = merchantAccountId;
+        this.merchantAccountId = merchantAccountId;
     }
 
     /**
@@ -187,59 +187,59 @@ public abstract class PayPalRequest implements Parcelable {
      * @param lineItems a collection of {@link PayPalLineItem}
      */
     public void setLineItems(Collection<PayPalLineItem> lineItems) {
-        mLineItems.clear();
-        mLineItems.addAll(lineItems);
+        this.lineItems.clear();
+        this.lineItems.addAll(lineItems);
     }
 
     public String getLocaleCode() {
-        return mLocaleCode;
+        return localeCode;
     }
 
     public String getBillingAgreementDescription() {
-        return mBillingAgreementDescription;
+        return billingAgreementDescription;
     }
 
     public boolean isShippingAddressRequired() {
-        return mShippingAddressRequired;
+        return shippingAddressRequired;
     }
 
     public boolean isShippingAddressEditable() {
-        return mShippingAddressEditable;
+        return shippingAddressEditable;
     }
 
     public PostalAddress getShippingAddressOverride() {
-        return mShippingAddressOverride;
+        return shippingAddressOverride;
     }
 
     public String getDisplayName() {
-        return mDisplayName;
+        return displayName;
     }
 
     public String getMerchantAccountId() {
-        return mMerchantAccountId;
+        return merchantAccountId;
     }
 
     public ArrayList<PayPalLineItem> getLineItems() {
-        return mLineItems;
+        return lineItems;
     }
 
     @PayPalLandingPageType
     public String getLandingPageType() {
-        return mLandingPageType;
+        return landingPageType;
     }
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
 
     protected PayPalRequest(Parcel in) {
-        mLocaleCode = in.readString();
-        mBillingAgreementDescription = in.readString();
-        mShippingAddressRequired = in.readByte() != 0;
-        mShippingAddressEditable = in.readByte() != 0;
-        mShippingAddressOverride = in.readParcelable(PostalAddress.class.getClassLoader());
-        mLandingPageType = in.readString();
-        mDisplayName = in.readString();
-        mMerchantAccountId = in.readString();
-        mLineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
+        localeCode = in.readString();
+        billingAgreementDescription = in.readString();
+        shippingAddressRequired = in.readByte() != 0;
+        shippingAddressEditable = in.readByte() != 0;
+        shippingAddressOverride = in.readParcelable(PostalAddress.class.getClassLoader());
+        landingPageType = in.readString();
+        displayName = in.readString();
+        merchantAccountId = in.readString();
+        lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
     }
 
     @Override
@@ -249,14 +249,14 @@ public abstract class PayPalRequest implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel parcel, int i) {
-        parcel.writeString(mLocaleCode);
-        parcel.writeString(mBillingAgreementDescription);
-        parcel.writeByte((byte) (mShippingAddressRequired ? 1 : 0));
-        parcel.writeByte((byte) (mShippingAddressEditable ? 1 : 0));
-        parcel.writeParcelable(mShippingAddressOverride, i);
-        parcel.writeString(mLandingPageType);
-        parcel.writeString(mDisplayName);
-        parcel.writeString(mMerchantAccountId);
-        parcel.writeTypedList(mLineItems);
+        parcel.writeString(localeCode);
+        parcel.writeString(billingAgreementDescription);
+        parcel.writeByte((byte) (shippingAddressRequired ? 1 : 0));
+        parcel.writeByte((byte) (shippingAddressEditable ? 1 : 0));
+        parcel.writeParcelable(shippingAddressOverride, i);
+        parcel.writeString(landingPageType);
+        parcel.writeString(displayName);
+        parcel.writeString(merchantAccountId);
+        parcel.writeTypedList(lineItems);
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -39,6 +39,7 @@ public abstract class PayPalRequest implements Parcelable {
     static final String MERCHANT_ACCOUNT_ID = "merchant_account_id";
     static final String LINE_ITEMS_KEY = "line_items";
 
+
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({PayPalRequest.LANDING_PAGE_TYPE_BILLING, PayPalRequest.LANDING_PAGE_TYPE_LOGIN})
     @interface PayPalLandingPageType {
@@ -62,13 +63,14 @@ public abstract class PayPalRequest implements Parcelable {
     private String mLandingPageType;
     private String mDisplayName;
     private String mMerchantAccountId;
-    private final ArrayList<PayPalLineItem> mLineItems = new ArrayList<>();
+    private final ArrayList<PayPalLineItem> mLineItems;
 
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
      */
     public PayPalRequest() {
         mShippingAddressRequired = false;
+        mLineItems = new ArrayList<>();
     }
 
     /**
@@ -228,6 +230,18 @@ public abstract class PayPalRequest implements Parcelable {
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
 
+    protected PayPalRequest(Parcel in) {
+        mLocaleCode = in.readString();
+        mBillingAgreementDescription = in.readString();
+        mShippingAddressRequired = in.readByte() != 0;
+        mShippingAddressEditable = in.readByte() != 0;
+        mShippingAddressOverride = in.readParcelable(PostalAddress.class.getClassLoader());
+        mLandingPageType = in.readString();
+        mDisplayName = in.readString();
+        mMerchantAccountId = in.readString();
+        mLineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -243,16 +257,6 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(mLandingPageType);
         parcel.writeString(mDisplayName);
         parcel.writeString(mMerchantAccountId);
-    }
-
-    PayPalRequest(Parcel in) {
-        mLocaleCode = in.readString();
-        mBillingAgreementDescription = in.readString();
-        mShippingAddressRequired = in.readByte() != 0;
-        mShippingAddressEditable = in.readByte() != 0;
-        mShippingAddressOverride = in.readParcelable(PostalAddress.class.getClassLoader());
-        mLandingPageType = in.readString();
-        mDisplayName = in.readString();
-        mMerchantAccountId = in.readString();
+        parcel.writeTypedList(mLineItems);
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -39,7 +39,6 @@ public abstract class PayPalRequest implements Parcelable {
     static final String MERCHANT_ACCOUNT_ID = "merchant_account_id";
     static final String LINE_ITEMS_KEY = "line_items";
 
-
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({PayPalRequest.LANDING_PAGE_TYPE_BILLING, PayPalRequest.LANDING_PAGE_TYPE_LOGIN})
     @interface PayPalLandingPageType {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -1,5 +1,8 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import androidx.annotation.StringDef;
 
 import org.json.JSONException;
@@ -13,7 +16,7 @@ import java.util.Collection;
  * Represents the parameters that are needed to tokenize a PayPal account.
  * See {@link PayPalCheckoutRequest} and {@link PayPalVaultRequest}.
  */
-public abstract class PayPalRequest {
+public abstract class PayPalRequest implements Parcelable {
 
     static final String NO_SHIPPING_KEY = "no_shipping";
     static final String ADDRESS_OVERRIDE_KEY = "address_override";
@@ -224,4 +227,32 @@ public abstract class PayPalRequest {
     }
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(mLocaleCode);
+        parcel.writeString(mBillingAgreementDescription);
+        parcel.writeByte((byte) (mShippingAddressRequired ? 1 : 0));
+        parcel.writeByte((byte) (mShippingAddressEditable ? 1 : 0));
+        parcel.writeParcelable(mShippingAddressOverride, i);
+        parcel.writeString(mLandingPageType);
+        parcel.writeString(mDisplayName);
+        parcel.writeString(mMerchantAccountId);
+    }
+
+    PayPalRequest(Parcel in) {
+        mLocaleCode = in.readString();
+        mBillingAgreementDescription = in.readString();
+        mShippingAddressRequired = in.readByte() != 0;
+        mShippingAddressEditable = in.readByte() != 0;
+        mShippingAddressOverride = in.readParcelable(PostalAddress.class.getClassLoader());
+        mLandingPageType = in.readString();
+        mDisplayName = in.readString();
+        mMerchantAccountId = in.readString();
+    }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -1,5 +1,7 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.TextUtils;
 
 import org.json.JSONException;
@@ -8,7 +10,7 @@ import org.json.JSONObject;
 /**
  * Represents the parameters that are needed to start the PayPal Vault flow
  */
-public class PayPalVaultRequest extends PayPalRequest {
+public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     private boolean shouldOfferCredit;
 
@@ -83,4 +85,32 @@ public class PayPalVaultRequest extends PayPalRequest {
         parameters.put(EXPERIENCE_PROFILE_KEY, experienceProfile);
         return parameters.toString();
     }
+
+    PayPalVaultRequest(Parcel in) {
+        super(in);
+        shouldOfferCredit = in.readByte() != 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeByte((byte) (shouldOfferCredit ? 1 : 0));
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<PayPalVaultRequest> CREATOR = new Creator<PayPalVaultRequest>() {
+        @Override
+        public PayPalVaultRequest createFromParcel(Parcel in) {
+            return new PayPalVaultRequest(in);
+        }
+
+        @Override
+        public PayPalVaultRequest[] newArray(int size) {
+            return new PayPalVaultRequest[size];
+        }
+    };
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -1,8 +1,12 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -58,5 +62,51 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals("Display Name", request.getDisplayName());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferPayLater());
+    }
+
+    @Test
+    public void parcelsCorrectly() {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("12.34");
+        request.setCurrencyCode("USD");
+        request.setLocaleCode("en-US");
+        request.setBillingAgreementDescription("Billing Agreement Description");
+        request.setShippingAddressRequired(true);
+        request.setShippingAddressEditable(true);
+
+        PostalAddress postalAddress = new PostalAddress();
+        postalAddress.setRecipientName("Postal Address");
+        request.setShippingAddressOverride(postalAddress);
+
+        request.setIntent(PayPalPaymentIntent.SALE);
+        request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
+        request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
+        request.setDisplayName("Display Name");
+        request.setMerchantAccountId("merchant_account_id");
+
+        ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
+        lineItems.add(new PayPalLineItem(PayPalLineItem.KIND_DEBIT, "An Item", "1", "1"));
+        request.setLineItems(lineItems);
+
+        Parcel parcel = Parcel.obtain();
+        request.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        PayPalCheckoutRequest result = PayPalCheckoutRequest.CREATOR.createFromParcel(parcel);
+
+        assertEquals("12.34", result.getAmount());
+        assertEquals("USD", result.getCurrencyCode());
+        assertEquals("en-US", result.getLocaleCode());
+        assertEquals("Billing Agreement Description",
+                result.getBillingAgreementDescription());
+        assertTrue(result.isShippingAddressRequired());
+        assertTrue(result.isShippingAddressEditable());
+        assertEquals("Postal Address", result.getShippingAddressOverride()
+                .getRecipientName());
+        assertEquals(PayPalPaymentIntent.SALE, result.getIntent());
+        assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, result.getLandingPageType());
+        assertEquals(PayPalCheckoutRequest.USER_ACTION_COMMIT, result.getUserAction());
+        assertEquals("Display Name", result.getDisplayName());
+        assertEquals("merchant_account_id", result.getMerchantAccountId());
+        assertEquals(1, result.getLineItems().size());
+        assertEquals("An Item", result.getLineItems().get(0).getName());
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -1,8 +1,12 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -43,5 +47,46 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("Display Name", request.getDisplayName());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
+    }
+
+    @Test
+    public void parcelsCorrectly() {
+        PayPalVaultRequest request = new PayPalVaultRequest();
+        request.setLocaleCode("en-US");
+        request.setBillingAgreementDescription("Billing Agreement Description");
+        request.setShippingAddressRequired(true);
+        request.setShippingAddressEditable(true);
+        request.setShouldOfferCredit(true);
+
+        PostalAddress postalAddress = new PostalAddress();
+        postalAddress.setRecipientName("Postal Address");
+        request.setShippingAddressOverride(postalAddress);
+
+        request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
+        request.setDisplayName("Display Name");
+        request.setMerchantAccountId("merchant_account_id");
+
+        ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
+        lineItems.add(new PayPalLineItem(PayPalLineItem.KIND_DEBIT, "An Item", "1", "1"));
+        request.setLineItems(lineItems);
+
+        Parcel parcel = Parcel.obtain();
+        request.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        PayPalVaultRequest result = PayPalVaultRequest.CREATOR.createFromParcel(parcel);
+
+        assertEquals("en-US", result.getLocaleCode());
+        assertEquals("Billing Agreement Description",
+                result.getBillingAgreementDescription());
+        assertTrue(result.getShouldOfferCredit());
+        assertTrue(result.isShippingAddressRequired());
+        assertTrue(result.isShippingAddressEditable());
+        assertEquals("Postal Address", result.getShippingAddressOverride()
+                .getRecipientName());
+        assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, result.getLandingPageType());
+        assertEquals("Display Name", result.getDisplayName());
+        assertEquals("merchant_account_id", result.getMerchantAccountId());
+        assertEquals(1, result.getLineItems().size());
+        assertEquals("An Item", result.getLineItems().get(0).getName());
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Make `PayPalRequest` and subclasses `Parcelable`. We previously removed this, but realized it needs to be parcelable for Drop in, so adding it back.
 - Remove missed hungarian notation from `PayPalRequest`.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @sshropshire 
