### PR TITLE
Update `cardAddChallengeRequested` Param to Pass False

### DIFF
--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
@@ -40,7 +40,7 @@ public class ThreeDSecureRequest implements Parcelable {
     private boolean challengeRequested = false;
     private boolean dataOnlyRequested = false;
     private boolean exemptionRequested = false;
-    private boolean cardAddChallengeRequested = false;
+    private Boolean cardAddChallengeRequested;
     private ThreeDSecureV2UiCustomization v2UiCustomization;
     private ThreeDSecureV1UiCustomization v1UiCustomization;
 
@@ -167,8 +167,12 @@ public class ThreeDSecureRequest implements Parcelable {
      * Optional. An authentication created using this flag should only be used for adding a
      * payment method to the merchant's vault and not for creating transactions.
      *
-     * @param cardAddChallengeRequested If set to true, the authentication challenge will be requested from the issuer
-     *                to confirm adding new card to the merchant's vault.
+     * @param cardAddChallengeRequested If set to true, the authentication challenge will be requested
+     *                                  from the issuer to confirm adding new card to the merchant's
+     *                                  vault. If not set and amount is 0, the authentication challenge
+     *                                  will be presented to the user. If set to false, when the amount
+     *                                  is 0, the authentication challenge will not be presented to the user.
+     *
      */
     public void setCardAddChallengeRequested(boolean cardAddChallengeRequested) {
         this.cardAddChallengeRequested = cardAddChallengeRequested;

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
@@ -174,7 +174,7 @@ public class ThreeDSecureRequest implements Parcelable {
      *                                  is 0, the authentication challenge will not be presented to the user.
      *
      */
-    public void setCardAddChallengeRequested(boolean cardAddChallengeRequested) {
+    public void setCardAddChallengeRequested(@Nullable Boolean cardAddChallengeRequested) {
         this.cardAddChallengeRequested = cardAddChallengeRequested;
     }
 
@@ -290,9 +290,10 @@ public class ThreeDSecureRequest implements Parcelable {
 
     /**
      * @return If the authentication challenge will be requested from the issuer to confirm adding
-     * new card to the merchant's vault.
+     * new card to the merchant's vault or null if the value has not been set.
      */
-    public boolean isCardAddChallengeRequested() {
+    @Nullable
+    public Boolean isCardAddChallengeRequested() {
         return cardAddChallengeRequested;
     }
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureRequest.java
@@ -385,7 +385,7 @@ public class ThreeDSecureRequest implements Parcelable {
             base.put("additional_info", additionalInfo);
             base.putOpt("account_type", accountType);
 
-            if (cardAddChallengeRequested) {
+            if (cardAddChallengeRequested != null) {
                base.put("card_add", cardAddChallengeRequested);
             }
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureRequestUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureRequestUnitTest.java
@@ -274,6 +274,7 @@ public class ThreeDSecureRequestUnitTest {
     @Test
     public void build_whenCardAddChallengeRequestedFalse_setsCardAddChallengeRequestedFalse() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
+        threeDSecureRequest.setCardAddChallengeRequested(false);
 
         JSONObject json = new JSONObject(threeDSecureRequest.build("df-reference-id"));
         assertFalse(json.getBoolean("card_add"));

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureRequestUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureRequestUnitTest.java
@@ -262,4 +262,20 @@ public class ThreeDSecureRequestUnitTest {
         JSONObject json = new JSONObject(threeDSecureRequest.build("df-reference-id"));
         assertFalse(json.getJSONObject("additional_info").has("shipping_method"));
     }
+
+    @Test
+    public void build_whenCardAddChallengeRequestedNotSet_doesNotSetCardAddChallengeRequested() throws JSONException {
+        ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
+
+        JSONObject json = new JSONObject(threeDSecureRequest.build("df-reference-id"));
+        assertFalse(json.has("card_add"));
+    }
+
+    @Test
+    public void build_whenCardAddChallengeRequestedFalse_setsCardAddChallengeRequestedFalse() throws JSONException {
+        ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
+
+        JSONObject json = new JSONObject(threeDSecureRequest.build("df-reference-id"));
+        assertFalse(json.getBoolean("card_add"));
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - Update `ThreeDSecureRequest` to include `cardAddChallengeRequested` param when set to true or false, and not include when null.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @kate-paypal 
- @sarahkoop 
