### PR TITLE
BraintreeClient Custom URL Scheme Constructor

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -66,7 +66,9 @@ public class BraintreeClient {
     }
 
     /**
-     * Create a new instance of {@link BraintreeClient} using a tokenization key or client token.
+     * Create a new instance of {@link BraintreeClient} using a tokenization key or client token and a custom url scheme.
+     *
+     * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
      *
      * @param context         Android Context
      * @param authorization   The tokenization key or client token to use. If an invalid authorization is provided, a {@link BraintreeException} will be returned via callback.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -27,9 +27,18 @@ public class BraintreeClient {
     private final ManifestValidator manifestValidator;
     private final String sessionId;
     private final String integrationType;
-
+    private final String returnUrlScheme;
 
     private static BraintreeClientParams createDefaultParams(Context context, String authString) {
+        String returnUrlScheme = context
+                .getApplicationContext()
+                .getPackageName()
+                .toLowerCase(Locale.ROOT)
+                .replace("_", "") + ".braintree";
+        return createDefaultParams(context, authString, returnUrlScheme);
+    }
+
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, String returnUrlScheme) {
         Authorization authorization = Authorization.fromString(authString);
         BraintreeHttpClient httpClient = new BraintreeHttpClient(authorization);
         return new BraintreeClientParams()
@@ -38,6 +47,7 @@ public class BraintreeClient {
                 .setIntegrationType(IntegrationType.get(context))
                 .sessionId(UUIDHelper.getFormattedUUID())
                 .httpClient(httpClient)
+                .returnUrlScheme(returnUrlScheme)
                 .graphQLClient(new BraintreeGraphQLClient(authorization))
                 .analyticsClient(new AnalyticsClient(authorization))
                 .browserSwitchClient(new BrowserSwitchClient())
@@ -55,6 +65,17 @@ public class BraintreeClient {
         this(createDefaultParams(context, authorization));
     }
 
+    /**
+     * Create a new instance of {@link BraintreeClient} using a tokenization key or client token.
+     *
+     * @param context         Android Context
+     * @param authorization   The tokenization key or client token to use. If an invalid authorization is provided, a {@link BraintreeException} will be returned via callback.
+     * @param returnUrlScheme A custom return url to use for browser and app switching
+     */
+    public BraintreeClient(@NonNull Context context, @NonNull String authorization, @NonNull String returnUrlScheme) {
+        this(createDefaultParams(context, authorization, returnUrlScheme));
+    }
+
     @VisibleForTesting
     BraintreeClient(BraintreeClientParams params) {
         this.analyticsClient = params.getAnalyticsClient();
@@ -67,6 +88,7 @@ public class BraintreeClient {
         this.manifestValidator = params.getManifestValidator();
         this.sessionId = params.getSessionId();
         this.integrationType = params.getIntegrationType();
+        this.returnUrlScheme = params.getReturnUrlScheme();
 
         this.crashReporter = new CrashReporter(this);
         this.crashReporter.start();
@@ -155,11 +177,7 @@ public class BraintreeClient {
     }
 
     String getReturnUrlScheme() {
-        if (applicationContext != null) {
-            return applicationContext.getPackageName().toLowerCase(Locale.ROOT)
-                    .replace("_", "") + ".braintree";
-        }
-        return null;
+        return returnUrlScheme;
     }
 
     boolean canPerformBrowserSwitch(FragmentActivity activity, @BraintreeRequestCodes int requestCode) {
@@ -183,7 +201,7 @@ public class BraintreeClient {
         return manifestValidator.isUrlSchemeDeclaredInAndroidManifest(applicationContext, urlScheme, klass);
     }
 
-    ActivityInfo getManifestActivityInfo(Class klass) {
+    <T> ActivityInfo getManifestActivityInfo(Class<T> klass) {
         return manifestValidator.getActivityInfo(applicationContext, klass);
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.java
@@ -13,6 +13,7 @@ class BraintreeClientParams {
     private String integrationType;
     private BraintreeGraphQLClient graphQLClient;
 
+    private String returnUrlScheme;
     private ConfigurationLoader configurationLoader;
     private BrowserSwitchClient browserSwitchClient;
     private ManifestValidator manifestValidator;
@@ -104,6 +105,15 @@ class BraintreeClientParams {
 
     BraintreeClientParams setIntegrationType(String integrationType) {
         this.integrationType = integrationType;
+        return this;
+    }
+
+    String getReturnUrlScheme() {
+        return returnUrlScheme;
+    }
+
+    BraintreeClientParams returnUrlScheme(String returnUrlScheme) {
+        this.returnUrlScheme = returnUrlScheme;
         return this;
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -341,12 +341,22 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void getReturnUrlScheme_returnsUrlScheme() {
-        BraintreeClientParams params = createDefaultParams(configurationLoader, "sessionId", "integrationType");
-        BraintreeClient sut = new BraintreeClient(params);
+    public void getReturnUrlScheme_returnsUrlSchemeBasedOnApplicationIdByDefault() {
+        Context context = ApplicationProvider.getApplicationContext();
+        String authorization = Fixtures.BASE64_CLIENT_TOKEN;
+        BraintreeClient sut = new BraintreeClient(context, authorization);
 
-        String returnUrlScheme = sut.getReturnUrlScheme();
-        assertEquals("com.braintreepayments.api.test.braintree", returnUrlScheme);
+        assertEquals("com.braintreepayments.api.test.braintree", sut.getReturnUrlScheme());
+    }
+
+    @Test
+    public void getReturnUrlScheme_returnsUrlSchemeDefinedInConstructor() {
+        Context context = ApplicationProvider.getApplicationContext();
+        String authorization = Fixtures.BASE64_CLIENT_TOKEN;
+        String returnUrlScheme = "custom-url-scheme";
+        BraintreeClient sut = new BraintreeClient(context, authorization, returnUrlScheme);
+
+        assertEquals("custom-url-scheme", sut.getReturnUrlScheme());
     }
 
     private BraintreeClientParams createDefaultParams(ConfigurationLoader configurationLoader, String sessionId, String integrationType) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* BraintreeCore
+  * Add `BraintreeClient` constructor to allow a custom return url scheme to be used for browser and app switching
+
 ## 4.4.1
 
 * ThreeDSecure


### PR DESCRIPTION
### Summary of changes

 - Create a new `BraintreeClient` instructor that allows for a custom `returnUrlScheme` for browser and app switching
 - Cleanup random lint errors

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire
