### PR TITLE
Fix SamsungPay Amex Issue

### DIFF
--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationUnitTest.java
@@ -411,7 +411,7 @@ public class ConfigurationUnitTest {
     public void getSamsungPaySupportedCardBrands_forwardsValuesFromConfiguration() throws JSONException {
         Configuration sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_SAMSUNGPAY);
 
-        List<String> expected = Arrays.asList("american_express", "diners", "discover", "jcb", "maestro", "mastercard", "visa");
+        List<String> expected = Arrays.asList("american_express", "discover", "jcb", "mastercard", "visa");
         assertEquals(expected, sut.getSamsungPaySupportedCardBrands());
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * BraintreeCore
   * Add `BraintreeClient` constructor to allow a custom return url scheme to be used for browser and app switching
+* SamsungPay
+  * Add additional alias for Amex in `SamsungPay` (fixes #430)
 
 ## 4.4.1
 

--- a/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayMapAcceptedCardBrands.java
+++ b/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayMapAcceptedCardBrands.java
@@ -25,6 +25,7 @@ class SamsungPayMapAcceptedCardBrands {
                 case "discover":
                     result.add(SpaySdk.Brand.DISCOVER);
                     break;
+                case "american express":
                 case "american_express":
                     result.add(SpaySdk.Brand.AMERICANEXPRESS);
                     break;

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -49,9 +49,9 @@ public class SamsungPayInternalClientUnitTest {
     private ArgumentCaptor<List<SpaySdk.Brand>> cardBrandsCaptor;
 
     @Before
-    public void beforeEach() {
+    public void beforeEach() throws JSONException {
         MockitoAnnotations.initMocks(this);
-        configuration = mock(Configuration.class);
+        configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_SAMSUNGPAY);
     }
 
     @Test
@@ -204,8 +204,6 @@ public class SamsungPayInternalClientUnitTest {
                 .requestCardInfoSuccess(Arrays.asList(visaCardInfo, masterCardInfo))
                 .build();
 
-        when(configuration.getSupportedCardTypes()).thenReturn(Arrays.asList("mastercard", "american_express"));
-
         SamsungPay samsungPay = mock(SamsungPay.class);
         SamsungPayInternalClient sut = new SamsungPayInternalClient(configuration, samsungPay, paymentManager);
 
@@ -214,7 +212,8 @@ public class SamsungPayInternalClientUnitTest {
         verify(callback).onResult(cardBrandsCaptor.capture(), (Exception) isNull());
 
         List<SpaySdk.Brand> acceptedCardBrands = cardBrandsCaptor.getValue();
-        assertEquals(1, acceptedCardBrands.size());
+        assertEquals(2, acceptedCardBrands.size());
+        assertEquals(SpaySdk.Brand.MASTERCARD, acceptedCardBrands.get(0));
         assertEquals(SpaySdk.Brand.MASTERCARD, acceptedCardBrands.get(0));
     }
 

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -214,7 +214,7 @@ public class SamsungPayInternalClientUnitTest {
         List<SpaySdk.Brand> acceptedCardBrands = cardBrandsCaptor.getValue();
         assertEquals(2, acceptedCardBrands.size());
         assertEquals(SpaySdk.Brand.MASTERCARD, acceptedCardBrands.get(0));
-        assertEquals(SpaySdk.Brand.MASTERCARD, acceptedCardBrands.get(0));
+        assertEquals(SpaySdk.Brand.VISA, acceptedCardBrands.get(1));
     }
 
     @Test

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -21,7 +21,9 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import static com.samsung.android.sdk.samsungpay.v2.SpaySdk.ERROR_SPAY_APP_NEED_TO_UPDATE;
@@ -213,8 +215,11 @@ public class SamsungPayInternalClientUnitTest {
 
         List<SpaySdk.Brand> acceptedCardBrands = cardBrandsCaptor.getValue();
         assertEquals(2, acceptedCardBrands.size());
-        assertEquals(SpaySdk.Brand.MASTERCARD, acceptedCardBrands.get(0));
-        assertEquals(SpaySdk.Brand.VISA, acceptedCardBrands.get(1));
+
+        Set<SpaySdk.Brand> expected = new HashSet<>(
+                Arrays.asList(SpaySdk.Brand.MASTERCARD, SpaySdk.Brand.VISA));
+        Set<SpaySdk.Brand> actual = new HashSet<>(acceptedCardBrands);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -811,15 +811,22 @@ object Fixtures {
           "environment": "test",
           "merchantId": "integration_merchant_id",
           "merchantAccountId": "integration_merchant_account_id",
+          "creditCards": {
+            "supportedCardTypes": [
+              "American Express",
+              "Discover",
+              "JCB",
+              "MasterCard",
+              "Visa"
+            ]
+          },
           "samsungPay" : {
             "displayName": "some example merchant",
             "serviceId": "some-service-id",
             "supportedCardBrands": [
               "american_express",
-              "diners",
               "discover",
               "jcb",
-              "maestro",
               "mastercard",
               "visa"
             ],


### PR DESCRIPTION
### Summary of changes

 - Add additional alias for Amex in `SamsungPay` (fixes #430)
 - Update `Configuration` fixture for SamsungPay

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire
