### PR TITLE
VenmoClient.isReadyToPay()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Add `VenmoClient#isReadyToPay()` method
+
 ## 4.1.0
 
 * Bump Cardinal version to `2.2.5-3`

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -296,4 +296,28 @@ public class VenmoClient {
     public boolean isVenmoAppSwitchAvailable(@NonNull Context context) {
         return deviceInspector.isVenmoAppSwitchAvailable(context);
     }
+
+    /**
+     * Before starting the Venmo flow, use this method to check whether
+     * Venmo is supported and set up on the device. When the callback is called with
+     * {@code true}, show the Venmo button. When it is called with {@code false}, display other
+     * checkout options.
+     *
+     * @param context Android Context
+     * @param callback {@link VenmoIsReadyToPayCallback}
+     */
+    public void isReadyToPay(final Context context, final VenmoIsReadyToPayCallback callback) {
+        braintreeClient.getConfiguration(new ConfigurationCallback() {
+            @Override
+            public void onResult(@Nullable Configuration configuration, @Nullable Exception configError) {
+                if (configuration != null) {
+                    boolean result =
+                        configuration.isVenmoEnabled() && isVenmoAppSwitchAvailable(context);
+                    callback.onResult(result, null);
+                } else {
+                    callback.onResult(false, configError);
+                }
+            }
+        });
+    }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoIsReadyToPayCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoIsReadyToPayCallback.java
@@ -1,0 +1,18 @@
+package com.braintreepayments.api;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Callback for receiving result of
+ * {@link VenmoClient#isReadyToPay(Context, VenmoIsReadyToPayCallback)}.
+ */
+public interface VenmoIsReadyToPayCallback {
+
+    /**
+     * @param isReadyToPay true if Venmo is ready; false otherwise.
+     * @param error an exception that occurred while checking if Venmo is ready
+     */
+    void onResult(boolean isReadyToPay, @Nullable Exception error);
+}

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -874,7 +874,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void isReadyToPay_whenConfigurationFails_callbackFalseAndpropagatesError() {
+    public void isReadyToPay_whenConfigurationFails_callbackFalseAndPropagatesError() {
         Exception configError = new Exception("configuration error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configurationError(configError)

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -872,4 +872,19 @@ public class VenmoClientUnitTest {
 
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));
     }
+
+    @Test
+    public void isReadyToPay_whenConfigurationFails_propagatesError() {
+        Exception configError = new Exception("configuration error");
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configurationError(configError)
+                .build();
+
+        VenmoClient sut = new VenmoClient(braintreeClient, tokenizationClient, sharedPrefsWriter, deviceInspector);
+
+        VenmoIsReadyToPayCallback callback = mock(VenmoIsReadyToPayCallback.class);
+        sut.isReadyToPay(activity, callback);
+
+        verify(callback).onResult(false, configError);
+    }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -874,7 +874,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void isReadyToPay_whenConfigurationFails_propagatesError() {
+    public void isReadyToPay_whenConfigurationFails_callbackFalseAndpropagatesError() {
         Exception configError = new Exception("configuration error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configurationError(configError)
@@ -886,5 +886,49 @@ public class VenmoClientUnitTest {
         sut.isReadyToPay(activity, callback);
 
         verify(callback).onResult(false, configError);
+    }
+
+    @Test
+    public void isReadyToPay_whenVenmoDisabled_callbackFalse() throws JSONException {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS))
+                .build();
+
+        VenmoClient sut = new VenmoClient(braintreeClient, tokenizationClient, sharedPrefsWriter, deviceInspector);
+
+        VenmoIsReadyToPayCallback callback = mock(VenmoIsReadyToPayCallback.class);
+        sut.isReadyToPay(activity, callback);
+
+        verify(callback).onResult(false, null);
+    }
+
+    @Test
+    public void isReadyToPay_whenVenmoEnabledAndAppSwitchUnavailable_callbackFalse() throws JSONException {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO))
+                .build();
+
+        VenmoClient sut = new VenmoClient(braintreeClient, tokenizationClient, sharedPrefsWriter, deviceInspector);
+        when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(false);
+
+        VenmoIsReadyToPayCallback callback = mock(VenmoIsReadyToPayCallback.class);
+        sut.isReadyToPay(activity, callback);
+
+        verify(callback).onResult(false, null);
+    }
+
+    @Test
+    public void isReadyToPay_whenVenmoEnabledAndAppSwitchAvailable_callbackTrue() throws JSONException {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO))
+                .build();
+
+        VenmoClient sut = new VenmoClient(braintreeClient, tokenizationClient, sharedPrefsWriter, deviceInspector);
+        when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
+
+        VenmoIsReadyToPayCallback callback = mock(VenmoIsReadyToPayCallback.class);
+        sut.isReadyToPay(activity, callback);
+
+        verify(callback).onResult(true, null);
     }
 }


### PR DESCRIPTION
### Summary of changes

This PR creates a `VenmoClient.isReadyToPay()` method to make two assertions:
1. The merchant has Venmo enabled in their Braintree Configuration
2. The customer device has a signature verified Venmo app installed

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire 
