### PR TITLE
Update README to Remove Braintree Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ Braintree's Android SDK is available for Android SDK >= 21.
 
 ## Adding It To Your Project
 
-Add the dependency in your `build.gradle`:
+The features of the Braintree SDK are organized into modules and that can be imported as dependencies in your `build.gradle` file.
+See the [v4 migration guide](v4_MIGRATION_GUIDE.md) for specific dependencies required for each module.
+
+For an integration offering card payments, add the following dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'com.braintreepayments.api:braintree:4.2.0'
+  implementation 'com.braintreepayments.api:card:4.2.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Braintree's Android SDK is available for Android SDK >= 21.
 
 ## Adding It To Your Project
 
-The features of the Braintree SDK are organized into modules and that can be imported as dependencies in your `build.gradle` file.
+The features of the Braintree SDK are organized into modules that can be imported as dependencies in your `build.gradle` file.
 See the [v4 migration guide](v4_MIGRATION_GUIDE.md) for specific dependencies required for each module.
 
 For an integration offering card payments, add the following dependency in your `build.gradle`:

--- a/Rakefile
+++ b/Rakefile
@@ -221,7 +221,7 @@ end
 def update_readme_version(version)
   IO.write("README.md",
     File.open("README.md") do |file|
-      file.read.gsub(/:braintree:\d+\.\d+\.\d+'/, ":braintree:#{version}'")
+      file.read.gsub(/:card:\d+\.\d+\.\d+'/, ":card:#{version}'")
     end
   )
 end


### PR DESCRIPTION
### Summary of changes

 - In `v4` the `braintree` module no longer exists as a dependency, our README incorrectly tells merchants to include `com.braintreepayments.api:braintree:4.2.0`
 - Update the README dependency to show a simple card import
 - Update the rake release step for updating the README

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
