### PR TITLE
Mark BraintreeCore as api dependency for BraintreeDataCollector.

### DIFF
--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation files('libs/android-magnessdk-5.3.0.jar')
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation project(':BraintreeCore')
+    api project(':BraintreeCore')
 
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.mockito:mockito-core:3.6.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Add `BraintreeClient` constructor to allow a custom return url scheme to be used for browser and app switching
 * BraintreeDataCollector
   * Bump Magnes dependency to version 5.3.0
+  * Add `BraintreeCore` as an `api` dependency (Fixes #437)
 * SamsungPay
   * Add additional alias for Amex in `SamsungPay` (fixes #430)
 


### PR DESCRIPTION
### Summary of changes

 - Make `:BraintreeCore` an `api` dependency for `:BraintreeDataCollector` (Fixes #437)

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire
