### PR TITLE
Fix docs for `amount` on `PayPalCheckoutRequest`

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -49,8 +49,8 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
     /**
      * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
      *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
-     *               number, may optionally contain exactly 2 decimal places separated by '.', optional
-     *               thousands separator ',', limited to 7 digits before the decimal point.
+     *               number, may optionally contain exactly 2 decimal places separated by '.',
+     *               limited to 7 digits before the decimal point.
      *               <p>
      *               This amount may differ slightly from the transaction amount. The exact decline rules
      *               for mismatches between this client-side amount and the final amount in the Transaction

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -49,7 +49,7 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
     /**
      * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
      *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
-     *               number, may optionally contain exactly 2 decimal places separated by '.',
+     *               number, may optionally contain exactly 2 decimal places separated by '.' and is
      *               limited to 7 digits before the decimal point.
      *               <p>
      *               This amount may differ slightly from the transaction amount. The exact decline rules


### PR DESCRIPTION
### Summary of changes

 - Remove incorrect docs indicating that commas are allowed in the amount on PayPalCheckoutRequest

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
