### PR TITLE
Update Migration Guide with Conflicting Intent Scenario 

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -83,6 +83,8 @@ public class BraintreeClient {
      * Create a new instance of {@link BraintreeClient} using a tokenization key or client token and a custom url scheme.
      *
      * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
+     * This can be helpful for integrations using Drop-in and BraintreeClient to avoid deep linking collisions, since
+     * Drop-in uses the same custom url scheme as the default BraintreeClient constructor.
      *
      * @param context         Android Context
      * @param authorization   The tokenization key or client token to use. If an invalid authorization is provided, a {@link BraintreeException} will be returned via callback.

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -51,7 +51,7 @@ In the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integrati
 </activity>
 ``` 
 
-Additionally, apps that use both DropIn and BraintreeClient should specify a custom url scheme, since `DropInActivity` already uses the `${applicationId}.braintree` url intent filter.
+Additionally, apps that use both Drop-in and BraintreeClient should specify a custom url scheme, since `DropInActivity` already uses the `${applicationId}.braintree` url intent filter.
 
 
 ## BraintreeFragment

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -36,6 +36,8 @@ In v3, `com.braintreepayments.api.BraintreeBrowserSwitchActivity` was the design
 
 In the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integration into an activity you own:
 
+> Note: `android:exported` is required if your app compile SDK version is API 31 (Android 12) or later.
+
 ```xml
 <activity android:name="com.company.app.MyPaymentsActivity"
     android:exported="true">
@@ -49,7 +51,8 @@ In the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integrati
 </activity>
 ``` 
 
-Note: `android:exported` is required if your app compile SDK version is API 31 (Android 12) or later.
+Additionally, apps that use both DropIn and BraintreeClient should specify a custom url scheme, since `DropInActivity` already uses the `${applicationId}.braintree` url intent filter.
+
 
 ## BraintreeFragment
 


### PR DESCRIPTION
### Summary of changes

 - Mention conflicting intent scenario in v4_MIGRATION_GUIDE (Addresses [braintree-android-drop-in #296](https://github.com/braintree/braintree-android-drop-in/issues/296))

 ### Checklist

 ~- [ ] Added a changelog entry~