### PR TITLE
Return UserCanceledException on user cancellation

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
@@ -1,0 +1,11 @@
+package com.braintreepayments.api;
+
+/**
+ * Error class thrown when a user cancels a payment flow
+ */
+public class UserCanceledException extends BraintreeException {
+
+    UserCanceledException(String message) {
+        super(message);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Make `PayPalCreditFinancingAmount#fromJson()` package-private
   * Make `UnionPayCapabilities#fromJson()` package-private
   * Make `PaymentMethodClient#parsePaymentMethodNonces()` package-private
+  * Return `UserCanceledException` on user cancellation
 
 ## 4.0.0-beta3
 

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -249,7 +249,7 @@ public class GooglePayClient {
                     AutoResolveHelper.getStatusFromIntent(data)));
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
             braintreeClient.sendAnalyticsEvent("google-payment.canceled");
-            callback.onResult(null, new BraintreeException("User canceled Google Pay."));
+            callback.onResult(null, new UserCanceledException("User canceled Google Pay."));
         }
     }
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -1032,12 +1032,12 @@ public class GooglePayClientUnitTest {
 
         verify(braintreeClient).sendAnalyticsEvent(eq("google-payment.canceled"));
 
-        ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(activityResultCallback).onResult((PaymentMethodNonce) isNull(), captor.capture());
 
-        BraintreeException exception = captor.getValue();
+        Exception exception = captor.getValue();
         assertEquals("User canceled Google Pay.", exception.getMessage());
-        assertTrue(exception instanceof BraintreeException);
+        assertTrue(exception instanceof UserCanceledException);
     }
 
     @Test

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -146,7 +146,7 @@ public class LocalPaymentClient {
         switch (result) {
             case BrowserSwitchStatus.CANCELED:
                 sendAnalyticsEvent(paymentType, "local-payment.webswitch.canceled");
-                callback.onResult(null, new BraintreeException("User canceled Local Payment."));
+                callback.onResult(null, new UserCanceledException("User canceled Local Payment."));
                 return;
             case BrowserSwitchStatus.SUCCESS:
                 Uri deepLinkUri = browserSwitchResult.getDeepLinkUrl();
@@ -160,7 +160,7 @@ public class LocalPaymentClient {
                 String responseString = deepLinkUri.toString();
                 if (responseString.toLowerCase().contains(LOCAL_PAYMENT_CANCEL.toLowerCase())) {
                     sendAnalyticsEvent(paymentType, "local-payment.webswitch.canceled");
-                    callback.onResult(null, new BraintreeException("User canceled Local Payment."));
+                    callback.onResult(null, new UserCanceledException("User canceled Local Payment."));
                     return;
                 }
                 JSONObject payload = new JSONObject();

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -524,7 +524,7 @@ public class LocalPaymentClientUnitTest {
         verify(localPaymentBrowserSwitchResultCallback).onResult((LocalPaymentNonce) isNull(), exceptionCaptor.capture());
 
         Exception cancelException = exceptionCaptor.getValue();
-        assertTrue(cancelException instanceof BraintreeException);
+        assertTrue(cancelException instanceof UserCanceledException);
         assertEquals("User canceled Local Payment.", cancelException.getMessage());
         verify(braintreeClient).sendAnalyticsEvent("ideal.local-payment.webswitch.canceled");
     }
@@ -546,7 +546,7 @@ public class LocalPaymentClientUnitTest {
         verify(localPaymentBrowserSwitchResultCallback).onResult((LocalPaymentNonce) isNull(), exceptionCaptor.capture());
 
         Exception cancelException = exceptionCaptor.getValue();
-        assertTrue(cancelException instanceof BraintreeException);
+        assertTrue(cancelException instanceof UserCanceledException);
         assertEquals("User canceled Local Payment.", cancelException.getMessage());
         verify(braintreeClient).sendAnalyticsEvent("ideal.local-payment.webswitch.canceled");
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -217,7 +217,7 @@ public class PayPalClient {
         int result = browserSwitchResult.getStatus();
         switch (result) {
             case BrowserSwitchStatus.CANCELED:
-                callback.onResult(null, new BraintreeException("User canceled PayPal."));
+                callback.onResult(null, new UserCanceledException("User canceled PayPal."));
                 braintreeClient.sendAnalyticsEvent(String.format("%s.browser-switch.canceled", analyticsPrefix));
                 break;
             case BrowserSwitchStatus.SUCCESS:
@@ -264,7 +264,7 @@ public class PayPalClient {
                     } else {
                         callback.onResult(null, new BraintreeException("Unknown error"));
                     }
-                } catch (JSONException | PayPalBrowserSwitchException e) {
+                } catch (JSONException | UserCanceledException | PayPalBrowserSwitchException e) {
                     callback.onResult(null, e);
                     braintreeClient.sendAnalyticsEvent(String.format("%s.browser-switch.failed", analyticsPrefix));
                 }
@@ -272,11 +272,11 @@ public class PayPalClient {
         }
     }
 
-    private JSONObject parseUrlResponseData(Uri uri, String successUrl, String approvalUrl, String tokenKey) throws JSONException, PayPalBrowserSwitchException {
+    private JSONObject parseUrlResponseData(Uri uri, String successUrl, String approvalUrl, String tokenKey) throws JSONException, UserCanceledException, PayPalBrowserSwitchException {
         String status = uri.getLastPathSegment();
 
         if (!Uri.parse(successUrl).getLastPathSegment().equals(status)) {
-            throw new PayPalBrowserSwitchException("User canceled.");
+            throw new UserCanceledException("User canceled PayPal.");
         }
 
         String requestXoToken = Uri.parse(approvalUrl).getQueryParameter(tokenKey);

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -548,8 +548,8 @@ public class PayPalClientUnitTest {
         verify(payPalBrowserSwitchResultCallback).onResult((PayPalAccountNonce) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof PayPalBrowserSwitchException);
-        assertEquals("User canceled.", exception.getMessage());
+        assertTrue(exception instanceof UserCanceledException);
+        assertEquals("User canceled PayPal.", exception.getMessage());
     }
 
     @Test
@@ -569,7 +569,7 @@ public class PayPalClientUnitTest {
         verify(payPalBrowserSwitchResultCallback).onResult((PayPalAccountNonce) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof BraintreeException);
+        assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled PayPal.", exception.getMessage());
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -325,7 +325,7 @@ public class ThreeDSecureClient {
         int status = browserSwitchResult.getStatus();
         switch (status) {
             case BrowserSwitchStatus.CANCELED:
-                callback.onResult(null, new BraintreeException("User canceled 3DS."));
+                callback.onResult(null, new UserCanceledException("User canceled 3DS."));
                 break;
             case BrowserSwitchStatus.SUCCESS:
             default:
@@ -355,7 +355,7 @@ public class ThreeDSecureClient {
     public void onActivityResult(int resultCode, Intent data, ThreeDSecureResultCallback callback) {
         // V2 flow
         if (resultCode != RESULT_OK) {
-            callback.onResult(null, new BraintreeException("User canceled 3DS."));
+            callback.onResult(null, new UserCanceledException("User canceled 3DS."));
             return;
         }
 
@@ -379,7 +379,7 @@ public class ThreeDSecureClient {
                 braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.failed");
                 break;
             case CANCEL:
-                callback.onResult(null, new BraintreeException("User canceled 3DS."));
+                callback.onResult(null, new UserCanceledException("User canceled 3DS."));
                 braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.canceled");
                 break;
         }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -250,7 +250,7 @@ public class ThreeDSecureClientUnitTest {
         verify(threeDSecureResultCallback).onResult((ThreeDSecureResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof BraintreeException);
+        assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
     }
 
@@ -359,7 +359,7 @@ public class ThreeDSecureClientUnitTest {
         verify(threeDSecureResultCallback).onResult((ThreeDSecureResult) isNull(), captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof BraintreeException);
+        assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
     }
 }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -568,7 +568,7 @@ public class ThreeDSecureV2UnitTest {
 
         BraintreeException exception = captor.getValue();
         assertEquals("User canceled 3DS.", exception.getMessage());
-        assertTrue(exception instanceof BraintreeException);
+        assertTrue(exception instanceof UserCanceledException);
     }
 
     @Test

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -146,7 +146,7 @@ public class VenmoClient {
             }
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");
-            callback.onResult(null, new BraintreeException("User canceled Venmo."));
+            callback.onResult(null, new UserCanceledException("User canceled Venmo."));
         }
     }
 

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -103,7 +103,7 @@ Full implementation examples can be found in the payment method feature sections
 
 ### Handling Cancellation 
 
-All user cancellations will be returned as a `BraintreeException` with an error message indicating user cancellation to the callback of the invoked method. 
+All user cancellations will be returned as a `UserCanceledException` with an error message indicating user cancellation to the callback of the invoked method. 
 
 ### Handling Errors
 

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -103,7 +103,7 @@ Full implementation examples can be found in the payment method feature sections
 
 ### Handling Cancellation 
 
-All user cancellations will be returned as a `UserCanceledException` with an error message indicating user cancellation to the callback of the invoked method. 
+When the customer cancels out of a payment flow, a `UserCanceledException` will be returned in the callback of the invoked method.
 
 ### Handling Errors
 


### PR DESCRIPTION
### Summary of changes

 - Return `UserCanceledException` on user cancellation
 - This is useful for Drop-in to differentiate between user cancellation and other errors in the payment flow

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 
