### PR TITLE
Get Browser Switch Result

### DIFF
--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.work:work-runtime:2.4.0'
 
-    api 'com.braintreepayments.api:browser-switch:2.0.1'
+    api 'com.braintreepayments.api:browser-switch:2.0.2'
     api project(':SharedUtils')
 
     androidTestImplementation playServicesWallet

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -146,6 +146,10 @@ public class BraintreeClient {
         }
     }
 
+    BrowserSwitchResult getBrowserSwitchResult(@NonNull FragmentActivity activity) {
+        return browserSwitchClient.getResult(activity);
+    }
+
     public BrowserSwitchResult deliverBrowserSwitchResult(@NonNull FragmentActivity activity) {
         return browserSwitchClient.deliverResult(activity);
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -8,6 +8,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.test.core.app.ApplicationProvider;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -257,6 +258,18 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
+    public void getBrowserSwitchResult_forwardsInvocationToBrowserSwitchClient() {
+        FragmentActivity activity = mock(FragmentActivity.class);
+        BrowserSwitchResult browserSwitchResult = createSuccessfulBrowserSwitchResult();
+        when(browserSwitchClient.getResult(activity)).thenReturn(browserSwitchResult);
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, "sessionId", "integrationType");
+        BraintreeClient sut = new BraintreeClient(params);
+
+        assertSame(browserSwitchResult, sut.getBrowserSwitchResult(activity));
+    }
+
+    @Test
     public void deliverBrowserSwitchResult_forwardsInvocationToBrowserSwitchClient() {
         FragmentActivity activity = mock(FragmentActivity.class);
 
@@ -348,5 +361,14 @@ public class BraintreeClientUnitTest {
                 .analyticsClient(analyticsClient)
                 .browserSwitchClient(browserSwitchClient)
                 .manifestValidator(manifestValidator);
+    }
+
+    private static BrowserSwitchResult createSuccessfulBrowserSwitchResult() {
+        int requestCode = 123;
+        Uri url = Uri.parse("www.example.com");
+        String returnUrlScheme = "sample-scheme";
+        BrowserSwitchRequest browserSwitchRequest = new BrowserSwitchRequest(
+                requestCode, url, new JSONObject(), returnUrlScheme, true);
+        return new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, browserSwitchRequest);
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Core
+  * Bump `browser-switch` version to `2.0.2`
 * SamsungPay
   * Add `SamsungPayClient`
   * Add `SamsungPayClient#goToUpdatePage()`


### PR DESCRIPTION
### Summary of changes

 - Bump `browser-switch` version to `2.0.2` 
 - Add package-private `BraintreeClient#getBrowserSwitchResult()` method.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire
