### PR TITLE
Make Google Pay Merchant ID Explicitly Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+* GooglePay
+  * Deprecate `googleMerchantId`
+
 ## 4.8.0
 
 * BraintreeCore

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
     testImplementation project(':ThreeDSecure')
-    testImplementation "androidx.core:core-ktx:+"
+    testImplementation "androidx.core:core-ktx:1.6.0"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
 

--- a/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
@@ -101,7 +101,6 @@ public class GooglePayFragment extends BaseFragment {
                     googlePayRequest.setShippingAddressRequirements(ShippingAddressRequirements.newBuilder()
                             .addAllowedCountryCodes(Settings.getGooglePayAllowedCountriesForShipping(activity))
                             .build());
-                    googlePayRequest.setGoogleMerchantId(Settings.getGooglePayMerchantId(activity));
 
             googlePayClient.requestPayment(getActivity(), googlePayRequest, (requestPaymentError) -> {
                 if (requestPaymentError != null) {

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
@@ -39,6 +39,9 @@ public class GooglePayRequest implements Parcelable {
     private final HashMap<String, JSONArray> allowedAuthMethods = new HashMap<>();
     private final HashMap<String, JSONArray> allowedCardNetworks = new HashMap<>();
     private String environment;
+
+    // NEXT_MAJOR_VERSION: remove googleMerchantId since it is no longer required/included in the
+    // Google Pay API documentation
     private String googleMerchantId;
     private String googleMerchantName;
     private String countryCode;
@@ -172,6 +175,8 @@ public class GooglePayRequest implements Parcelable {
     }
 
     /**
+     * Optional.
+     *
      * @param merchantId The merchant ID that Google Pay has provided.
      */
     public void setGoogleMerchantId(@Nullable String merchantId) {
@@ -179,6 +184,8 @@ public class GooglePayRequest implements Parcelable {
     }
 
     /**
+     * Optional.
+     *
      * @param merchantName The merchant name that will be presented in Google Pay
      */
     public void setGoogleMerchantName(@Nullable String merchantName) {

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
@@ -177,8 +177,11 @@ public class GooglePayRequest implements Parcelable {
     /**
      * Optional.
      *
+     * @deprecated Google Merchant ID is no longer required and will be removed.
+     *
      * @param merchantId The merchant ID that Google Pay has provided.
      */
+    @Deprecated
     public void setGoogleMerchantId(@Nullable String merchantId) {
         googleMerchantId = merchantId;
     }
@@ -441,8 +444,11 @@ public class GooglePayRequest implements Parcelable {
     }
 
     /**
+     * @deprecated Google Merchant ID is no longer required and will be removed.
+     *
      * @return The merchant ID that Google Pay has provided.
      */
+    @Deprecated
     @Nullable
     public String getGoogleMerchantId() {
         return googleMerchantId;

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     implementation project(':BraintreeCore')
     implementation project(':ThreeDSecure')
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
-    testImplementation "androidx.core:core-ktx:+"
+    testImplementation "androidx.core:core-ktx:1.6.0"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
 


### PR DESCRIPTION
### Summary of changes

 - Update doc string to note that `googleMerchantId` is optional
 - Remove setting merchant ID from demo app

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
