### PR TITLE
Encrypt SharedPreferences

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
@@ -92,7 +92,7 @@ class AnalyticsClient {
                 .build();
     }
 
-    void uploadAnalytics(Context context, Configuration configuration) throws Exception {
+    void uploadAnalytics(Context context, Configuration configuration, BraintreeSharedPreferences braintreeSharedPreferences) throws Exception {
         String analyticsUrl = configuration.getAnalyticsUrl();
 
         final AnalyticsDatabase db = AnalyticsDatabase.getInstance(context);
@@ -100,7 +100,7 @@ class AnalyticsClient {
 
         try {
             for (final List<AnalyticsEvent> innerEvents : events) {
-                JSONObject analyticsRequest = serializeEvents(context, httpClient.getAuthorization(), innerEvents);
+                JSONObject analyticsRequest = serializeEvents(context, httpClient.getAuthorization(), innerEvents, braintreeSharedPreferences);
                 httpClient.post(analyticsUrl, analyticsRequest.toString(), configuration);
                 db.removeEvents(innerEvents);
             }
@@ -112,7 +112,7 @@ class AnalyticsClient {
     }
 
     private JSONObject serializeEvents(Context context, Authorization authorization,
-                                       List<AnalyticsEvent> events) throws JSONException {
+                                       List<AnalyticsEvent> events, BraintreeSharedPreferences braintreeSharedPreferences) throws JSONException {
         AnalyticsEvent primeEvent = events.get(0);
 
         JSONObject requestObject = new JSONObject();
@@ -132,7 +132,7 @@ class AnalyticsClient {
                 .put(DEVICE_MANUFACTURER_KEY, Build.MANUFACTURER)
                 .put(DEVICE_MODEL_KEY, Build.MODEL)
                 .put(DEVICE_APP_GENERATED_PERSISTENT_UUID_KEY,
-                        UUIDHelper.getPersistentUUID(context))
+                        UUIDHelper.getPersistentUUID(context, braintreeSharedPreferences))
                 .put(IS_SIMULATOR_KEY, deviceInspector.isDeviceEmulator());
         requestObject.put(META_KEY, meta);
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsUploadWorker.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsUploadWorker.java
@@ -34,7 +34,7 @@ public class AnalyticsUploadWorker extends Worker {
 
         AnalyticsClient analyticsClient = new AnalyticsClient(authorization);
         try {
-            analyticsClient.uploadAnalytics(getApplicationContext(), configuration);
+            analyticsClient.uploadAnalytics(getApplicationContext(), configuration, new BraintreeSharedPreferences());
             return Result.success();
         } catch (Exception e) {
             return Result.failure();

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -6,6 +6,8 @@ import android.content.SharedPreferences;
 import androidx.annotation.VisibleForTesting;
 
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.TimeUnit;
 
 class ConfigurationCache {
@@ -35,7 +37,12 @@ class ConfigurationCache {
 
     @VisibleForTesting
     String getConfiguration(Context context, String cacheKey, long currentTimeMillis) {
-        SharedPreferences prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+        SharedPreferences prefs;
+        try {
+            prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+        } catch (GeneralSecurityException | IOException e) {
+            return null;
+        }
 
         String timestampKey = cacheKey + "_timestamp";
         if (prefs.contains(timestampKey)) {
@@ -54,9 +61,13 @@ class ConfigurationCache {
     @VisibleForTesting
     void saveConfiguration(Context context, Configuration configuration, String cacheKey, long currentTimeMillis) {
         String timestampKey = String.format("%s_timestamp", cacheKey);
-        BraintreeSharedPreferences.getSharedPreferences(context).edit()
-                .putString(cacheKey, configuration.toJson())
-                .putLong(timestampKey, currentTimeMillis)
-                .apply();
+        try {
+            BraintreeSharedPreferences.getSharedPreferences(context).edit()
+                    .putString(cacheKey, configuration.toJson())
+                    .putLong(timestampKey, currentTimeMillis)
+                    .apply();
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -32,14 +32,14 @@ class ConfigurationCache {
     ConfigurationCache() {}
 
     String getConfiguration(Context context, String cacheKey) {
-        return getConfiguration(context, cacheKey, System.currentTimeMillis());
+        return getConfiguration(context, new BraintreeSharedPreferences(), cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    String getConfiguration(Context context, String cacheKey, long currentTimeMillis) {
+    String getConfiguration(Context context, BraintreeSharedPreferences braintreeSharedPreferences, String cacheKey, long currentTimeMillis) {
         SharedPreferences prefs;
         try {
-            prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+            prefs = braintreeSharedPreferences.getSharedPreferences(context);
         } catch (GeneralSecurityException | IOException e) {
             return null;
         }
@@ -55,14 +55,14 @@ class ConfigurationCache {
     }
 
     void saveConfiguration(Context context, Configuration configuration, String cacheKey) {
-        saveConfiguration(context, configuration, cacheKey, System.currentTimeMillis());
+        saveConfiguration(context, configuration, new BraintreeSharedPreferences(), cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    void saveConfiguration(Context context, Configuration configuration, String cacheKey, long currentTimeMillis) {
+    void saveConfiguration(Context context, Configuration configuration, BraintreeSharedPreferences braintreeSharedPreferences, String cacheKey, long currentTimeMillis) {
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
-            BraintreeSharedPreferences.getSharedPreferences(context).edit()
+            braintreeSharedPreferences.getSharedPreferences(context).edit()
                     .putString(cacheKey, configuration.toJson())
                     .putLong(timestampKey, currentTimeMillis)
                     .apply();

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -66,8 +66,7 @@ class ConfigurationCache {
                     .putString(cacheKey, configuration.toJson())
                     .putLong(timestampKey, currentTimeMillis)
                     .apply();
-        } catch (GeneralSecurityException | IOException e) {
-            e.printStackTrace();
+        } catch (GeneralSecurityException | IOException ignored) {
         }
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -13,15 +13,14 @@ class UUIDHelper {
 
     /**
      * @param context Android Context
-     * @param braintreeSharedPreferences
+     * @param braintreeSharedPreferences {@link BraintreeSharedPreferences}
      * @return A persistent UUID for this application install.
      */
     static String getPersistentUUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         SharedPreferences prefs = null;
         try {
             prefs = braintreeSharedPreferences.getSharedPreferences(context);
-        } catch (GeneralSecurityException | IOException e) {
-            e.printStackTrace();
+        } catch (GeneralSecurityException | IOException ignored) {
         }
 
         String uuid = null;

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -3,6 +3,8 @@ package com.braintreepayments.api;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.UUID;
 
 class UUIDHelper {
@@ -14,12 +16,22 @@ class UUIDHelper {
      * @return A persistent UUID for this application install.
      */
     static String getPersistentUUID(Context context) {
-        SharedPreferences prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+        SharedPreferences prefs = null;
+        try {
+            prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
 
-        String uuid = prefs.getString(BRAINTREE_UUID_KEY, null);
+        String uuid = null;
+        if (prefs != null) {
+            uuid = prefs.getString(BRAINTREE_UUID_KEY, null);
+        }
         if (uuid == null) {
             uuid = getFormattedUUID();
-            prefs.edit().putString(BRAINTREE_UUID_KEY, uuid).apply();
+            if (prefs != null) {
+                prefs.edit().putString(BRAINTREE_UUID_KEY, uuid).apply();
+            }
         }
 
         return uuid;

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -13,12 +13,13 @@ class UUIDHelper {
 
     /**
      * @param context Android Context
+     * @param braintreeSharedPreferences
      * @return A persistent UUID for this application install.
      */
-    static String getPersistentUUID(Context context) {
+    static String getPersistentUUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         SharedPreferences prefs = null;
         try {
-            prefs = BraintreeSharedPreferences.getSharedPreferences(context);
+            prefs = braintreeSharedPreferences.getSharedPreferences(context);
         } catch (GeneralSecurityException | IOException e) {
             e.printStackTrace();
         }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -5,26 +5,40 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
 import org.json.JSONException;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.TimeUnit;
 
 import static com.braintreepayments.api.SharedPreferencesHelper.getSharedPreferences;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class ConfigurationCacheUnitTest {
 
+    BraintreeSharedPreferences braintreeSharedPreferences;
+    Context context;
+
+    @Before
+    public void beforeEach() throws GeneralSecurityException, IOException {
+        context = ApplicationProvider.getApplicationContext();
+        braintreeSharedPreferences = mock(BraintreeSharedPreferences.class);
+        when(braintreeSharedPreferences.getSharedPreferences(context)).thenReturn(getSharedPreferences(context));
+    }
+
     @Test
     public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        Context context = ApplicationProvider.getApplicationContext();
 
         ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(context, configuration, "cacheKey", 123);
+        sut.saveConfiguration(context, configuration, braintreeSharedPreferences, "cacheKey", 123);
 
         assertEquals(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN, getSharedPreferences(context).getString("cacheKey", ""));
         assertEquals(123L, getSharedPreferences(context).getLong("cacheKey_timestamp", 0));
@@ -33,22 +47,20 @@ public class ConfigurationCacheUnitTest {
     @Test
     public void getCacheConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        Context context = ApplicationProvider.getApplicationContext();
 
         ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(context, configuration, "cacheKey", 0);
+        sut.saveConfiguration(context, configuration, braintreeSharedPreferences, "cacheKey", 0);
 
-        assertEquals(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN, ConfigurationCache.getInstance().getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
+        assertEquals(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN, ConfigurationCache.getInstance().getConfiguration(context, braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
     }
 
     @Test
     public void getCacheConfiguration_returnsNullIfCacheEntryExpires() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        Context context = ApplicationProvider.getApplicationContext();
 
         ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(context, configuration, "cacheKey", 0);
+        sut.saveConfiguration(context, configuration, braintreeSharedPreferences, "cacheKey", 0);
 
-        assertNull(ConfigurationCache.getInstance().getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)));
+        assertNull(ConfigurationCache.getInstance().getConfiguration(context, braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5)));
     }
 }

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
@@ -54,6 +55,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
+    androidTestImplementation 'org.mockito:mockito-core:3.6.0'
     androidTestImplementation project(':TestUtils')
 }
 

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
-    androidTestImplementation 'org.mockito:mockito-core:3.6.0'
     androidTestImplementation project(':TestUtils')
 }
 

--- a/BraintreeDataCollector/src/main/java/com/braintreepayments/api/PayPalInstallationIdentifier.java
+++ b/BraintreeDataCollector/src/main/java/com/braintreepayments/api/PayPalInstallationIdentifier.java
@@ -14,6 +14,10 @@ class PayPalInstallationIdentifier {
     private static final String INSTALL_GUID = "InstallationGUID";
     private static final String SHARED_PREFS_NAMESPACE = "com.braintreepayments.api.paypal";
 
+    String getInstallationGUID(Context context) {
+        return getInstallationGUID(context, new BraintreeSharedPreferences());
+    }
+
     @VisibleForTesting
     String getInstallationGUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         SharedPreferences preferences;
@@ -36,9 +40,5 @@ class PayPalInstallationIdentifier {
             }
         }
         return null;
-    }
-
-    String getInstallationGUID(Context context) {
-        return getInstallationGUID(context, new BraintreeSharedPreferences());
     }
 }

--- a/BraintreeDataCollector/src/main/java/com/braintreepayments/api/PayPalInstallationIdentifier.java
+++ b/BraintreeDataCollector/src/main/java/com/braintreepayments/api/PayPalInstallationIdentifier.java
@@ -3,6 +3,10 @@ package com.braintreepayments.api;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.VisibleForTesting;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.UUID;
 
 class PayPalInstallationIdentifier {
@@ -10,8 +14,14 @@ class PayPalInstallationIdentifier {
     private static final String INSTALL_GUID = "InstallationGUID";
     private static final String SHARED_PREFS_NAMESPACE = "com.braintreepayments.api.paypal";
 
-    String getInstallationGUID(Context context) {
-        SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFS_NAMESPACE, Context.MODE_PRIVATE);
+    @VisibleForTesting
+    String getInstallationGUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
+        SharedPreferences preferences;
+        try {
+            preferences = braintreeSharedPreferences.getSharedPreferences(context, SHARED_PREFS_NAMESPACE);
+        } catch (GeneralSecurityException | IOException e) {
+            return null;
+        }
         if (preferences != null) {
             String existingGUID = preferences.getString(INSTALL_GUID, null);
             if (existingGUID != null) {
@@ -26,5 +36,9 @@ class PayPalInstallationIdentifier {
             }
         }
         return null;
+    }
+
+    String getInstallationGUID(Context context) {
+        return getInstallationGUID(context, new BraintreeSharedPreferences());
     }
 }

--- a/BraintreeDataCollector/src/test/java/com/braintreepayments/api/PayPalInstallationIdentifierTest.java
+++ b/BraintreeDataCollector/src/test/java/com/braintreepayments/api/PayPalInstallationIdentifierTest.java
@@ -1,29 +1,40 @@
 package com.braintreepayments.api;
 
+import static com.braintreepayments.api.SharedPreferencesHelper.getSharedPreferences;
+
 import android.content.Context;
 import android.content.SharedPreferences;
-
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.UUID;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4ClassRunner.class)
+import androidx.test.core.app.ApplicationProvider;
+
+@RunWith(RobolectricTestRunner.class)
 public class PayPalInstallationIdentifierTest {
 
+    private Context context;
     private SharedPreferences prefs;
+    private BraintreeSharedPreferences braintreeSharedPreferences;
 
     @Before
-    public void setup() {
-        prefs = ApplicationProvider.getApplicationContext().getSharedPreferences("com.braintreepayments.api.paypal", Context.MODE_PRIVATE);
+    public void setup() throws GeneralSecurityException, IOException {
+        context = ApplicationProvider.getApplicationContext();
+        prefs = getSharedPreferences(context, "com.braintreepayments.api.paypal");
+        braintreeSharedPreferences = mock(BraintreeSharedPreferences.class);
+        when(braintreeSharedPreferences.getSharedPreferences(context, "com.braintreepayments.api.paypal")).thenReturn(prefs);
         prefs.edit().clear().apply();
     }
 
@@ -33,7 +44,7 @@ public class PayPalInstallationIdentifierTest {
 
         assertNull(prefs.getString("InstallationGUID", null));
 
-        assertNotNull(sut.getInstallationGUID(ApplicationProvider.getApplicationContext()));
+        assertNotNull(sut.getInstallationGUID(context, braintreeSharedPreferences));
 
         assertNotNull(prefs.getString("InstallationGUID", null));
     }
@@ -48,7 +59,7 @@ public class PayPalInstallationIdentifierTest {
         String existingGUID = prefs.getString("InstallationGUID", null);
         assertNotNull(existingGUID);
 
-        assertEquals(existingGUID, sut.getInstallationGUID(ApplicationProvider.getApplicationContext()));
+        assertEquals(existingGUID, sut.getInstallationGUID(context, braintreeSharedPreferences));
 
         assertEquals(existingGUID, prefs.getString("InstallationGUID", null));
     }

--- a/BraintreeDataCollector/src/test/java/com/braintreepayments/api/PayPalInstallationIdentifierUnitTest.java
+++ b/BraintreeDataCollector/src/test/java/com/braintreepayments/api/PayPalInstallationIdentifierUnitTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import androidx.test.core.app.ApplicationProvider;
 
 @RunWith(RobolectricTestRunner.class)
-public class PayPalInstallationIdentifierTest {
+public class PayPalInstallationIdentifierUnitTest {
 
     private Context context;
     private SharedPreferences prefs;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* SharedPreferences
+  * Encrypt shared preferences in BraintreeSharedPreferences (fixes #440)
 * ThreeDSecure
   * Make `pareq` optional on `ThreeDSecureLookup`
 

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -32,6 +32,7 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.4.0'

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -1,0 +1,54 @@
+package com.braintreepayments.api;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class BraintreeSharedPreferencesTest {
+
+    @Before
+    public void beforeEach() throws GeneralSecurityException, IOException {
+        new BraintreeSharedPreferences().getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().apply();
+    }
+
+    @Test
+    public void getSharedPreferences_returnsEncryptedSharedPreferences() throws GeneralSecurityException, IOException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences();
+        SharedPreferences sharedPreferences = sut.getSharedPreferences(ApplicationProvider.getApplicationContext());
+        assertTrue(sharedPreferences instanceof EncryptedSharedPreferences);
+    }
+
+    @Test
+    public void getSharedPreferences_returnsPreferencesWithBraintreeApiFileNameByDefault() throws GeneralSecurityException, IOException {
+        Context context = ApplicationProvider.getApplicationContext();
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences();
+        SharedPreferences sharedPreferences = sut.getSharedPreferences(context);
+        sharedPreferences.edit().putBoolean("test-key-braintree-api", true).apply();
+        assertTrue(sut.getSharedPreferences(context, "BraintreeApi").getBoolean("test-key-braintree-api", false));
+    }
+
+    @Test
+    public void getSharedPreferences_returnsPreferencesWithFileNameByFromConstructor() throws GeneralSecurityException, IOException {
+        Context context = ApplicationProvider.getApplicationContext();
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences();
+        SharedPreferences sharedPreferences = sut.getSharedPreferences(context, "custom-file-name");
+        sharedPreferences.edit().putBoolean("test-key-custom-file", true).apply();
+        assertTrue(sut.getSharedPreferences(context, "custom-file-name").getBoolean("test-key-custom-file", false));
+    }
+}

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -11,17 +11,21 @@ import java.security.GeneralSecurityException;
 
 class BraintreeSharedPreferences {
 
-    SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
+    SharedPreferences getSharedPreferences(Context context, String fileName) throws GeneralSecurityException, IOException {
         MasterKey masterKey = new MasterKey.Builder(context)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build();
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build();
 
         return EncryptedSharedPreferences.create(
                 context,
-                "BraintreeApi",
+                fileName,
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         );
+    }
+
+    SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
+        return getSharedPreferences(context, "BraintreeApi");
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -11,7 +11,7 @@ import java.security.GeneralSecurityException;
 
 class BraintreeSharedPreferences {
 
-    static SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
+    SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
         MasterKey masterKey = new MasterKey.Builder(context)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                     .build();

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -28,4 +28,5 @@ class BraintreeSharedPreferences {
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         );
     }
+
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -11,6 +11,10 @@ import java.security.GeneralSecurityException;
 
 class BraintreeSharedPreferences {
 
+    SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
+        return getSharedPreferences(context, "BraintreeApi");
+    }
+
     SharedPreferences getSharedPreferences(Context context, String fileName) throws GeneralSecurityException, IOException {
         MasterKey masterKey = new MasterKey.Builder(context)
                 .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -23,9 +27,5 @@ class BraintreeSharedPreferences {
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         );
-    }
-
-    SharedPreferences getSharedPreferences(Context context) throws GeneralSecurityException, IOException {
-        return getSharedPreferences(context, "BraintreeApi");
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -2,11 +2,9 @@ package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
-import androidx.security.crypto.MasterKeys;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -25,7 +23,5 @@ class BraintreeSharedPreferences {
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         );
-
-//        return context.getApplicationContext().getSharedPreferences("BraintreeApi", Context.MODE_PRIVATE);
     }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -5,6 +5,9 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.util.Base64;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 public class SharedPreferencesHelper {
 
     public static SharedPreferences getSharedPreferences(Context context) {
@@ -20,20 +23,28 @@ public class SharedPreferencesHelper {
 
         String cacheKey = Base64.encodeToString(String.format("%s%s", configUrl, authorization.getBearer()).getBytes(), 0);
         String timestampKey = String.format("%s_timestamp", cacheKey);
-        BraintreeSharedPreferences
-                .getSharedPreferences(context)
-                .edit()
-                .putString(cacheKey, configuration.toJson())
-                .putLong(timestampKey, System.currentTimeMillis())
-                .apply();
+        try {
+            BraintreeSharedPreferences
+                    .getSharedPreferences(context)
+                    .edit()
+                    .putString(cacheKey, configuration.toJson())
+                    .putLong(timestampKey, System.currentTimeMillis())
+                    .apply();
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public static void clearConfigurationCacheOverride(Context context) {
-        BraintreeSharedPreferences
-                .getSharedPreferences(context)
-                .edit()
-                .clear()
-                .apply();
+        try {
+            BraintreeSharedPreferences
+                    .getSharedPreferences(context)
+                    .edit()
+                    .clear()
+                    .apply();
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @SuppressWarnings("ApplySharedPref")

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -24,7 +24,7 @@ public class SharedPreferencesHelper {
         String cacheKey = Base64.encodeToString(String.format("%s%s", configUrl, authorization.getBearer()).getBytes(), 0);
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
-            BraintreeSharedPreferences
+            new BraintreeSharedPreferences()
                     .getSharedPreferences(context)
                     .edit()
                     .putString(cacheKey, configuration.toJson())
@@ -37,7 +37,7 @@ public class SharedPreferencesHelper {
 
     public static void clearConfigurationCacheOverride(Context context) {
         try {
-            BraintreeSharedPreferences
+           new BraintreeSharedPreferences()
                     .getSharedPreferences(context)
                     .edit()
                     .clear()

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -34,8 +34,7 @@ public class SharedPreferencesHelper {
                     .putString(cacheKey, configuration.toJson())
                     .putLong(timestampKey, System.currentTimeMillis())
                     .apply();
-        } catch (GeneralSecurityException | IOException e) {
-            e.printStackTrace();
+        } catch (GeneralSecurityException | IOException ignored) {
         }
     }
 
@@ -46,8 +45,7 @@ public class SharedPreferencesHelper {
                     .edit()
                     .clear()
                     .apply();
-        } catch (GeneralSecurityException | IOException e) {
-            e.printStackTrace();
+        } catch (GeneralSecurityException | IOException ignored) {
         }
     }
 

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -14,6 +14,10 @@ public class SharedPreferencesHelper {
         return context.getSharedPreferences("BraintreeApi", Context.MODE_PRIVATE);
     }
 
+    public static SharedPreferences getSharedPreferences(Context context, String fileName) {
+        return context.getSharedPreferences(fileName, Context.MODE_PRIVATE);
+    }
+
     public static void overrideConfigurationCache(Context context, Authorization authorization, Configuration configuration) {
         final String configUrl = Uri.parse(authorization.getConfigUrl())
                 .buildUpon()

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -2,6 +2,8 @@ package com.braintreepayments.api;
 
 import android.content.Context;
 
+import androidx.annotation.VisibleForTesting;
+
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -11,9 +13,10 @@ class VenmoSharedPrefsWriter {
 
     VenmoSharedPrefsWriter() {}
 
-    void persistVenmoVaultOption(Context context, boolean shouldVault) {
+    @VisibleForTesting
+    void persistVenmoVaultOption(Context context, BraintreeSharedPreferences braintreeSharedPreferences, boolean shouldVault) {
         try {
-            BraintreeSharedPreferences.getSharedPreferences(context).edit()
+            braintreeSharedPreferences.getSharedPreferences(context).edit()
                     .putBoolean(VAULT_VENMO_KEY, shouldVault)
                     .apply();
         } catch (GeneralSecurityException | IOException e) {
@@ -21,12 +24,21 @@ class VenmoSharedPrefsWriter {
         }
     }
 
-    boolean getVenmoVaultOption(Context context) {
+    void persistVenmoVaultOption(Context context, boolean shouldVault) {
+        persistVenmoVaultOption(context, new BraintreeSharedPreferences(), shouldVault);
+    }
+
+    @VisibleForTesting
+    boolean getVenmoVaultOption(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         try {
-            return BraintreeSharedPreferences.getSharedPreferences(context)
+            return braintreeSharedPreferences.getSharedPreferences(context)
                     .getBoolean(VAULT_VENMO_KEY, false);
         } catch (GeneralSecurityException | IOException e) {
             return false;
         }
+    }
+
+    boolean getVenmoVaultOption(Context context) {
+        return getVenmoVaultOption(context, new BraintreeSharedPreferences());
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -13,6 +13,10 @@ class VenmoSharedPrefsWriter {
 
     VenmoSharedPrefsWriter() {}
 
+    void persistVenmoVaultOption(Context context, boolean shouldVault) {
+        persistVenmoVaultOption(context, new BraintreeSharedPreferences(), shouldVault);
+    }
+
     @VisibleForTesting
     void persistVenmoVaultOption(Context context, BraintreeSharedPreferences braintreeSharedPreferences, boolean shouldVault) {
         try {
@@ -23,8 +27,8 @@ class VenmoSharedPrefsWriter {
         }
     }
 
-    void persistVenmoVaultOption(Context context, boolean shouldVault) {
-        persistVenmoVaultOption(context, new BraintreeSharedPreferences(), shouldVault);
+    boolean getVenmoVaultOption(Context context) {
+        return getVenmoVaultOption(context, new BraintreeSharedPreferences());
     }
 
     @VisibleForTesting
@@ -35,9 +39,5 @@ class VenmoSharedPrefsWriter {
         } catch (GeneralSecurityException | IOException e) {
             return false;
         }
-    }
-
-    boolean getVenmoVaultOption(Context context) {
-        return getVenmoVaultOption(context, new BraintreeSharedPreferences());
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -19,8 +19,7 @@ class VenmoSharedPrefsWriter {
             braintreeSharedPreferences.getSharedPreferences(context).edit()
                     .putBoolean(VAULT_VENMO_KEY, shouldVault)
                     .apply();
-        } catch (GeneralSecurityException | IOException e) {
-            e.printStackTrace();
+        } catch (GeneralSecurityException | IOException ignored) {
         }
     }
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -2,6 +2,9 @@ package com.braintreepayments.api;
 
 import android.content.Context;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 class VenmoSharedPrefsWriter {
 
     private static final String VAULT_VENMO_KEY = "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY";
@@ -9,13 +12,21 @@ class VenmoSharedPrefsWriter {
     VenmoSharedPrefsWriter() {}
 
     void persistVenmoVaultOption(Context context, boolean shouldVault) {
-        BraintreeSharedPreferences.getSharedPreferences(context).edit()
-                .putBoolean(VAULT_VENMO_KEY, shouldVault)
-                .apply();
+        try {
+            BraintreeSharedPreferences.getSharedPreferences(context).edit()
+                    .putBoolean(VAULT_VENMO_KEY, shouldVault)
+                    .apply();
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
     }
 
     boolean getVenmoVaultOption(Context context) {
-        return BraintreeSharedPreferences.getSharedPreferences(context)
-                .getBoolean(VAULT_VENMO_KEY, false);
+        try {
+            return BraintreeSharedPreferences.getSharedPreferences(context)
+                    .getBoolean(VAULT_VENMO_KEY, false);
+        } catch (GeneralSecurityException | IOException e) {
+            return false;
+        }
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
@@ -11,17 +11,25 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 
 @RunWith(RobolectricTestRunner.class)
 public class VenmoSharedPrefsWriterUnitTest {
 
     private Context context;
     private SharedPreferences sharedPrefs;
+    private BraintreeSharedPreferences braintreeSharedPreferences;
 
     @Before
-    public void beforeEach() {
+    public void beforeEach() throws GeneralSecurityException, IOException {
         context = ApplicationProvider.getApplicationContext();
-        sharedPrefs = context.getSharedPreferences("BraintreeApi", Context.MODE_PRIVATE);
+        sharedPrefs = SharedPreferencesHelper.getSharedPreferences(context);
+        braintreeSharedPreferences = mock(BraintreeSharedPreferences.class);
+        when(braintreeSharedPreferences.getSharedPreferences(context)).thenReturn(sharedPrefs);
         sharedPrefs.edit()
             .putBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", false)
             .apply();
@@ -30,7 +38,7 @@ public class VenmoSharedPrefsWriterUnitTest {
     @Test
     public void persistVenmoVaultOption_persistsVaultOption() {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
-        sut.persistVenmoVaultOption(context, true);
+        sut.persistVenmoVaultOption(context, braintreeSharedPreferences, true);
         assertTrue(
             sharedPrefs.getBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", false)
         );
@@ -39,7 +47,7 @@ public class VenmoSharedPrefsWriterUnitTest {
     @Test
     public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
-        sut.persistVenmoVaultOption(context, true);
-        assertTrue(sut.getVenmoVaultOption(context));
+        sut.persistVenmoVaultOption(context, braintreeSharedPreferences, true);
+        assertTrue(sut.getVenmoVaultOption(context, braintreeSharedPreferences));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Update `BraintreeSharedPreferences` to use `EncryptedSharedPreferences` (fixes #440)
 - Make `BraintreeSharedPreferences` non-static and update methods that use `BraintreeSharedPreferences` to be able to inject an instance of `BraintreeSharedPreferences`. This was necessary for testing - there is an issue where [Robolectric throws an error that it is unable to find AndroidKeyStore](https://github.com/robolectric/robolectric/issues/1518), so Robolectric can't be used in tests that do not mock out EncryptedSharedPreferences. I tried using PowerMock to mock `BraintreeSharedPreferences`, but PowerMock and Robolectric were not working well together and causing other errors. Making the class non-static and injecting it allowed me to use Mockito to mock the class with Robolectric. 

**Note**: I didn't modify the Demo app SharedPreferences.
 
 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
