### PR TITLE
Fix Migration Guide Typo and Add Section on Multiple Deep Link Targets

### DIFF
--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -53,6 +53,45 @@ In the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integrati
 
 Additionally, apps that use both Drop-in and BraintreeClient should specify a custom url scheme, since `DropInActivity` already uses the `${applicationId}.braintree` url intent filter.
 
+If your app has multiple browser switch targets, you can specify multiple intent filters, and use the `BraintreeClient` constructor that allows you to specify a `customUrlScheme`:
+
+```xml
+<activity android:name="com.company.app.MyPaymentsActivity1"
+    android:exported="true">
+    ...
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <data android:scheme="custom-url-scheme-1"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+    </intent-filter>
+</activity>
+
+<activity android:name="com.company.app.MyPaymentsActivity2"
+    android:exported="true">
+    ...
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <data android:scheme="custom-url-scheme-2"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+    </intent-filter>
+</activity>
+``` 
+
+Then when constructing your `BraintreeClient`, make sure to pass the appropriate custom url scheme for each deep link target Activity.
+
+```java
+// MyPaymentsActivity1.java
+BraintreeClient braintreeClient =
+        new BraintreeClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", "custom-url-scheme-1");
+```
+
+```java
+// MyPaymentsActivity2.java
+BraintreeClient braintreeClient =
+    new BraintreeClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", "custom-url-scheme-2");
+```
 
 ## BraintreeFragment
 

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -527,7 +527,7 @@ public class PayPalActivity extends AppCompatActivity {
       payPalClient.onBrowserSwitchResult(browserSwitchResult, (payPalAccountNonce, error) -> {
         if (payPalAccountNonce != null) {
           // Send nonce to server
-          String payPalAccountNonce = payPalNonce.getString();
+          String nonce = payPalAccountNonce.getString();
         } else {
           // handle error
         }

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -79,7 +79,7 @@ If your app has multiple browser switch targets, you can specify multiple intent
 </activity>
 ``` 
 
-Then when constructing your `BraintreeClient`, make sure to pass the appropriate custom url scheme for each deep link target Activity.
+Then when constructing your `BraintreeClient` make sure to pass the appropriate custom url scheme for each deep link target Activity:
 
 ```java
 // MyPaymentsActivity1.java

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -84,7 +84,7 @@ Then when constructing your `BraintreeClient` make sure to pass the appropriate 
 ```java
 // MyPaymentsActivity1.java
 BraintreeClient braintreeClient =
-        new BraintreeClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", "custom-url-scheme-1");
+    new BraintreeClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", "custom-url-scheme-1");
 ```
 
 ```java

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -488,7 +488,7 @@ public class PayPalActivity extends AppCompatActivity {
       payPalClient.onBrowserSwitchResult(browserSwitchResult, (payPalAccountNonce, error) -> {
         if (payPalAccountNonce != null) {
           // Send nonce to server
-          String nonce = payPalNonce.getString();
+          String payPalAccountNonce = payPalNonce.getString();
         } else {
           // handle error
         }

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -53,7 +53,7 @@ In the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integrati
 
 Additionally, apps that use both Drop-in and BraintreeClient should specify a custom url scheme, since `DropInActivity` already uses the `${applicationId}.braintree` url intent filter.
 
-If your app has multiple browser switch targets, you can specify multiple intent filters, and use the `BraintreeClient` constructor that allows you to specify a `customUrlScheme`:
+If your app has multiple browser switch targets, you can specify multiple intent filters and use the `BraintreeClient` constructor that allows you to specify a `customUrlScheme`:
 
 ```xml
 <activity android:name="com.company.app.MyPaymentsActivity1"


### PR DESCRIPTION
### Summary of changes

 - Fix migration guide typo related to PayPal Browser Switch
 - Add a section to the migration guide for multiple deep-link targets (Fixes #488)

 ### Checklist

 ~- [ ] Added a changelog entry~
