### PR TITLE
Fix Setter Typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   * Use primitives instead of boxed types where possible
   * Add nullability annotations to public methods
   * Remove `Context` parameter from `CardClient#tokenize()` method
+  * Fix typo in `ThreeDSecureAdditionalInformation#getPaymentAccountIndicator()` method name
 
 ## 4.0.0-beta3
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureAdditionalInformation.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureAdditionalInformation.java
@@ -625,7 +625,7 @@ public class ThreeDSecureAdditionalInformation implements Parcelable {
      * @return Payment account indicator
      */
     @Nullable
-    public String getPaymentAccountIdicator() {
+    public String getPaymentAccountIndicator() {
         return paymentAccountIndicator;
     }
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureAdditionalInformationUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureAdditionalInformationUnitTest.java
@@ -91,7 +91,7 @@ public class ThreeDSecureAdditionalInformationUnitTest {
         assertEquals("account_purchases", postSerialized.getAccountPurchases());
         assertEquals("fraud_activity", postSerialized.getFraudActivity());
         assertEquals("shipping_name_indicator", postSerialized.getShippingNameIndicator());
-        assertEquals("payment_account_indicator", postSerialized.getPaymentAccountIdicator());
+        assertEquals("payment_account_indicator", postSerialized.getPaymentAccountIndicator());
         assertEquals("payment_account_age", postSerialized.getPaymentAccountAge());
         assertEquals("address_match", postSerialized.getAddressMatch());
         assertEquals("account_id", postSerialized.getAccountId());


### PR DESCRIPTION
### Summary of changes

 * Fix typo in `ThreeDSecureAdditionalInformation#getPaymentAccountIndicator()` method name

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
