### PR TITLE
Update Browser Switch and Work Manager

### DIFF
--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -46,9 +46,9 @@ def playServicesWallet = "com.google.android.gms:play-services-wallet:${rootProj
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.work:work-runtime:2.7.0-alpha05'
+    implementation 'androidx.work:work-runtime:2.7.0'
 
-    api 'com.braintreepayments.api:browser-switch:2.1.0'
+    api 'com.braintreepayments.api:browser-switch:2.1.1'
     api project(':SharedUtils')
 
     androidTestImplementation playServicesWallet
@@ -56,12 +56,12 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.work:work-testing:2.5.0'
+    androidTestImplementation 'androidx.work:work-testing:2.7.0'
     androidTestImplementation project(':Card')
     androidTestImplementation project(':PayPal')
     androidTestImplementation project(':TestUtils')
 
-    testImplementation 'androidx.work:work-testing:2.5.0'
+    testImplementation 'androidx.work:work-testing:2.7.0'
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* BraintreeCore
+  * Bump `work-runtime` version to `2.7.0`
+  * Bump `browser-switch` version to `2.1.1`
+
 ## 4.7.0
 
 * SharedPreferences


### PR DESCRIPTION

### Summary of changes

  * Bump `work-runtime` version to `2.7.0`
  * Bump `browser-switch` version to `2.1.1`

 ### Checklist

 - [x] Added a changelog entry
