### PR TITLE
Update Google Pay SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* GooglePay
+  * Bump `play-services-wallet` version to `18.1.3`
 * BraintreeCore
   * Bump `work-runtime` version to `2.7.0`
   * Bump `browser-switch` version to `2.1.1`

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    api 'com.google.android.gms:play-services-wallet:16.0.1'
+    api 'com.google.android.gms:play-services-wallet:18.1.3'
 
     api project(':BraintreeCore')
     api project(':PayPal')

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    api 'com.google.android.gms:play-services-wallet:18.1.3'
+    api "com.google.android.gms:play-services-wallet:${rootProject.playServicesWalletVersion}"
 
     api project(':BraintreeCore')
     api project(':PayPal')
@@ -44,7 +44,7 @@ dependencies {
     testImplementation project(':TestUtils')
     testImplementation 'androidx.test:rules:1.4.0'
     testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    testImplementation "com.google.android.gms:play-services-wallet:${rootProject.playServicesWalletVersion}"
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayInternalClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayInternalClient.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.common.api.ApiException;
@@ -13,11 +14,19 @@ import com.google.android.gms.wallet.WalletConstants;
 
 class GooglePayInternalClient {
 
+    private final PaymentsClientWrapper paymentsClientWrapper;
+
+    GooglePayInternalClient() {
+        this(new PaymentsClientWrapper());
+    }
+
+    @VisibleForTesting
+    GooglePayInternalClient(PaymentsClientWrapper paymentsClientWrapper) {
+        this.paymentsClientWrapper = paymentsClientWrapper;
+    }
+
     void isReadyToPay(FragmentActivity activity, Configuration configuration, IsReadyToPayRequest isReadyToPayRequest, final GooglePayIsReadyToPayCallback callback) {
-        PaymentsClient paymentsClient = Wallet.getPaymentsClient(activity,
-                new Wallet.WalletOptions.Builder()
-                        .setEnvironment(getGooglePayEnvironment(configuration))
-                        .build());
+        PaymentsClient paymentsClient = paymentsClientWrapper.getPaymentsClient(activity, configuration);
         paymentsClient.isReadyToPay(isReadyToPayRequest).addOnCompleteListener(new OnCompleteListener<Boolean>() {
             @Override
             public void onComplete(@NonNull Task<Boolean> task) {
@@ -28,13 +37,5 @@ class GooglePayInternalClient {
                 }
             }
         });
-    }
-
-    int getGooglePayEnvironment(Configuration configuration) {
-        if ("production".equals(configuration.getGooglePayEnvironment())) {
-            return WalletConstants.ENVIRONMENT_PRODUCTION;
-        } else {
-            return WalletConstants.ENVIRONMENT_TEST;
-        }
     }
 }

--- a/GooglePay/src/main/java/com/braintreepayments/api/PaymentsClientWrapper.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/PaymentsClientWrapper.java
@@ -10,11 +10,7 @@ class PaymentsClientWrapper {
     private final WalletOptionsWrapper walletOptionsWrapper;
 
     PaymentsClientWrapper() {
-        this(new WalletOptionsWrapper());
-    }
-
-    PaymentsClientWrapper(WalletOptionsWrapper walletOptionsWrapper) {
-        this.walletOptionsWrapper = walletOptionsWrapper;
+        this.walletOptionsWrapper = new WalletOptionsWrapper();
     }
 
     PaymentsClient getPaymentsClient(FragmentActivity activity, Configuration configuration) {

--- a/GooglePay/src/main/java/com/braintreepayments/api/PaymentsClientWrapper.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/PaymentsClientWrapper.java
@@ -1,0 +1,23 @@
+package com.braintreepayments.api;
+
+import androidx.fragment.app.FragmentActivity;
+
+import com.google.android.gms.wallet.PaymentsClient;
+import com.google.android.gms.wallet.Wallet;
+
+class PaymentsClientWrapper {
+
+    private final WalletOptionsWrapper walletOptionsWrapper;
+
+    PaymentsClientWrapper() {
+        this(new WalletOptionsWrapper());
+    }
+
+    PaymentsClientWrapper(WalletOptionsWrapper walletOptionsWrapper) {
+        this.walletOptionsWrapper = walletOptionsWrapper;
+    }
+
+    PaymentsClient getPaymentsClient(FragmentActivity activity, Configuration configuration) {
+        return Wallet.getPaymentsClient(activity, walletOptionsWrapper.buildWalletOptions(configuration));
+    }
+}

--- a/GooglePay/src/main/java/com/braintreepayments/api/WalletOptionsWrapper.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/WalletOptionsWrapper.java
@@ -1,0 +1,21 @@
+package com.braintreepayments.api;
+
+import com.google.android.gms.wallet.Wallet;
+import com.google.android.gms.wallet.WalletConstants;
+
+class WalletOptionsWrapper {
+
+    Wallet.WalletOptions buildWalletOptions(Configuration configuration) {
+        return new Wallet.WalletOptions.Builder()
+                .setEnvironment(getGooglePayEnvironment(configuration))
+                .build();
+    }
+
+   private int getGooglePayEnvironment(Configuration configuration) {
+        if ("production".equals(configuration.getGooglePayEnvironment())) {
+            return WalletConstants.ENVIRONMENT_PRODUCTION;
+        } else {
+            return WalletConstants.ENVIRONMENT_TEST;
+        }
+    }
+}

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCapabilitiesUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCapabilitiesUnitTest.java
@@ -6,9 +6,7 @@ import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.wallet.Wallet;
 
-import org.json.JSONException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(RobolectricTestRunner.class)
-@PrepareForTest({GoogleApiAvailability.class, Wallet.class})
+@PrepareForTest({GoogleApiAvailability.class})
 @PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "androidx.*"})
 public class GooglePayCapabilitiesUnitTest {
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.java
@@ -1,6 +1,12 @@
 package com.braintreepayments.api;
 
-import android.app.Activity;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import androidx.fragment.app.FragmentActivity;
 
@@ -9,107 +15,39 @@ import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.Tasks;
 import com.google.android.gms.wallet.IsReadyToPayRequest;
 import com.google.android.gms.wallet.PaymentsClient;
-import com.google.android.gms.wallet.Wallet;
-import com.google.android.gms.wallet.WalletConstants;
 
 import org.json.JSONException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
-
 @RunWith(RobolectricTestRunner.class)
-@PrepareForTest({Wallet.class})
-@PowerMockIgnore({"org.powermock.*", "org.mockito.*", "org.robolectric.*", "android.*", "androidx.*"})
 public class GooglePayInternalClientUnitTest {
 
-    @Rule
-    public PowerMockRule powerMockRule = new PowerMockRule();
-
     private FragmentActivity activity;
-
+    private PaymentsClientWrapper paymentsClientWrapper;
     private PaymentsClient paymentsClient;
     private IsReadyToPayRequest isReadyToPayRequest;
-    private GooglePayIsReadyToPayCallback isReadyToPayCallback;
 
     @Before
     public void beforeEach() {
-        mockStatic(Wallet.class);
-
         activity = mock(FragmentActivity.class);
-        isReadyToPayCallback = mock(GooglePayIsReadyToPayCallback.class);
-
+        paymentsClientWrapper = mock(PaymentsClientWrapper.class);
         paymentsClient = mock(PaymentsClient.class);
         isReadyToPayRequest = IsReadyToPayRequest.fromJson("{}");
     }
 
     @Test
-    public void isReadyToPay_whenConfigurationEnvironmentIsSandbox_requestsSandboxWalletEnvironment() throws JSONException {
-        when(Wallet.getPaymentsClient(any(Activity.class), any(Wallet.WalletOptions.class))).thenReturn(paymentsClient);
-        when(paymentsClient.isReadyToPay(same(isReadyToPayRequest))).thenReturn(Tasks.forResult(true));
-
-        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
-
-        GooglePayInternalClient sut = new GooglePayInternalClient();
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest, isReadyToPayCallback);
-
-        verifyStatic(Wallet.class);
-
-        ArgumentCaptor<Wallet.WalletOptions> captor = ArgumentCaptor.forClass(Wallet.WalletOptions.class);
-        Wallet.getPaymentsClient(same(activity), captor.capture());
-
-        Wallet.WalletOptions walletOptions = captor.getValue();
-        assertEquals(WalletConstants.ENVIRONMENT_TEST, walletOptions.environment);
-    }
-
-    @Test
-    public void isReadyToPay_whenConfigurationEnvironmentIsProduction_requestsProductionWalletEnvironment() throws JSONException {
-        when(Wallet.getPaymentsClient(any(Activity.class), any(Wallet.WalletOptions.class))).thenReturn(paymentsClient);
-        when(paymentsClient.isReadyToPay(same(isReadyToPayRequest))).thenReturn(Tasks.forResult(true));
-
-        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY_PRODUCTION);
-
-        GooglePayInternalClient sut = new GooglePayInternalClient();
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest, isReadyToPayCallback);
-
-        verifyStatic(Wallet.class);
-
-        ArgumentCaptor<Wallet.WalletOptions> captor = ArgumentCaptor.forClass(Wallet.WalletOptions.class);
-        Wallet.getPaymentsClient(same(activity), captor.capture());
-
-        Wallet.WalletOptions walletOptions = captor.getValue();
-        assertEquals(WalletConstants.ENVIRONMENT_PRODUCTION, walletOptions.environment);
-    }
-
-    @Test
     public void isReadyToPay_onSuccess_forwardsResultToCallback() throws InterruptedException, JSONException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        when(Wallet.getPaymentsClient(same(activity), any(Wallet.WalletOptions.class))).thenReturn(paymentsClient);
