### PR TITLE
Local Payment Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased
 
 * Make `PayPalRequest` and subclasses `Parcelable`
+* Breaking Changes
+  * Rename `LocalPaymentTransaction` to `LocalPaymentResult`
+  * Rename `LocalPaymentClient#approveTransaction()` to `LocalPaymentClient#approvePayment()` 
 
 ## 4.0.0-beta3
 

--- a/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentFragment.java
@@ -68,7 +68,7 @@ public class LocalPaymentFragment extends BaseFragment {
                 localPaymentClient.startPayment(request, (transaction, error) -> {
                     if (transaction != null) {
                         try {
-                            localPaymentClient.approveTransaction(getActivity(), transaction);
+                            localPaymentClient.approvePayment(getActivity(), transaction);
                         } catch (JSONException | BrowserSwitchException e) {
                             e.printStackTrace();
                         }

--- a/LocalPayment/src/androidTest/java/com/braintreepayments/api/LocalPaymentClientTest.java
+++ b/LocalPayment/src/androidTest/java/com/braintreepayments/api/LocalPaymentClientTest.java
@@ -52,9 +52,9 @@ public class LocalPaymentClientTest {
         LocalPaymentClient sut = new LocalPaymentClient(braintreeClient);
         sut.startPayment(request, new LocalPaymentStartCallback() {
             @Override
-            public void onResult(@Nullable LocalPaymentTransaction transaction, @Nullable Exception error) {
-                assertNotNull(transaction.getApprovalUrl());
-                assertNotNull(transaction.getPaymentId());
+            public void onResult(@Nullable LocalPaymentResult localPaymentResult, @Nullable Exception error) {
+                assertNotNull(localPaymentResult.getApprovalUrl());
+                assertNotNull(localPaymentResult.getPaymentId());
                 countDownLatch.countDown();
             }
         });

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentResult.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentResult.java
@@ -1,15 +1,15 @@
 package com.braintreepayments.api;
 
 /**
- * Local payment transaction information.
+ * Local payment result information.
  */
-public class LocalPaymentTransaction {
+public class LocalPaymentResult {
 
     private final LocalPaymentRequest request;
     private final String approvalUrl;
     private final String paymentId;
 
-    LocalPaymentTransaction(LocalPaymentRequest request, String approvalUrl, String paymentId) {
+    LocalPaymentResult(LocalPaymentRequest request, String approvalUrl, String paymentId) {
         this.request = request;
         this.approvalUrl = approvalUrl;
         this.paymentId = paymentId;

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentStartCallback.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentStartCallback.java
@@ -9,8 +9,8 @@ import androidx.annotation.Nullable;
 public interface LocalPaymentStartCallback {
 
     /**
-     * @param transaction {@link LocalPaymentTransaction}
-     * @param error an exception that occurred while initiating a Local Payment transaction
+     * @param localPaymentResult {@link LocalPaymentResult}
+     * @param error an exception that occurred while initiating a Local Payment
      */
-    void onResult(@Nullable LocalPaymentTransaction transaction, @Nullable Exception error);
+    void onResult(@Nullable LocalPaymentResult localPaymentResult, @Nullable Exception error);
 }

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -101,10 +101,10 @@ public class LocalPaymentClientUnitTest {
         LocalPaymentRequest request = getIdealLocalPaymentRequest();
         sut.startPayment(request, localPaymentStartCallback);
 
-        ArgumentCaptor<LocalPaymentTransaction> transactionCaptor = ArgumentCaptor.forClass(LocalPaymentTransaction.class);
+        ArgumentCaptor<LocalPaymentResult> transactionCaptor = ArgumentCaptor.forClass(LocalPaymentResult.class);
         verify(localPaymentStartCallback).onResult(transactionCaptor.capture(), (Exception) isNull());
 
-        LocalPaymentTransaction transaction = transactionCaptor.getValue();
+        LocalPaymentResult transaction = transactionCaptor.getValue();
         assertSame(request, transaction.getRequest());
         assertEquals("https://checkout.paypal.com/latinum?token=payment-token", transaction.getApprovalUrl());
         assertEquals("local-payment-id-123", transaction.getPaymentId());
@@ -136,7 +136,7 @@ public class LocalPaymentClientUnitTest {
         LocalPaymentRequest request = getIdealLocalPaymentRequest();
         sut.startPayment(request, localPaymentStartCallback);
 
-        verify(localPaymentStartCallback).onResult((LocalPaymentTransaction) isNull(), same(configException));
+        verify(localPaymentStartCallback).onResult((LocalPaymentResult) isNull(), same(configException));
     }
 
     @Test
@@ -211,7 +211,7 @@ public class LocalPaymentClientUnitTest {
         sut.startPayment(request, localPaymentStartCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(localPaymentStartCallback).onResult((LocalPaymentTransaction) isNull(), captor.capture());
+        verify(localPaymentStartCallback).onResult((LocalPaymentResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
         assertTrue(exception instanceof ConfigurationException);
@@ -227,7 +227,7 @@ public class LocalPaymentClientUnitTest {
         sut.startPayment(request, localPaymentStartCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(localPaymentStartCallback).onResult((LocalPaymentTransaction) isNull(), captor.capture());
+        verify(localPaymentStartCallback).onResult((LocalPaymentResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
         assertTrue(exception instanceof BraintreeException);
@@ -243,7 +243,7 @@ public class LocalPaymentClientUnitTest {
         sut.startPayment(request, localPaymentStartCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(localPaymentStartCallback).onResult((LocalPaymentTransaction) isNull(), captor.capture());
+        verify(localPaymentStartCallback).onResult((LocalPaymentResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
         assertTrue(exception instanceof BraintreeException);
@@ -257,7 +257,7 @@ public class LocalPaymentClientUnitTest {
         sut.startPayment(null, localPaymentStartCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(localPaymentStartCallback).onResult((LocalPaymentTransaction) isNull(), captor.capture());
+        verify(localPaymentStartCallback).onResult((LocalPaymentResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
         assertTrue(exception instanceof BraintreeException);
@@ -283,9 +283,9 @@ public class LocalPaymentClientUnitTest {
 
         LocalPaymentRequest request = getIdealLocalPaymentRequest();
         String approvalUrl = "https://sample.com/approval?token=sample-token";
-        LocalPaymentTransaction transaction = new LocalPaymentTransaction(request, approvalUrl, "payment-id");
+        LocalPaymentResult transaction = new LocalPaymentResult(request, approvalUrl, "payment-id");
 
-        sut.approveTransaction(activity, transaction);
+        sut.approvePayment(activity, transaction);
 
         ArgumentCaptor<BrowserSwitchOptions> optionsCaptor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
         verify(braintreeClient).startBrowserSwitch(same(activity), optionsCaptor.capture());
@@ -308,22 +308,22 @@ public class LocalPaymentClientUnitTest {
 
         LocalPaymentRequest request = getIdealLocalPaymentRequest();
         String approvalUrl = "https://sample.com/approval?token=sample-token";
-        LocalPaymentTransaction transaction = new LocalPaymentTransaction(request, approvalUrl, "payment-id");
+        LocalPaymentResult transaction = new LocalPaymentResult(request, approvalUrl, "payment-id");
 
-        sut.approveTransaction(activity, transaction);
+        sut.approvePayment(activity, transaction);
         verify(braintreeClient).sendAnalyticsEvent("ideal.local-payment.webswitch.initiate.succeeded");
     }
 
     @Test
-    public void approveTransaction_whenActivityIsNull_throwsError() throws BrowserSwitchException, JSONException {
+    public void approvePayment_whenActivityIsNull_throwsError() throws BrowserSwitchException, JSONException {
         LocalPaymentClient sut = new LocalPaymentClient(braintreeClient, payPalDataCollector);
 
         LocalPaymentRequest request = getIdealLocalPaymentRequest();
         String approvalUrl = "https://sample.com/approval?token=sample-token";
-        LocalPaymentTransaction transaction = new LocalPaymentTransaction(request, approvalUrl, "payment-id");
+        LocalPaymentResult transaction = new LocalPaymentResult(request, approvalUrl, "payment-id");
 
         try {
-            sut.approveTransaction(null, transaction);
+            sut.approvePayment(null, transaction);
             fail("Should throw");
         } catch (RuntimeException exception) {
             assertEquals("A FragmentActivity is required.", exception.getMessage());
@@ -331,11 +331,11 @@ public class LocalPaymentClientUnitTest {
     }
 
     @Test
-    public void approveTransaction_whenTransactionIsNull_throwsError() throws BrowserSwitchException, JSONException {
+    public void approvePayment_whenTransactionIsNull_throwsError() throws BrowserSwitchException, JSONException {
         LocalPaymentClient sut = new LocalPaymentClient(braintreeClient, payPalDataCollector);
 
         try {
-            sut.approveTransaction(activity, null);
+            sut.approvePayment(activity, null);
             fail("Should throw");
         } catch (RuntimeException exception) {
             assertEquals("A LocalPaymentTransaction is required.", exception.getMessage());


### PR DESCRIPTION

### Summary of changes

  - Rename `LocalPaymentTransaction` to `LocalPaymentResult`since transactions are viewed as a server-side concept
  - Rename `LocalPaymentClient#approveTransaction()` to `LocalPaymentClient#approvePayment()` 


 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
