### PR TITLE
Make VenmoRequest Parcelable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Venmo
+  * Make `VenmoRequest` parcelable
 * ThreeDSecure
   * Make `pareq` optional on `ThreeDSecureLookup`
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -1,11 +1,14 @@
 package com.braintreepayments.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import androidx.annotation.Nullable;
 
 /**
  A VenmoRequest specifies options that contribute to the Venmo flow
  */
-public class VenmoRequest {
+public class VenmoRequest implements Parcelable {
 
     private boolean shouldVault;
     private String profileId;
@@ -88,5 +91,37 @@ public class VenmoRequest {
             default:
                 return null;
         }
+    }
+
+    protected VenmoRequest(Parcel in) {
+        shouldVault = in.readByte() != 0;
+        profileId = in.readString();
+        displayName = in.readString();
+        paymentMethodUsage = in.readInt();
+    }
+
+    public static final Creator<VenmoRequest> CREATOR = new Creator<VenmoRequest>() {
+        @Override
+        public VenmoRequest createFromParcel(Parcel in) {
+            return new VenmoRequest(in);
+        }
+
+        @Override
+        public VenmoRequest[] newArray(int size) {
+            return new VenmoRequest[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeByte((byte) (shouldVault ? 1 : 0));
+        parcel.writeString(profileId);
+        parcel.writeString(displayName);
+        parcel.writeInt(paymentMethodUsage);
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoRequestUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoRequestUnitTest.java
@@ -1,10 +1,17 @@
 package com.braintreepayments.api;
 
+import static junit.framework.TestCase.assertTrue;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import android.os.Parcel;
+
+@RunWith(RobolectricTestRunner.class)
 public class VenmoRequestUnitTest {
 
     @Test
@@ -17,5 +24,23 @@ public class VenmoRequestUnitTest {
     public void getPaymentMethodUsageAsString_whenMultiUse_returnsStringEquivalent() {
         VenmoRequest sut = new VenmoRequest(VenmoPaymentMethodUsage.MULTI_USE);
         assertEquals("MULTI_USE", sut.getPaymentMethodUsageAsString());
+    }
+
+    @Test
+    public void parcelsCorrectly() {
+        VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.MULTI_USE);
+        request.setDisplayName("venmo-user");
+        request.setShouldVault(true);
+        request.setProfileId("profile-id");
+
+        Parcel parcel = Parcel.obtain();
+        request.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        VenmoRequest result = VenmoRequest.CREATOR.createFromParcel(parcel);
+
+        assertEquals(VenmoPaymentMethodUsage.MULTI_USE, result.getPaymentMethodUsage());
+        assertEquals("venmo-user", result.getDisplayName());
+        assertTrue(result.getShouldVault());
+        assertEquals("profile-id", result.getProfileId());
     }
 }


### PR DESCRIPTION
### Summary of changes

 - As part of Drop-in updates, we want to allow merchants to set a `VenmoRequest` on their `DropInRequest` - similar to what they do for PayPal and Google Pay. To make that change in Drop-in, `VenmoRequest` needs to be parcelable.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
