### PR TITLE
Client SDK deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This SDK abides by our Client SDK Deprecation Policy. For more information on th
 | -------------------- | ------ | -------- | ---------- | ----------- |
 | 4.x.x | Beta | March 2021 | TBA | TBA |
 | 3.x.x | Active | February 2019 | TBA | TBA |
-| 2.x.x | Inactive | November 2015 | March 2020 | March 2021 |
+| 2.x.x | Unsupported | November 2015 | March 2020 | March 2021 |
 
 Versions 2.7.3 and below use outdated SSL certificates and are unsupported.
 
@@ -64,4 +64,3 @@ for personal support at any phase of integration
 ## License
 
 The Braintree Android SDK is open source and available under the MIT license. See the [LICENSE](LICENSE) file for more info.
-

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This SDK abides by our Client SDK Deprecation Policy. For more information on th
 | -------------------- | ------ | -------- | ---------- | ----------- |
 | 4.x.x | Beta | March 2021 | TBA | TBA |
 | 3.x.x | Active | February 2019 | TBA | TBA |
-| 2.x.x | Inactive | November 2015 | February 2020 | February 2021 |
+| 2.x.x | Inactive | November 2015 | March 2020 | March 2021 |
 
-Versions 2.7.3 and below are unsupported.
+Versions 2.7.3 and below use outdated SSL certificates and are unsupported.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Start with [**'Hello, Client!'**](https://developers.braintreepayments.com/start
 
 Next, read the [**full documentation**](https://developers.braintreepayments.com/guides/overview) for information about integration options, such as Drop-In UI, PayPal and credit card tokenization.
 
+## Versions
+
+This SDK abides by our Client SDK Deprecation Policy. For more information on the potential statuses of an SDK check our [developer docs](http://developers.braintreepayments.com/guides/client-sdk/deprecation-policy).
+
+| Major version number | Status | Released | Deprecated | Unsupported |
+| -------------------- | ------ | -------- | ---------- | ----------- |
+| 4.x.x | Beta | March 2021 | TBA | TBA |
+| 3.x.x | Active | February 2019 | TBA | TBA |
+| 2.x.x | Inactive | November 2015 | February 2020 | February 2021 |
+
+Versions 2.7.3 and below are unsupported.
+
 ## Help
 
 * [Read the docs](https://developers.braintreepayments.com/guides/overview)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Next, read the [**full documentation**](https://developers.braintreepayments.com
 
 This SDK abides by our Client SDK Deprecation Policy. For more information on the potential statuses of an SDK check our [developer docs](http://developers.braintreepayments.com/guides/client-sdk/deprecation-policy).
 
+<!-- TODO: Update TBA dates when v4 GA releases. -->
 | Major version number | Status | Released | Deprecated | Unsupported |
 | -------------------- | ------ | -------- | ---------- | ----------- |
 | 4.x.x | Beta | March 2021 | TBA | TBA |


### PR DESCRIPTION
### Summary of changes

 - There was an old JIRA in our backlog to add the Client SDK Deprecation policy to the Android README. I formatted it similarly to[ the README in iOS](https://github.com/braintree/braintree_ios#versions).
 - I called out that v2.7.3 and below are unsupported since those use expired SSL certs.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
@scannillo