-
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
+        when(paymentsClientWrapper.getPaymentsClient(same(activity), same(configuration))).thenReturn(paymentsClient);
         when(paymentsClient.isReadyToPay(same(isReadyToPayRequest))).thenReturn(Tasks.forResult(true));
 
-        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
-
-        GooglePayInternalClient sut = new GooglePayInternalClient();
+        GooglePayInternalClient sut = new GooglePayInternalClient(paymentsClientWrapper);
         sut.isReadyToPay(activity, configuration, isReadyToPayRequest, new GooglePayIsReadyToPayCallback() {
             @Override
             public void onResult(boolean isReadyToPay, Exception error) {
@@ -124,14 +62,13 @@ public class GooglePayInternalClientUnitTest {
     @Test
     public void isReadyToPay_onFailure_forwardsResultToCallback() throws InterruptedException, JSONException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        when(Wallet.getPaymentsClient(any(Activity.class), any(Wallet.WalletOptions.class))).thenReturn(paymentsClient);
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
+        when(paymentsClientWrapper.getPaymentsClient(same(activity), same(configuration))).thenReturn(paymentsClient);
 
         final ApiException error = new ApiException(Status.RESULT_INTERNAL_ERROR);
         when(paymentsClient.isReadyToPay(same(isReadyToPayRequest))).thenReturn(Tasks.<Boolean>forException(error));
 
-        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
-
-        GooglePayInternalClient sut = new GooglePayInternalClient();
+        GooglePayInternalClient sut = new GooglePayInternalClient(paymentsClientWrapper);
         sut.isReadyToPay(activity, configuration, isReadyToPayRequest, new GooglePayIsReadyToPayCallback() {
             @Override
             public void onResult(boolean isReadyToPay, Exception e) {

--- a/GooglePay/src/test/java/com/braintreepayments/api/WalletOptionsWrapperUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/WalletOptionsWrapperUnitTest.java
@@ -1,0 +1,32 @@
+package com.braintreepayments.api;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.android.gms.wallet.Wallet;
+import com.google.android.gms.wallet.WalletConstants;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+public class WalletOptionsWrapperUnitTest {
+
+    @Test
+    public void buildWalletOptions_whenConfigurationEnvironmentIsSandbox_returnsWalletOptionsWithEnvironmentTest() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY);
+        WalletOptionsWrapper sut = new WalletOptionsWrapper();
+
+        Wallet.WalletOptions walletOptions = sut.buildWalletOptions(configuration);
+
+        assertEquals(WalletConstants.ENVIRONMENT_TEST, walletOptions.environment);
+    }
+
+    @Test
+    public void buildWalletOptions_whenConfigurationEnvironmentIsProduction_returnsWalletOptionsWithEnvironmentProduction() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY_PRODUCTION);
+        WalletOptionsWrapper sut = new WalletOptionsWrapper();
+
+        Wallet.WalletOptions walletOptions = sut.buildWalletOptions(configuration);
+
+        assertEquals(WalletConstants.ENVIRONMENT_PRODUCTION, walletOptions.environment);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     versionCode = 138
     versionName = version
 
-    playServicesWalletVersion ='18.1.3'
+    playServicesWalletVersion = '18.1.3'
 }
 
 nexusStaging {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     versionCode = 138
     versionName = version
 
-    playServicesWalletVersion ='16.0.1'
+    playServicesWalletVersion ='18.1.3'
 }
 
 nexusStaging {


### PR DESCRIPTION
### Summary of changes

 - Update `play-services-wallet` dependency to `18.1.3` (fixes: #446)
 - Updating to this version of the play services wallet SDK causes issues with our unit tests because the Google `Wallet` class becomes a static final class (difficult for mocking), and breaks our tests that use Powermock (to mock static classes), and Robolectric (for the Android system classes - like Activity). The google pay integration requires both Activity and Wallet, so I added wrapper classes to separate out as much of the testable logic into their own classes to allow us to maintain test coverage while upgrading this library. 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
