### PR TITLE
Standardize Gradle Dependencies

### DIFF
--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -32,10 +32,10 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
 }

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     api project(':BraintreeCore')
 
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation deps.annotation
 
     testImplementation deps.robolectric
     testImplementation deps.powermockJunit

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 }
 

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.2.0'
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -46,7 +46,7 @@ def playServicesWallet = "com.google.android.gms:play-services-wallet:${rootProj
 
 dependencies {
     implementation deps.appCompat
-    implementation 'androidx.work:work-runtime:2.7.0-alpha05'
+    implementation deps.work
 
     implementation 'androidx.room:room-runtime:2.2.6'
     annotationProcessor 'androidx.room:room-compiler:2.2.6'
@@ -56,17 +56,17 @@ dependencies {
 
     androidTestImplementation playServicesWallet
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.work:work-testing:2.5.0'
+    androidTestImplementation deps.workTesting
     androidTestImplementation project(':Card')
     androidTestImplementation project(':PayPal')
     androidTestImplementation project(':TestUtils')
 
-    testImplementation 'androidx.work:work-testing:2.5.0'
+    testImplementation deps.workTesting
     testImplementation 'org.robolectric:robolectric:4.1'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation deps.androidxTestCore
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -42,19 +42,18 @@ android {
     }
 }
 
-def playServicesWallet = "com.google.android.gms:play-services-wallet:${rootProject.playServicesWalletVersion}"
 
 dependencies {
     implementation deps.appCompat
     implementation deps.work
 
-    implementation 'androidx.room:room-runtime:2.2.6'
-    annotationProcessor 'androidx.room:room-compiler:2.2.6'
+    implementation deps.roomRuntime
+    annotationProcessor deps.roomCompiler
 
-    api 'com.braintreepayments.api:browser-switch:2.1.1'
+    api deps.browserSwitch
     api project(':SharedUtils')
 
-    androidTestImplementation playServicesWallet
+    androidTestImplementation deps.playServicesWallet
     androidTestImplementation deps.dexmakerMockito
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -45,7 +45,7 @@ android {
 def playServicesWallet = "com.google.android.gms:play-services-wallet:${rootProject.playServicesWalletVersion}"
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
     implementation 'androidx.work:work-runtime:2.7.0-alpha05'
 
     implementation 'androidx.room:room-runtime:2.2.6'

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     androidTestImplementation deps.dexmakerMockito
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
     androidTestImplementation deps.workTesting
     androidTestImplementation project(':Card')
     androidTestImplementation project(':PayPal')
@@ -66,7 +66,7 @@ dependencies {
     testImplementation deps.workTesting
     testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
-    testImplementation deps.junit
+    testImplementation deps.junitTest
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -68,10 +68,10 @@ dependencies {
     testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
     testImplementation deps.junit
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
     testImplementation project(':PayPal')
     testImplementation project(':TestUtils')

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     androidTestImplementation project(':TestUtils')
 
     testImplementation deps.workTesting
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
     testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     api project(':SharedUtils')
 
     androidTestImplementation playServicesWallet
-    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation deps.dexmakerMockito
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
     androidTestImplementation deps.junit
@@ -72,7 +72,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':PayPal')
     testImplementation project(':TestUtils')
     testImplementation project(':UnionPay')

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
     androidTestImplementation deps.workTesting
     androidTestImplementation project(':Card')
     androidTestImplementation project(':PayPal')
@@ -67,7 +67,7 @@ dependencies {
     testImplementation deps.workTesting
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation deps.androidxTestCore
-    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
     androidTestImplementation deps.appCompat
     androidTestImplementation project(':TestUtils')
 }

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -44,10 +44,10 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation deps.androidxTestCore
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
 
     testImplementation project(':TestUtils')
 

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
     androidTestImplementation deps.appCompat
     androidTestImplementation project(':TestUtils')
 }

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation deps.robolectric
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation deps.androidxTestCore
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -37,11 +37,11 @@ dependencies {
     implementation files('libs/kount-data-collector-3.2.jar')
     implementation files('libs/android-magnessdk-5.3.0.jar')
 
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation deps.annotation
     api project(':BraintreeCore')
 
     testImplementation deps.robolectric
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation deps.mockitoCore
     testImplementation deps.androidxTestCore
     testImplementation deps.jsonAssert
     testImplementation deps.powermockJunit

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
     api project(':BraintreeCore')
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation deps.androidxTestCore
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.mockito:mockito-core:3.6.0'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation deps.androidxTestCore
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
@@ -51,8 +51,8 @@ dependencies {
 
     testImplementation project(':TestUtils')
 
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation deps.appCompat
     androidTestImplementation project(':TestUtils')

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
+    androidTestImplementation deps.appCompat
     androidTestImplementation project(':TestUtils')
 }
 

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -34,10 +34,10 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
     testImplementation project(':ThreeDSecure')

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -41,9 +41,9 @@ dependencies {
     testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
     testImplementation project(':ThreeDSecure')
-    testImplementation "androidx.core:core-ktx:1.6.0"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
+    testImplementation deps.coreKtx
+    testImplementation deps.kotlinStdLib
+    testImplementation deps.kotlinTest
 
     androidTestImplementation project(':TestUtils')
     androidTestImplementation deps.androidxTestRules

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
     testImplementation project(':ThreeDSecure')
     testImplementation "androidx.core:core-ktx:1.6.0"

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     androidTestImplementation project(':TestUtils')
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
 }
 
 // region signing and publishing

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
 
     androidTestImplementation project(':TestUtils')
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 }
 

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     androidTestImplementation project(':TestUtils')
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
 }
 
 // region signing and publishing

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api project(':BraintreeCore')
     implementation project(':BraintreeDataCollector')
 
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation deps.annotation
 
     testImplementation deps.robolectric
     testImplementation deps.powermockJunit

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.2.0'
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/Card/src/test/java/com/braintreepayments/api/CardClientUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/CardClientUnitTest.java
@@ -36,7 +36,7 @@ public class CardClientUnitTest {
     @Before
     public void beforeEach() throws JSONException {
         context = mock(Context.class);
-        card = mock(Card.class);
+        card = new Card();
         cardTokenizeCallback = mock(CardTokenizeCallback.class);
 
         dataCollector = mock(DataCollector.class);
@@ -75,7 +75,6 @@ public class CardClientUnitTest {
 
         CardClient sut = new CardClient(braintreeClient, apiClient);
 
-        Card card = new Card();
         sut.tokenize(card, cardTokenizeCallback);
 
         ArgumentCaptor<CardNonce> captor = ArgumentCaptor.forClass(CardNonce.class);
@@ -97,7 +96,6 @@ public class CardClientUnitTest {
 
         CardClient sut = new CardClient(braintreeClient, apiClient);
 
-        Card card = new Card();
         sut.tokenize(card, cardTokenizeCallback);
 
         ArgumentCaptor<CardNonce> captor = ArgumentCaptor.forClass(CardNonce.class);

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.8.1'
     implementation 'com.google.code.gson:gson:2.8.1'
     implementation 'de.greenrobot:eventbus:2.4.1'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation "androidx.core:core-ktx:1.3.2"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation deps.kotlinStdLib
 }
 
 // region signing and publishing

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
     api 'com.google.android.gms:play-services-wallet:16.0.1'
 
     api project(':BraintreeCore')

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation deps.appCompat
-    api 'com.google.android.gms:play-services-wallet:16.0.1'
+    api deps.playServicesWallet
 
     api project(':BraintreeCore')
     api project(':PayPal')
@@ -44,7 +44,7 @@ dependencies {
     testImplementation project(':TestUtils')
     testImplementation deps.androidxTestRules
     testImplementation deps.androidxTestRunner
-    testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    testImplementation deps.playServicesWallet
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     testImplementation deps.powermockClassloading
     testImplementation deps.robolectric
     testImplementation deps.jsonAssert
-    testImplementation "androidx.core:core-ktx:1.3.2"
+    testImplementation deps.coreKtx
     testImplementation deps.kotlinStdLib
 }
 

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
     testImplementation deps.robolectric
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation "androidx.core:core-ktx:1.3.2"
     testImplementation deps.kotlinStdLib
 }

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -46,10 +46,10 @@ dependencies {
     testImplementation deps.androidxTestRunner
     testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation deps.robolectric
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation "androidx.core:core-ktx:1.3.2"

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -42,15 +42,15 @@ dependencies {
     api project(':Card')
 
     testImplementation project(':TestUtils')
-    testImplementation 'androidx.test:rules:1.4.0'
-    testImplementation 'androidx.test:runner:1.4.0'
+    testImplementation deps.androidxTestRules
+    testImplementation deps.androidxTestRunner
     testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation deps.robolectric
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation "androidx.core:core-ktx:1.3.2"
     testImplementation deps.kotlinStdLib

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation deps.androidxTestRules
     testImplementation deps.androidxTestRunner
     testImplementation deps.playServicesWallet
-    testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
+    testImplementation deps.assertJ
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
 
     api project(':BraintreeCore')
     implementation project(':BraintreeDataCollector')

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     implementation project(':BraintreeDataCollector')
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
     testImplementation project(':TestUtils')
 

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     api project(':BraintreeCore')
     implementation project(':BraintreeDataCollector')
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 
     androidTestImplementation project(':TestUtils')

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     testImplementation project(':TestUtils')
 
     androidTestImplementation project(':TestUtils')
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 }
 

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     androidTestImplementation project(':TestUtils')
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
 }
 
 // region signing and publishing

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     androidTestImplementation project(':TestUtils')
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
 }
 
 // region signing and publishing

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 }
 

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation deps.appCompat
     implementation project(':BraintreeDataCollector')
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     api project(':BraintreeCore')
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
     implementation project(':BraintreeDataCollector')
 
     testImplementation 'org.robolectric:robolectric:4.1'

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     implementation project(':BraintreeDataCollector')
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
 }

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api 'com.samsung.android.spay:sdk:2.5.01'
 
     testImplementation 'org.robolectric:robolectric:4.1'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     api 'com.samsung.android.spay:sdk:2.5.01'
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     api project(':BraintreeCore')
     api project(':Card')
 
-    api 'com.samsung.android.spay:sdk:2.5.01'
+    api deps.samsungPay
 
     testImplementation deps.robolectric
     testImplementation deps.junitTest

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 }
 

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api 'com.samsung.android.spay:sdk:2.5.01'
 
     testImplementation deps.robolectric
