### PR TITLE
PwPP: Add correlation id to PayPalRequest

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -230,6 +230,10 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
             parameters.put(MERCHANT_ACCOUNT_ID, getMerchantAccountId());
         }
 
+        if (getCorrelationId() != null) {
+            parameters.put(CORRELATION_ID_KEY, getCorrelationId());
+        }
+
         parameters.put(EXPERIENCE_PROFILE_KEY, experienceProfile);
         return parameters.toString();
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -39,6 +39,7 @@ public abstract class PayPalRequest implements Parcelable {
     static final String DISPLAY_NAME_KEY = "brand_name";
     static final String SHIPPING_ADDRESS_KEY = "shipping_address";
     static final String MERCHANT_ACCOUNT_ID = "merchant_account_id";
+    static final String CORRELATION_ID_KEY = "correlation_id";
     static final String LINE_ITEMS_KEY = "line_items";
 
     @Retention(RetentionPolicy.SOURCE)
@@ -64,6 +65,7 @@ public abstract class PayPalRequest implements Parcelable {
     private String landingPageType;
     private String displayName;
     private String merchantAccountId;
+    private String correlationId;
     private final ArrayList<PayPalLineItem> lineItems;
 
     /**
@@ -183,6 +185,15 @@ public abstract class PayPalRequest implements Parcelable {
     }
 
     /**
+     * Optional: A correlation ID created with Set Transaction Context on your server.
+     *
+     * @param correlationId the correlation ID.
+     */
+    public void setCorrelationId(@Nullable String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    /**
      * Optional: The line items for this transaction. It can include up to 249 line items.
      *
      * @param lineItems a collection of {@link PayPalLineItem}
@@ -225,6 +236,11 @@ public abstract class PayPalRequest implements Parcelable {
         return merchantAccountId;
     }
 
+    @Nullable
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
     @NonNull
     public ArrayList<PayPalLineItem> getLineItems() {
         return lineItems;
@@ -247,6 +263,7 @@ public abstract class PayPalRequest implements Parcelable {
         landingPageType = in.readString();
         displayName = in.readString();
         merchantAccountId = in.readString();
+        correlationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
     }
 
@@ -265,6 +282,7 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(landingPageType);
         parcel.writeString(displayName);
         parcel.writeString(merchantAccountId);
+        parcel.writeString(correlationId);
         parcel.writeTypedList(lineItems);
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -82,6 +82,10 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
             parameters.put(MERCHANT_ACCOUNT_ID, getMerchantAccountId());
         }
 
+        if (getCorrelationId() != null) {
+            parameters.put(CORRELATION_ID_KEY, getCorrelationId());
+        }
+
         parameters.put(EXPERIENCE_PROFILE_KEY, experienceProfile);
         return parameters.toString();
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -48,6 +48,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setShippingAddressOverride(postalAddress);
         request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
         request.setDisplayName("Display Name");
+        request.setCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
 
         assertEquals("1.00", request.getAmount());
@@ -60,6 +61,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(PayPalPaymentIntent.SALE, request.getIntent());
         assertEquals(PayPalCheckoutRequest.USER_ACTION_COMMIT, request.getUserAction());
         assertEquals("Display Name", request.getDisplayName());
+        assertEquals("123-correlation", request.getCorrelationId());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferPayLater());
     }
@@ -81,6 +83,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
         request.setDisplayName("Display Name");
+        request.setCorrelationId("123-correlation");
         request.setMerchantAccountId("merchant_account_id");
 
         ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
@@ -105,6 +108,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, result.getLandingPageType());
         assertEquals(PayPalCheckoutRequest.USER_ACTION_COMMIT, result.getUserAction());
         assertEquals("Display Name", result.getDisplayName());
+        assertEquals("123-correlation", result.getCorrelationId());
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -37,6 +37,7 @@ public class PayPalVaultRequestUnitTest {
         request.setShippingAddressRequired(true);
         request.setShippingAddressOverride(postalAddress);
         request.setDisplayName("Display Name");
+        request.setCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setShouldOfferCredit(true);
 
@@ -45,6 +46,7 @@ public class PayPalVaultRequestUnitTest {
         assertTrue(request.isShippingAddressRequired());
         assertEquals(postalAddress, request.getShippingAddressOverride());
         assertEquals("Display Name", request.getDisplayName());
+        assertEquals("123-correlation", request.getCorrelationId());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
     }
@@ -64,6 +66,7 @@ public class PayPalVaultRequestUnitTest {
 
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setDisplayName("Display Name");
+        request.setCorrelationId("123-correlation");
         request.setMerchantAccountId("merchant_account_id");
 
         ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
@@ -85,6 +88,7 @@ public class PayPalVaultRequestUnitTest {
                 .getRecipientName());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, result.getLandingPageType());
         assertEquals("Display Name", result.getDisplayName());
+        assertEquals("123-correlation", result.getCorrelationId());
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());


### PR DESCRIPTION
### Summary of changes
- Add `correlation_id` to PayPalRequest.

Allows for the linking of STC and RDA before the PwPP flow starts.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
- @demerino 