-    testImplementation deps.junit
+    testImplementation deps.junitTest
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -40,10 +40,10 @@ dependencies {
 
     testImplementation deps.robolectric
     testImplementation deps.junit
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
 }

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -39,10 +39,10 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation deps.robolectric
 
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
 
     androidTestImplementation deps.androidxTestRunner
     androidTestImplementation deps.junit

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
 
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
     androidTestImplementation deps.appCompat
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
 }

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 
     testImplementation 'junit:junit:4.13'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation deps.androidxTestCore
     testImplementation deps.mockitoCore
     testImplementation deps.robolectric
 
@@ -45,7 +45,7 @@ dependencies {
     testImplementation deps.powermockClassloading
 
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
     androidTestImplementation deps.appCompat
     androidTestImplementation deps.dexmakerMockito
 }

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
 
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -32,9 +32,9 @@ android {
 
 dependencies {
     implementation deps.annotation
-    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
+    implementation deps.securityCrypto
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation deps.junit
     testImplementation deps.androidxTestCore
     testImplementation deps.mockitoCore
     testImplementation deps.robolectric

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -31,12 +31,12 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation deps.annotation
     implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
+    testImplementation deps.mockitoCore
     testImplementation deps.robolectric
 
     testImplementation deps.powermockJunit

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
 
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation deps.appCompat
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     androidTestImplementation deps.androidxTestRunner
     androidTestImplementation deps.junit
     androidTestImplementation deps.appCompat
-    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation deps.dexmakerMockito
 }
 
 // region signing and publishing

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
+    androidTestImplementation deps.appCompat
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
 }
 

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -24,11 +24,11 @@ android {
 }
 
 dependencies {
-    api 'androidx.test:runner:1.4.0'
-    api 'androidx.test:rules:1.4.0'
+    api deps.androidxTestRunner
+    api deps.androidxTestRunner
     api deps.appCompat
 
-    implementation deps.junit
+    implementation deps.junitTest
 
     compileOnly deps.robolectric
     compileOnly deps.powermockJunit

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -39,8 +39,8 @@ dependencies {
 
     implementation project(':BraintreeCore')
     implementation project(':ThreeDSecure')
-    implementation "androidx.core:core-ktx:1.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.core:core-ktx:+"
+    implementation deps.kotlinStdLib
 }
 repositories {
     mavenCentral()

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     implementation project(':BraintreeCore')
     implementation project(':ThreeDSecure')
-    implementation "androidx.core:core-ktx:+"
+    implementation deps.coreKtx
     implementation deps.kotlinStdLib
 }
 repositories {

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     api 'androidx.test:runner:1.4.0'
     api 'androidx.test:rules:1.4.0'
-    api 'androidx.appcompat:appcompat:1.3.1'
+    api deps.appCompat
 
     implementation 'androidx.test.ext:junit:1.1.3'
 

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     implementation deps.junit
 
-    compileOnly 'org.robolectric:robolectric:4.1'
+    compileOnly deps.robolectric
     compileOnly 'org.powermock:powermock-module-junit4:1.6.6'
     compileOnly 'org.powermock:powermock-module-junit4-rule:1.6.6'
     compileOnly 'org.powermock:powermock-api-mockito:1.6.6'

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     api deps.androidxTestRunner
-    api deps.androidxTestRunner
+    api deps.androidxTestRules
     api deps.appCompat
 
     implementation deps.junitTest

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly deps.powermockRule
     compileOnly deps.powermockMockito
     compileOnly deps.powermockClassloading
-    compileOnly 'org.skyscreamer:jsonassert:1.4.0'
+    compileOnly deps.jsonAssert
 
     implementation project(':BraintreeCore')
     implementation project(':ThreeDSecure')

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     implementation deps.junit
 
     compileOnly deps.robolectric
-    compileOnly 'org.powermock:powermock-module-junit4:1.6.6'
-    compileOnly 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    compileOnly 'org.powermock:powermock-api-mockito:1.6.6'
-    compileOnly 'org.powermock:powermock-classloading-xstream:1.6.6'
+    compileOnly deps.powermockJunit
+    compileOnly deps.powermockRule
+    compileOnly deps.powermockMockito
+    compileOnly deps.powermockClassloading
     compileOnly 'org.skyscreamer:jsonassert:1.4.0'
 
     implementation project(':BraintreeCore')

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api 'androidx.test:rules:1.4.0'
     api deps.appCompat
 
-    implementation 'androidx.test.ext:junit:1.1.3'
+    implementation deps.junit
 
     compileOnly 'org.robolectric:robolectric:4.1'
     compileOnly 'org.powermock:powermock-module-junit4:1.6.6'

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -31,14 +31,14 @@ android {
 dependencies {
     api project(':BraintreeCore')
     api project(':Card')
-    implementation 'org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4'
+    implementation deps.cardinal
 
     implementation deps.appCompat
 
     androidTestImplementation deps.dexmakerMockito
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
     androidTestImplementation project(':TestUtils')
 
     testImplementation deps.robolectric

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
     androidTestImplementation project(':TestUtils')
 
     testImplementation 'org.robolectric:robolectric:4.1'

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -42,10 +42,10 @@ dependencies {
     androidTestImplementation project(':TestUtils')
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunitLegacy
+    testImplementation deps.powermockRuleLegacy
+    testImplementation deps.powermockMockitoLegacy
+    testImplementation deps.powermockClassloadingLegacy
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
 }

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     implementation deps.appCompat
 
-    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation deps.dexmakerMockito
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
     androidTestImplementation deps.junit
@@ -46,7 +46,7 @@ dependencies {
     testImplementation deps.powermockRuleLegacy
     testImplementation deps.powermockMockitoLegacy
     testImplementation deps.powermockClassloadingLegacy
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 }
 

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation deps.appCompat
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation project(':TestUtils')
 

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     androidTestImplementation deps.junit
     androidTestImplementation project(':TestUtils')
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':Card')
     implementation 'org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4'
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestImplementation 'androidx.test:rules:1.4.0'

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.robolectric.RobolectricTestRunner;
 
 import static com.braintreepayments.api.BraintreeRequestCodes.THREE_D_SECURE;
@@ -23,10 +22,9 @@ import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "org.json.*", "javax.crypto.*"})
 public class ThreeDSecureV1UnitTest {
 
     private FragmentActivity activity;

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     testImplementation deps.powermockClassloading
     testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
-    testImplementation "androidx.core:core-ktx:1.6.0"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
+    testImplementation deps.coreKtx
+    testImplementation deps.kotlinStdLib
+    testImplementation deps.kotlinTest
 
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.2.0'
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation deps.junit
     androidTestImplementation project(':TestUtils')
 }
 

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
     testImplementation "androidx.core:core-ktx:1.6.0"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
     testImplementation "androidx.core:core-ktx:1.6.0"

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.5.10"
 
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation deps.androidxTestRules
+    androidTestImplementation deps.androidxTestRunner
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation project(':TestUtils')
 }

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     api project(':BraintreeCore')
     api project(':Card')
 
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation deps.annotation
 
     testImplementation deps.robolectric
     testImplementation deps.powermockJunit

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.junit
+    androidTestImplementation deps.junitTest
     androidTestImplementation project(':TestUtils')
 }
 

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
     testImplementation deps.junit
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockRule
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockClassloading
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation project(':TestUtils')
 }

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     implementation deps.appCompat
 
     testImplementation 'org.robolectric:robolectric:4.1'
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation deps.androidxTestCore
+    testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation project(':TestUtils')
 }
 

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
-    testImplementation deps.junit
+    testImplementation deps.junitTest
     testImplementation deps.powermockJunit
     testImplementation deps.powermockRule
     testImplementation deps.powermockMockito

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     implementation deps.appCompat
 
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation deps.androidxTestCore
     testImplementation deps.junit
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     api project(':BraintreeCore')
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
 
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation deps.appCompat
 
     testImplementation project(':TestUtils')
-    testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    testImplementation deps.playServicesWallet
     testImplementation deps.androidxTestCore
     testImplementation deps.androidxTestRules
     testImplementation deps.androidxTestRunner

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     testImplementation deps.powermockRuleLegacy
     testImplementation deps.powermockMockitoLegacy
     testImplementation deps.powermockClassloadingLegacy
-    testImplementation 'org.skyscreamer:jsonassert:1.4.0'
+    testImplementation deps.jsonAssert
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
 }
 

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation deps.androidxTestCore
     testImplementation deps.androidxTestRules
     testImplementation deps.androidxTestRunner
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation deps.robolectric
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation deps.powermockMockitoLegacy
     testImplementation deps.powermockClassloadingLegacy
     testImplementation deps.jsonAssert
-    testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
+    testImplementation deps.assertJ
 }
 
 /* maven deploy + signing */

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -43,10 +43,10 @@ dependencies {
     testImplementation deps.androidxTestRules
     testImplementation deps.androidxTestRunner
     testImplementation deps.robolectric
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation deps.powermockJunitLegacy
+    testImplementation deps.powermockRuleLegacy
+    testImplementation deps.powermockMockitoLegacy
+    testImplementation deps.powermockClassloadingLegacy
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
 }

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -39,9 +39,9 @@ dependencies {
 
     testImplementation project(':TestUtils')
     testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'androidx.test:rules:1.4.0'
+    testImplementation deps.androidxTestCore
+    testImplementation deps.androidxTestRules
+    testImplementation deps.androidxTestRunner
     testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api project(':Card')
     api(group: 'com.visa.checkout', name: 'visacheckout-android-sdk', version: '6.6.1', ext: 'aar')
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation deps.appCompat
 
     testImplementation project(':TestUtils')
     testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
             "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
             "androidxTestCore": "androidx.test:core:${versions.androidxTest}",
 
-            "junit": "androidx.test.ext:junit:1.1.3",
+            "junitTest": "androidx.test.ext:junit:1.1.3",
             "robolectric": "org.robolectric:robolectric:4.1",
 
             "powermockJunit": "org.powermock:powermock-module-junit4:${versions.powermock}",
@@ -51,8 +51,10 @@ buildscript {
             "mockitoCore": "org.mockito:mockito-core:3.6.0",
 
             "jsonAssert": "org.skyscreamer:jsonassert:1.5.0",
+            "assertJ": "com.squareup.assertj:assertj-android:1.1.1",
 
             "browserSwitch": "com.braintreepayments.api:browser-switch:2.1.1",
+            "cardinal": "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4",
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ buildscript {
             "powermockRule"              : "org.powermock:powermock-module-junit4-rule:${versions.powermock}",
             "powermockMockito"           : "org.powermock:powermock-api-mockito2:${versions.powermock}",
             "powermockClassloading"      : "org.powermock:powermock-classloading-xstream:${versions.powermock}",
+
+            // Legacy versions of the powermock libraries are required until 3DS and Visa Checkout tests can be updated to resolve robolectric/powermock test issues
             "powermockJunitLegacy"       : "org.powermock:powermock-module-junit4:${versions.powermockLegacy}",
             "powermockRuleLegacy"        : "org.powermock:powermock-module-junit4-rule:${versions.powermockLegacy}",
             "powermockMockitoLegacy"     : "org.powermock:powermock-api-mockito:${versions.powermockLegacy}",

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ buildscript {
 
             "androidxTestRules": "androidx.test:rules:${versions.androidxTest}",
             "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
-            "androidxTestCore": "androidx.test:core:${versions.androidxTest}"
+            "androidxTestCore": "androidx.test:core:${versions.androidxTest}",
+            "junit": "androidx.test.ext:junit:1.1.3"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,11 @@ buildscript {
         }
     }
     ext.versions = [
-        "kotlin": "1.4.10",
+            "kotlin": "1.4.10",
     ]
     ext.deps = [
-        "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+            "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
+            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -45,7 +46,7 @@ ext {
     versionCode = 139
     versionName = version
 
-    playServicesWalletVersion ='16.0.1'
+    playServicesWalletVersion = '16.0.1'
 }
 
 nexusStaging {

--- a/build.gradle
+++ b/build.gradle
@@ -10,14 +10,22 @@ buildscript {
             "kotlin": "1.4.10",
             "androidxTest": "1.4.0",
             "powermock": "2.0.7",
-            "powermockLegacy": "1.6.6"
+            "powermockLegacy": "1.6.6",
+            "room": "2.2.6",
+            "playServices": "16.0.1"
     ]
     ext.deps = [
             "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
+            "annotation": "androidx.annotation:annotation:1.2.0",
             "kotlinStdLib": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+
+            "playServicesWallet": "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
             "work" : "androidx.work:work-runtime:2.7.0-alpha05",
             "workTesting" : "androidx.work:work-testing:2.5.0",
+
+            "roomCompiler": "androidx.room:room-compiler:${versions.room}",
+            "roomRuntime": "androidx.room:room-runtime:${versions.room}",
 
             "androidxTestRules": "androidx.test:rules:${versions.androidxTest}",
             "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
@@ -37,8 +45,11 @@ buildscript {
             "powermockClassloadingLegacy" : "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}",
 
             "dexmakerMockito": "com.google.dexmaker:dexmaker-mockito:1.2",
+            "mockitoCore": "org.mockito:mockito-core:3.6.0",
 
-            "jsonAssert": "org.skyscreamer:jsonassert:1.5.0"
+            "jsonAssert": "org.skyscreamer:jsonassert:1.5.0",
+
+            "browserSwitch": "com.braintreepayments.api:browser-switch:2.1.1",
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -72,8 +83,6 @@ ext {
     targetSdkVersion = 31
     versionCode = 139
     versionName = version
-
-    playServicesWalletVersion = '16.0.1'
 }
 
 nexusStaging {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ buildscript {
 
             "playServicesWallet": "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
+            "securityCrypto": "androidx.security:security-crypto:1.1.0-alpha03",
+
             "work" : "androidx.work:work-runtime:2.7.0-alpha05",
             "workTesting" : "androidx.work:work-testing:2.5.0",
 
@@ -34,6 +36,7 @@ buildscript {
             "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
             "androidxTestCore": "androidx.test:core:${versions.androidxTest}",
 
+            "junit": "junit:junit:4.13",
             "junitTest": "androidx.test.ext:junit:1.1.3",
             "robolectric": "org.robolectric:robolectric:4.1",
 
@@ -55,6 +58,7 @@ buildscript {
 
             "browserSwitch": "com.braintreepayments.api:browser-switch:2.1.1",
             "cardinal": "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4",
+            "samsungPay": "com.samsung.android.spay:sdk:2.5.01",
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ buildscript {
     ext.versions = [
             "kotlin": "1.4.10",
             "androidxTest": "1.4.0",
-            "powermock": "2.0.7"
+            "powermock": "2.0.7",
+            "powermockLegacy": "1.6.6"
     ]
     ext.deps = [
             "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
@@ -28,7 +29,12 @@ buildscript {
             "powermockJunit": "org.powermock:powermock-module-junit4:${versions.powermock}",
             "powermockRule": "org.powermock:powermock-module-junit4-rule:${versions.powermock}",
             "powermockMockito": "org.powermock:powermock-api-mockito2:${versions.powermock}",
-            "powermockClassloading" : "org.powermock:powermock-classloading-xstream:${versions.powermock}"
+            "powermockClassloading" : "org.powermock:powermock-classloading-xstream:${versions.powermock}",
+
+            "powermockJunitLegacy": "org.powermock:powermock-module-junit4:${versions.powermockLegacy}",
+            "powermockRuleLegacy": "org.powermock:powermock-module-junit4-rule:${versions.powermockLegacy}",
+            "powermockMockitoLegacy": "org.powermock:powermock-api-mockito:${versions.powermockLegacy}",
+            "powermockClassloadingLegacy" : "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,10 @@ buildscript {
     ext.deps = [
             "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
             "annotation": "androidx.annotation:annotation:1.2.0",
+            "coreKtx": "androidx.core:core-ktx:1.7.0",
+
             "kotlinStdLib": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+            "kotlinTest": "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
 
             "playServicesWallet": "com.google.android.gms:play-services-wallet:${versions.playServices}",
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,12 @@ buildscript {
     }
     ext.versions = [
             "kotlin": "1.4.10",
-            "androidxTest": "1.4.0"
+            "androidxTest": "1.4.0",
+            "powermock": "2.0.7"
     ]
     ext.deps = [
             "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
-            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
 
             "work" : "androidx.work:work-runtime:2.7.0-alpha05",
             "workTesting" : "androidx.work:work-testing:2.5.0",
@@ -20,13 +21,20 @@ buildscript {
             "androidxTestRules": "androidx.test:rules:${versions.androidxTest}",
             "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
             "androidxTestCore": "androidx.test:core:${versions.androidxTest}",
-            "junit": "androidx.test.ext:junit:1.1.3"
+
+            "junit": "androidx.test.ext:junit:1.1.3",
+            "robolectric": "org.robolectric:robolectric:4.1",
+
+            "powermockJunit": "org.powermock:powermock-module-junit4:${versions.powermock}",
+            "powermockRule": "org.powermock:powermock-module-junit4-rule:${versions.powermock}",
+            "powermockMockito": "org.powermock:powermock-api-mockito2:${versions.powermock}",
+            "powermockClassloading" : "org.powermock:powermock-classloading-xstream:${versions.powermock}"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
-        classpath deps.kotlinStdLib
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,60 +6,61 @@ buildscript {
             url = "https://plugins.gradle.org/m2/"
         }
     }
+
     ext.versions = [
-            "kotlin": "1.4.10",
-            "androidxTest": "1.4.0",
-            "powermock": "2.0.7",
+            "kotlin"         : "1.4.10",
+            "androidxTest"   : "1.4.0",
+            "powermock"      : "2.0.7",
             "powermockLegacy": "1.6.6",
-            "room": "2.2.6",
-            "playServices": "16.0.1"
+            "room"           : "2.2.6",
+            "playServices"   : "16.0.1"
     ]
+
     ext.deps = [
-            "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
-            "annotation": "androidx.annotation:annotation:1.2.0",
-            "coreKtx": "androidx.core:core-ktx:1.7.0",
+            "appCompat"                  : "androidx.appcompat:appcompat:1.3.1",
+            "annotation"                 : "androidx.annotation:annotation:1.2.0",
+            "coreKtx"                    : "androidx.core:core-ktx:1.7.0",
 
-            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
-            "kotlinTest": "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
+            "kotlinStdLib"               : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+            "kotlinTest"                 : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
 
-            "playServicesWallet": "com.google.android.gms:play-services-wallet:${versions.playServices}",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.1.1",
+            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4",
+            "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
+            "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
-            "securityCrypto": "androidx.security:security-crypto:1.1.0-alpha03",
+            // 1.1.0-alpha or higher is required for API 21 support
+            "securityCrypto"             : "androidx.security:security-crypto:1.1.0-alpha03",
 
-            "work" : "androidx.work:work-runtime:2.7.0-alpha05",
-            "workTesting" : "androidx.work:work-testing:2.5.0",
+            // NEXT_MAJOR_VERSION: upgrade to 2.7.1 (or latest) when Java 7 support is explicitly dropped
+            "work"                       : "androidx.work:work-runtime:2.7.0-alpha05",
+            "workTesting"                : "androidx.work:work-testing:2.5.0",
 
-            "roomCompiler": "androidx.room:room-compiler:${versions.room}",
-            "roomRuntime": "androidx.room:room-runtime:${versions.room}",
+            "roomCompiler"               : "androidx.room:room-compiler:${versions.room}",
+            "roomRuntime"                : "androidx.room:room-runtime:${versions.room}",
 
-            "androidxTestRules": "androidx.test:rules:${versions.androidxTest}",
-            "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
-            "androidxTestCore": "androidx.test:core:${versions.androidxTest}",
+            "androidxTestRules"          : "androidx.test:rules:${versions.androidxTest}",
+            "androidxTestRunner"         : "androidx.test:runner:${versions.androidxTest}",
+            "androidxTestCore"           : "androidx.test:core:${versions.androidxTest}",
 
-            "junit": "junit:junit:4.13",
-            "junitTest": "androidx.test.ext:junit:1.1.3",
-            "robolectric": "org.robolectric:robolectric:4.1",
+            "junit"                      : "junit:junit:4.13",
+            "junitTest"                  : "androidx.test.ext:junit:1.1.3",
+            "robolectric"                : "org.robolectric:robolectric:4.1",
+            "dexmakerMockito"            : "com.google.dexmaker:dexmaker-mockito:1.2",
+            "mockitoCore"                : "org.mockito:mockito-core:3.6.0",
+            "jsonAssert"                 : "org.skyscreamer:jsonassert:1.5.0",
+            "assertJ"                    : "com.squareup.assertj:assertj-android:1.1.1",
 
-            "powermockJunit": "org.powermock:powermock-module-junit4:${versions.powermock}",
-            "powermockRule": "org.powermock:powermock-module-junit4-rule:${versions.powermock}",
-            "powermockMockito": "org.powermock:powermock-api-mockito2:${versions.powermock}",
-            "powermockClassloading" : "org.powermock:powermock-classloading-xstream:${versions.powermock}",
-
-            "powermockJunitLegacy": "org.powermock:powermock-module-junit4:${versions.powermockLegacy}",
-            "powermockRuleLegacy": "org.powermock:powermock-module-junit4-rule:${versions.powermockLegacy}",
-            "powermockMockitoLegacy": "org.powermock:powermock-api-mockito:${versions.powermockLegacy}",
-            "powermockClassloadingLegacy" : "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}",
-
-            "dexmakerMockito": "com.google.dexmaker:dexmaker-mockito:1.2",
-            "mockitoCore": "org.mockito:mockito-core:3.6.0",
-
-            "jsonAssert": "org.skyscreamer:jsonassert:1.5.0",
-            "assertJ": "com.squareup.assertj:assertj-android:1.1.1",
-
-            "browserSwitch": "com.braintreepayments.api:browser-switch:2.1.1",
-            "cardinal": "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.5-4",
-            "samsungPay": "com.samsung.android.spay:sdk:2.5.01",
+            "powermockJunit"             : "org.powermock:powermock-module-junit4:${versions.powermock}",
+            "powermockRule"              : "org.powermock:powermock-module-junit4-rule:${versions.powermock}",
+            "powermockMockito"           : "org.powermock:powermock-api-mockito2:${versions.powermock}",
+            "powermockClassloading"      : "org.powermock:powermock-classloading-xstream:${versions.powermock}",
+            "powermockJunitLegacy"       : "org.powermock:powermock-module-junit4:${versions.powermockLegacy}",
+            "powermockRuleLegacy"        : "org.powermock:powermock-module-junit4-rule:${versions.powermockLegacy}",
+            "powermockMockitoLegacy"     : "org.powermock:powermock-api-mockito:${versions.powermockLegacy}",
+            "powermockClassloadingLegacy": "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}",
     ]
+
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,18 @@ buildscript {
     }
     ext.versions = [
             "kotlin": "1.4.10",
+            "androidxTest": "1.4.0"
     ]
     ext.deps = [
             "appCompat"   : "androidx.appcompat:appcompat:1.3.1",
-            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+            "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+
+            "work" : "androidx.work:work-runtime:2.7.0-alpha05",
+            "workTesting" : "androidx.work:work-testing:2.5.0",
+
+            "androidxTestRules": "androidx.test:rules:${versions.androidxTest}",
+            "androidxTestRunner": "androidx.test:runner:${versions.androidxTest}",
+            "androidxTestCore": "androidx.test:core:${versions.androidxTest}"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
     repositories {
         jcenter()
         google()
@@ -7,11 +6,17 @@ buildscript {
             url = "https://plugins.gradle.org/m2/"
         }
     }
+    ext.versions = [
+        "kotlin": "1.4.10",
+    ]
+    ext.deps = [
+        "kotlinStdLib": "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+    ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath deps.kotlinStdLib
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,11 @@ buildscript {
             "powermockJunitLegacy": "org.powermock:powermock-module-junit4:${versions.powermockLegacy}",
             "powermockRuleLegacy": "org.powermock:powermock-module-junit4-rule:${versions.powermockLegacy}",
             "powermockMockitoLegacy": "org.powermock:powermock-api-mockito:${versions.powermockLegacy}",
-            "powermockClassloadingLegacy" : "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}"
+            "powermockClassloadingLegacy" : "org.powermock:powermock-classloading-xstream:${versions.powermockLegacy}",
+
+            "dexmakerMockito": "com.google.dexmaker:dexmaker-mockito:1.2",
+
+            "jsonAssert": "org.skyscreamer:jsonassert:1.5.0"
     ]
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'


### PR DESCRIPTION
### Summary of changes

 - Move dependency libraries and versions to top-level `build.gradle` and standardize versions across modules (where possible)
 - This should make it easier to keep dependency versions the same across modules, and to make updates to versions in the future.
 - With this update, we lose the Android Studio highlighting/auto-update keyboard shortcut when a newer library is available, but this suggested dependency updates can still be found in Android Studio under `File` > `Project Structure` > `Suggestions`. 
 - Overall, the ability to keep dependency versions aligned and ensure that they are all updated together seems higher priority than the keyboard shortcut, but we will need to make it a regular practice to check for suggestions. 

**Note**: This PR organizes the dependencies into a single file, but does not update the versions (unless required for alignment). Another PR to follow will handle upgrading dependencies to the newest versions where possible. 

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
