### PR TITLE
Authorization Loader

### DIFF
--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
@@ -1,5 +1,7 @@
 package com.braintreepayments.api;
 
+import static org.junit.Assert.assertEquals;
+
 import android.content.Context;
 import android.util.Log;
 
@@ -16,8 +18,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class AnalyticsClientTest {
@@ -46,7 +46,7 @@ public class AnalyticsClientTest {
 
         Context context = activity.getApplicationContext();
         AnalyticsClient sut = new AnalyticsClient(activity);
-        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, );
+        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, authorization);
 
         WorkInfo workInfoBeforeDelay = WorkManager.getInstance(context).getWorkInfoById(workSpecId).get();
         assertEquals(workInfoBeforeDelay.getState(), WorkInfo.State.ENQUEUED);
@@ -65,7 +65,7 @@ public class AnalyticsClientTest {
 
         Context context = activity.getApplicationContext();
         AnalyticsClient sut = new AnalyticsClient(activity);
-        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, );
+        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, authorization);
 
         WorkInfo workInfoBeforeDelay = WorkManager.getInstance(context).getWorkInfoById(workSpecId).get();
         assertEquals(workInfoBeforeDelay.getState(), WorkInfo.State.ENQUEUED);

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
@@ -45,8 +45,8 @@ public class AnalyticsClientTest {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_SANDBOX_ANALYTICS);
 
         Context context = activity.getApplicationContext();
-        AnalyticsClient sut = new AnalyticsClient(activity, authorization);
-        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123);
+        AnalyticsClient sut = new AnalyticsClient(activity);
+        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, );
 
         WorkInfo workInfoBeforeDelay = WorkManager.getInstance(context).getWorkInfoById(workSpecId).get();
         assertEquals(workInfoBeforeDelay.getState(), WorkInfo.State.ENQUEUED);
@@ -64,8 +64,8 @@ public class AnalyticsClientTest {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PROD_ANALYTICS);
 
         Context context = activity.getApplicationContext();
-        AnalyticsClient sut = new AnalyticsClient(activity, authorization);
-        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123);
+        AnalyticsClient sut = new AnalyticsClient(activity);
+        UUID workSpecId = sut.sendEvent(configuration, "event.started", "sessionId", "custom", 123, );
 
         WorkInfo workInfoBeforeDelay = WorkManager.getInstance(context).getWorkInfoById(workSpecId).get();
         assertEquals(workInfoBeforeDelay.getState(), WorkInfo.State.ENQUEUED);

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/BraintreeHttpClientTest.java
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/BraintreeHttpClientTest.java
@@ -24,9 +24,9 @@ public class BraintreeHttpClientTest {
     @Test(timeout = 10000)
     public void getRequestSslCertificateSuccessfulInSandbox() throws InterruptedException, InvalidArgumentException {
         Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
-        BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient(authorization);
+        BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient();
 
-        braintreeHttpClient.get("https://api.sandbox.braintreegateway.com/", null, new HttpResponseCallback() {
+        braintreeHttpClient.get("https://api.sandbox.braintreegateway.com/", , , null, new HttpResponseCallback() {
 
             @Override
             public void onResult(String responseBody, Exception httpError) {
@@ -34,7 +34,7 @@ public class BraintreeHttpClientTest {
                 assertTrue(httpError instanceof AuthorizationException);
                 countDownLatch.countDown();
             }
-        });
+        }, );
 
         countDownLatch.await();
     }
@@ -42,9 +42,9 @@ public class BraintreeHttpClientTest {
     @Test(timeout = 10000)
     public void getRequestSslCertificateSuccessfulInProduction() throws InterruptedException, InvalidArgumentException {
         Authorization authorization = Authorization.fromString(Fixtures.PROD_TOKENIZATION_KEY);
-        BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient(authorization);
+        BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient();
 
-        braintreeHttpClient.get("https://api.braintreegateway.com/", null, new HttpResponseCallback() {
+        braintreeHttpClient.get("https://api.braintreegateway.com/", , , null, new HttpResponseCallback() {
 
             @Override
             public void onResult(String responseBody, Exception httpError) {
@@ -52,7 +52,7 @@ public class BraintreeHttpClientTest {
                 assertTrue(httpError instanceof AuthorizationException);
                 countDownLatch.countDown();
             }
-        });
+        }, );
 
         countDownLatch.await();
     }

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/BraintreeHttpClientTest.java
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/BraintreeHttpClientTest.java
@@ -1,5 +1,7 @@
 package com.braintreepayments.api;
 
+import static junit.framework.Assert.assertTrue;
+
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 
 import org.junit.Before;
@@ -7,9 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
-
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class BraintreeHttpClientTest {
@@ -22,11 +21,11 @@ public class BraintreeHttpClientTest {
     }
 
     @Test(timeout = 10000)
-    public void getRequestSslCertificateSuccessfulInSandbox() throws InterruptedException, InvalidArgumentException {
+    public void getRequestSslCertificateSuccessfulInSandbox() throws InterruptedException {
         Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient();
 
-        braintreeHttpClient.get("https://api.sandbox.braintreegateway.com/", , , null, new HttpResponseCallback() {
+        braintreeHttpClient.get("https://api.sandbox.braintreegateway.com/", null, authorization, new HttpResponseCallback() {
 
             @Override
             public void onResult(String responseBody, Exception httpError) {
@@ -34,17 +33,17 @@ public class BraintreeHttpClientTest {
                 assertTrue(httpError instanceof AuthorizationException);
                 countDownLatch.countDown();
             }
-        }, );
+        });
 
         countDownLatch.await();
     }
 
     @Test(timeout = 10000)
-    public void getRequestSslCertificateSuccessfulInProduction() throws InterruptedException, InvalidArgumentException {
+    public void getRequestSslCertificateSuccessfulInProduction() throws InterruptedException {
         Authorization authorization = Authorization.fromString(Fixtures.PROD_TOKENIZATION_KEY);
         BraintreeHttpClient braintreeHttpClient = new BraintreeHttpClient();
 
-        braintreeHttpClient.get("https://api.braintreegateway.com/", , , null, new HttpResponseCallback() {
+        braintreeHttpClient.get("https://api.braintreegateway.com/",null, authorization, new HttpResponseCallback() {
 
             @Override
             public void onResult(String responseBody, Exception httpError) {
@@ -52,7 +51,7 @@ public class BraintreeHttpClientTest {
                 assertTrue(httpError instanceof AuthorizationException);
                 countDownLatch.countDown();
             }
-        }, );
+        });
 
         countDownLatch.await();
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
@@ -14,6 +14,7 @@ import androidx.work.WorkerParameters;
  * This class is used internally by the SDK and should not be used directly.
  * It is not subject to semantic versioning and may change at any time.
  */
+// NEXT-MAJOR-VERSION: remove this class, it may no longer be needed
 public abstract class AnalyticsBaseWorker extends Worker {
 
     public AnalyticsBaseWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
@@ -21,9 +22,6 @@ public abstract class AnalyticsBaseWorker extends Worker {
     }
 
     protected AnalyticsClient createAnalyticsClientFromInputData() {
-        Data inputData = getInputData();
-        String authString = inputData.getString(WORK_INPUT_KEY_AUTHORIZATION);
-        Authorization authorization = Authorization.fromString(authString);
         return new AnalyticsClient(getApplicationContext());
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
@@ -24,6 +24,6 @@ public abstract class AnalyticsBaseWorker extends Worker {
         Data inputData = getInputData();
         String authString = inputData.getString(WORK_INPUT_KEY_AUTHORIZATION);
         Authorization authorization = Authorization.fromString(authString);
-        return new AnalyticsClient(getApplicationContext(), authorization);
+        return new AnalyticsClient(getApplicationContext());
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsBaseWorker.java
@@ -14,7 +14,7 @@ import androidx.work.WorkerParameters;
  * This class is used internally by the SDK and should not be used directly.
  * It is not subject to semantic versioning and may change at any time.
  */
-// NEXT-MAJOR-VERSION: remove this class, it may no longer be needed
+// NEXT_MAJOR_VERSION: remove this class, it may no longer be needed
 public abstract class AnalyticsBaseWorker extends Worker {
 
     public AnalyticsBaseWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
@@ -135,9 +135,9 @@ class AnalyticsClient {
         String sessionId = inputData.getString(WORK_INPUT_KEY_SESSION_ID);
         String integration = inputData.getString(WORK_INPUT_KEY_INTEGRATION);
 
-        boolean shouldFail =
+        boolean isMissingInputData =
             Arrays.asList(configuration, authorization, sessionId, integration).contains(null);
-        if (shouldFail) {
+        if (isMissingInputData) {
             return ListenableWorker.Result.failure();
         }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
@@ -48,7 +48,7 @@ class AnalyticsClient {
 
     AnalyticsClient(Context context, Authorization authorization) {
         this(
-                new BraintreeHttpClient(authorization),
+                new BraintreeHttpClient(),
                 AnalyticsDatabase.getInstance(context.getApplicationContext()),
                 WorkManager.getInstance(context.getApplicationContext()),
                 new DeviceInspector()
@@ -147,7 +147,7 @@ class AnalyticsClient {
                 JSONObject analyticsRequest = serializeEvents(httpClient.getAuthorization(), events, metadata);
 
                 String analyticsUrl = configuration.getAnalyticsUrl();
-                httpClient.post(analyticsUrl, analyticsRequest.toString(), configuration);
+                httpClient.post(analyticsUrl, analyticsRequest.toString(), configuration, );
                 analyticsEventDao.deleteEvents(events);
             }
             return ListenableWorker.Result.success();
@@ -171,7 +171,7 @@ class AnalyticsClient {
         List<AnalyticsEvent> events = Collections.singletonList(event);
         try {
             JSONObject analyticsRequest = serializeEvents(httpClient.getAuthorization(), events, metadata);
-            httpClient.post(lastKnownAnalyticsUrl, analyticsRequest.toString(), null, new HttpNoResponse());
+            httpClient.post(lastKnownAnalyticsUrl, analyticsRequest.toString(), null, , new HttpNoResponse(), );
         } catch (JSONException e) { /* ignored */ }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.java
@@ -13,6 +13,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -134,7 +135,9 @@ class AnalyticsClient {
         String sessionId = inputData.getString(WORK_INPUT_KEY_SESSION_ID);
         String integration = inputData.getString(WORK_INPUT_KEY_INTEGRATION);
 
-        if (configuration == null || sessionId == null || integration == null) {
+        boolean shouldFail =
+            Arrays.asList(configuration, authorization, sessionId, integration).contains(null);
+        if (shouldFail) {
             return ListenableWorker.Result.failure();
         }
 
@@ -202,7 +205,9 @@ class AnalyticsClient {
     private static Authorization getAuthorizationFromData(Data inputData) {
         if (inputData != null) {
             String authString = inputData.getString(WORK_INPUT_KEY_AUTHORIZATION);
-            return Authorization.fromString(authString);
+            if (authString != null) {
+                return Authorization.fromString(authString);
+            }
         }
         return null;
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.java
@@ -1,0 +1,7 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.Nullable;
+
+interface AuthorizationCallback {
+    void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error);
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -1,15 +1,18 @@
 package com.braintreepayments.api;
 
+import androidx.annotation.Nullable;
+
 class AuthorizationLoader {
 
-    public AuthorizationLoader(String initialAuthString) {
+    AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
 
     }
 
-    void loadAuthorization() {
+    void loadAuthorization(AuthorizationCallback callback) {
 
     }
 
+    @Nullable
     Authorization getAuthorizationFromCache() {
         return null;
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -27,8 +27,8 @@ class AuthorizationLoader {
                 }
 
                 @Override
-                public void onFailure(@NonNull Exception exception) {
-                    callback.onAuthorizationResult(null, exception);
+                public void onFailure(@NonNull Exception error) {
+                    callback.onAuthorizationResult(null, error);
                 }
             });
         } else {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -1,0 +1,16 @@
+package com.braintreepayments.api;
+
+class AuthorizationLoader {
+
+    public AuthorizationLoader(String initialAuthString) {
+
+    }
+
+    void loadAuthorization() {
+
+    }
+
+    Authorization getAuthorizationFromCache() {
+        return null;
+    }
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -32,7 +32,7 @@ class AuthorizationLoader {
                 }
             });
         } else {
-            callback.onAuthorizationResult(null, new BraintreeException("unable to fetch client token"));
+            callback.onAuthorizationResult(null, new BraintreeException("Unable to fetch client token"));
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -1,19 +1,46 @@
 package com.braintreepayments.api;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 class AuthorizationLoader {
 
-    AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
+    private Authorization authorization;
+    private final ClientTokenProvider clientTokenProvider;
 
+    AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
+        this.clientTokenProvider = clientTokenProvider;
+        this.authorization = Authorization.fromString(initialAuthString);
     }
 
-    void loadAuthorization(AuthorizationCallback callback) {
+    void loadAuthorization(@NonNull final AuthorizationCallback callback) {
+        if (authorization != null) {
+            callback.onAuthorizationResult(authorization, null);
+        } else {
+            clientTokenProvider.getClientToken(new ClientTokenCallback() {
+                @Override
+                public void onSuccess(@NonNull String clientToken) {
+                    authorization = Authorization.fromString(clientToken);
+                    callback.onAuthorizationResult(authorization, null);
+                }
 
+                @Override
+                public void onFailure(@NonNull Exception exception) {
+                    callback.onAuthorizationResult(null, exception);
+                }
+            });
+        }
     }
 
     @Nullable
     Authorization getAuthorizationFromCache() {
-        return null;
+        return authorization;
+    }
+
+    AuthorizationType getAuthorizationType() {
+        if (authorization instanceof TokenizationKey) {
+            return AuthorizationType.TOKENIZATION_KEY;
+        }
+        return AuthorizationType.CLIENT_TOKEN;
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -10,13 +10,15 @@ class AuthorizationLoader {
 
     AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
         this.clientTokenProvider = clientTokenProvider;
-        this.authorization = Authorization.fromString(initialAuthString);
+        if (initialAuthString != null) {
+            this.authorization = Authorization.fromString(initialAuthString);
+        }
     }
 
     void loadAuthorization(@NonNull final AuthorizationCallback callback) {
         if (authorization != null) {
             callback.onAuthorizationResult(authorization, null);
-        } else {
+        } else if (clientTokenProvider != null) {
             clientTokenProvider.getClientToken(new ClientTokenCallback() {
                 @Override
                 public void onSuccess(@NonNull String clientToken) {
@@ -29,6 +31,8 @@ class AuthorizationLoader {
                     callback.onAuthorizationResult(null, exception);
                 }
             });
+        } else {
+            callback.onAuthorizationResult(null, new BraintreeException("unable to fetch client token"));
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -6,10 +6,10 @@ import androidx.annotation.Nullable;
 class AuthorizationLoader {
 
     private Authorization authorization;
-    private final ClientTokenProvider clientTokenProvider;
+    private final AuthorizationProvider authorizationProvider;
 
-    AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
-        this.clientTokenProvider = clientTokenProvider;
+    AuthorizationLoader(@Nullable String initialAuthString, @Nullable AuthorizationProvider authorizationProvider) {
+        this.authorizationProvider = authorizationProvider;
         if (initialAuthString != null) {
             this.authorization = Authorization.fromString(initialAuthString);
         }
@@ -18,8 +18,8 @@ class AuthorizationLoader {
     void loadAuthorization(@NonNull final AuthorizationCallback callback) {
         if (authorization != null) {
             callback.onAuthorizationResult(authorization, null);
-        } else if (clientTokenProvider != null) {
-            clientTokenProvider.getClientToken(new ClientTokenCallback() {
+        } else if (authorizationProvider != null) {
+            authorizationProvider.getClientToken(new ClientTokenCallback() {
                 @Override
                 public void onSuccess(@NonNull String clientToken) {
                     authorization = Authorization.fromString(clientToken);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -32,7 +32,10 @@ class AuthorizationLoader {
                 }
             });
         } else {
-            callback.onAuthorizationResult(null, new BraintreeException("Unable to fetch client token"));
+            String clientSDKSetupURL
+                = "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#initialization";
+            String message = String.format("Authorization required. See %s for more info.", clientSDKSetupURL);
+            callback.onAuthorizationResult(null, new BraintreeException(message));
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -42,9 +42,18 @@ class AuthorizationLoader {
     }
 
     AuthorizationType getAuthorizationType() {
+        if (authorization instanceof InvalidAuthorization) {
+            return AuthorizationType.INVALID;
+        }
+
         if (authorization instanceof TokenizationKey) {
             return AuthorizationType.TOKENIZATION_KEY;
         }
-        return AuthorizationType.CLIENT_TOKEN;
+
+        if (clientTokenProvider != null) {
+            return AuthorizationType.CLIENT_TOKEN;
+        }
+
+        return AuthorizationType.INVALID;
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -40,20 +40,4 @@ class AuthorizationLoader {
     Authorization getAuthorizationFromCache() {
         return authorization;
     }
-
-    AuthorizationType getAuthorizationType() {
-        if (authorization instanceof InvalidAuthorization) {
-            return AuthorizationType.INVALID;
-        }
-
-        if (authorization instanceof TokenizationKey) {
-            return AuthorizationType.TOKENIZATION_KEY;
-        }
-
-        if (clientTokenProvider != null) {
-            return AuthorizationType.CLIENT_TOKEN;
-        }
-
-        return AuthorizationType.INVALID;
-    }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationProvider.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationProvider.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
  * Implement this interface to provide an asynchronous way for {@link BraintreeClient} to fetch
  * a client token from your server when it is needed.
  */
-public interface ClientTokenProvider {
+public interface AuthorizationProvider {
 
     /**
      * Method used by {@link BraintreeClient} to fetch a client token.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
@@ -1,5 +1,5 @@
 package com.braintreepayments.api;
 
 enum AuthorizationType {
-    TOKENIZATION_KEY, CLIENT_TOKEN
+    INVALID, TOKENIZATION_KEY, CLIENT_TOKEN
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
@@ -1,0 +1,5 @@
+package com.braintreepayments.api;
+
+public enum AuthorizationType {
+    TOKENIZATION_KEY, CLIENT_TOKEN
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
@@ -1,5 +1,5 @@
 package com.braintreepayments.api;
 
-public enum AuthorizationType {
+enum AuthorizationType {
     TOKENIZATION_KEY, CLIENT_TOKEN
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationType.java
@@ -1,5 +1,0 @@
-package com.braintreepayments.api;
-
-enum AuthorizationType {
-    INVALID, TOKENIZATION_KEY, CLIENT_TOKEN
-}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -53,7 +53,7 @@ public class BraintreeClient {
 
     private static BraintreeClientParams createDefaultParams(Context context, String initialAuthString, ClientTokenProvider clientTokenProvider, String returnUrlScheme, String sessionId, @IntegrationType.Integration String integrationType) {
         AuthorizationLoader authorizationLoader =
-            new AuthorizationLoader(initialAuthString, clientTokenProvider);
+                new AuthorizationLoader(initialAuthString, clientTokenProvider);
 
         BraintreeHttpClient httpClient = new BraintreeHttpClient();
         return new BraintreeClientParams()
@@ -81,13 +81,19 @@ public class BraintreeClient {
         this(createDefaultParams(context, authorization, null));
     }
 
+    /**
+     * Create a new instance of {@link BraintreeClient} using a {@link ClientTokenProvider}.
+     *
+     * @param context             Android Context
+     * @param clientTokenProvider An implementation of {@link ClientTokenProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
+     */
     public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider) {
         this(createDefaultParams(context, null, clientTokenProvider));
     }
 
     /**
      * Create a new instance of {@link BraintreeClient} using a tokenization key or client token and a custom url scheme.
-     *
+     * <p>
      * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
      * This can be helpful for integrations using Drop-in and BraintreeClient to avoid deep linking collisions, since
      * Drop-in uses the same custom url scheme as the default BraintreeClient constructor.
@@ -100,6 +106,17 @@ public class BraintreeClient {
         this(createDefaultParams(context, authorization, null, returnUrlScheme));
     }
 
+    /**
+     * Create a new instance of {@link BraintreeClient} using a tokenization key or client token and a custom url scheme.
+     * <p>
+     * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
+     * This can be helpful for integrations using Drop-in and BraintreeClient to avoid deep linking collisions, since
+     * Drop-in uses the same custom url scheme as the default BraintreeClient constructor.
+     *
+     * @param context             Android Context
+     * @param clientTokenProvider An implementation of {@link ClientTokenProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
+     * @param returnUrlScheme     A custom return url to use for browser and app switching
+     */
     public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider, @NonNull String returnUrlScheme) {
         this(createDefaultParams(context, null, clientTokenProvider, returnUrlScheme));
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -29,31 +29,31 @@ public class BraintreeClient {
     private final String integrationType;
     private final String returnUrlScheme;
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider) {
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, AuthorizationProvider authorizationProvider) {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
                 .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
-        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
+        return createDefaultParams(context, authString, authorizationProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider, String returnUrlScheme) {
-        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, AuthorizationProvider authorizationProvider, String returnUrlScheme) {
+        return createDefaultParams(context, authString, authorizationProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider, String sessionId, @IntegrationType.Integration String integrationType) {
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, AuthorizationProvider authorizationProvider, String sessionId, @IntegrationType.Integration String integrationType) {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
                 .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
-        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, sessionId, integrationType);
+        return createDefaultParams(context, authString, authorizationProvider, returnUrlScheme, sessionId, integrationType);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String initialAuthString, ClientTokenProvider clientTokenProvider, String returnUrlScheme, String sessionId, @IntegrationType.Integration String integrationType) {
+    private static BraintreeClientParams createDefaultParams(Context context, String initialAuthString, AuthorizationProvider authorizationProvider, String returnUrlScheme, String sessionId, @IntegrationType.Integration String integrationType) {
         AuthorizationLoader authorizationLoader =
-                new AuthorizationLoader(initialAuthString, clientTokenProvider);
+                new AuthorizationLoader(initialAuthString, authorizationProvider);
 
         BraintreeHttpClient httpClient = new BraintreeHttpClient();
         return new BraintreeClientParams()
@@ -82,13 +82,13 @@ public class BraintreeClient {
     }
 
     /**
-     * Create a new instance of {@link BraintreeClient} using a {@link ClientTokenProvider}.
+     * Create a new instance of {@link BraintreeClient} using a {@link AuthorizationProvider}.
      *
      * @param context             Android Context
-     * @param clientTokenProvider An implementation of {@link ClientTokenProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
+     * @param authorizationProvider An implementation of {@link AuthorizationProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
      */
-    public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider) {
-        this(createDefaultParams(context, null, clientTokenProvider));
+    public BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider) {
+        this(createDefaultParams(context, null, authorizationProvider));
     }
 
     /**
@@ -114,11 +114,11 @@ public class BraintreeClient {
      * Drop-in uses the same custom url scheme as the default BraintreeClient constructor.
      *
      * @param context             Android Context
-     * @param clientTokenProvider An implementation of {@link ClientTokenProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
+     * @param authorizationProvider An implementation of {@link AuthorizationProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
      * @param returnUrlScheme     A custom return url to use for browser and app switching
      */
-    public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider, @NonNull String returnUrlScheme) {
-        this(createDefaultParams(context, null, clientTokenProvider, returnUrlScheme));
+    public BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider, @NonNull String returnUrlScheme) {
+        this(createDefaultParams(context, null, authorizationProvider, returnUrlScheme));
     }
 
     BraintreeClient(@NonNull Context context, @NonNull String authorization, @NonNull String sessionId, @NonNull @IntegrationType.Integration String integrationType) {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -149,8 +149,12 @@ public class BraintreeClient {
         });
     }
 
-    private void getAuthorization(@NonNull final AuthorizationCallback callback) {
+    void getAuthorization(@NonNull final AuthorizationCallback callback) {
         authorizationLoader.loadAuthorization(callback);
+    }
+
+    AuthorizationType getAuthorizationType() {
+        return authorizationLoader.getAuthorizationType();
     }
 
     void sendAnalyticsEvent(final String eventName) {
@@ -295,16 +299,6 @@ public class BraintreeClient {
 
     static boolean isAnalyticsEnabled(Configuration configuration) {
         return configuration != null && configuration.isAnalyticsEnabled();
-    }
-
-    // TODO: figure out if this is needed, or if something like getAuthorizationType()
-    // is more appropriate
-    Authorization getAuthorization() {
-        return authorizationLoader.getAuthorizationFromCache();
-    }
-
-    AuthorizationType getAuthorizationType() {
-        return authorizationLoader.getAuthorizationType();
     }
 
     Context getApplicationContext() {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -107,7 +107,7 @@ public class BraintreeClient {
     }
 
     /**
-     * Create a new instance of {@link BraintreeClient} using a tokenization key or client token and a custom url scheme.
+     * Create a new instance of {@link BraintreeClient} using a {@link ClientTokenProvider} and a custom url scheme.
      * <p>
      * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
      * This can be helpful for integrations using Drop-in and BraintreeClient to avoid deep linking collisions, since

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -107,7 +107,7 @@ public class BraintreeClient {
     }
 
     /**
-     * Create a new instance of {@link BraintreeClient} using a {@link ClientTokenProvider} and a custom url scheme.
+     * Create a new instance of {@link BraintreeClient} using a {@link AuthorizationProvider} and a custom url scheme.
      * <p>
      * This constructor should only be used for applications with multiple activities and multiple supported return url schemes.
      * This can be helpful for integrations using Drop-in and BraintreeClient to avoid deep linking collisions, since

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -29,30 +29,33 @@ public class BraintreeClient {
     private final String integrationType;
     private final String returnUrlScheme;
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString) {
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider) {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
                 .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
-        return createDefaultParams(context, authString, returnUrlScheme, null, IntegrationType.CUSTOM);
+        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, String returnUrlScheme) {
-        return createDefaultParams(context, authString, returnUrlScheme, null, IntegrationType.CUSTOM);
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider, String returnUrlScheme) {
+        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, null, IntegrationType.CUSTOM);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, String sessionId, @IntegrationType.Integration String integrationType) {
+    private static BraintreeClientParams createDefaultParams(Context context, String authString, ClientTokenProvider clientTokenProvider, String sessionId, @IntegrationType.Integration String integrationType) {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
                 .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
-        return createDefaultParams(context, authString, returnUrlScheme, sessionId, integrationType);
+        return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, sessionId, integrationType);
     }
 
-    private static BraintreeClientParams createDefaultParams(Context context, String authString, String returnUrlScheme, String sessionId, @IntegrationType.Integration String integrationType) {
-        Authorization authorization = Authorization.fromString(authString);
+    private static BraintreeClientParams createDefaultParams(Context context, String initialAuthString, ClientTokenProvider clientTokenProvider, String returnUrlScheme, String sessionId, @IntegrationType.Integration String integrationType) {
+        AuthorizationLoader authorizationLoader =
+            new AuthorizationLoader(initialAuthString, clientTokenProvider);
+
+        Authorization authorization = Authorization.fromString(initialAuthString);
         BraintreeHttpClient httpClient = new BraintreeHttpClient(authorization);
         return new BraintreeClientParams()
                 .authorization(authorization)
@@ -76,7 +79,11 @@ public class BraintreeClient {
      * @param authorization The tokenization key or client token to use. If an invalid authorization is provided, a {@link BraintreeException} will be returned via callback.
      */
     public BraintreeClient(@NonNull Context context, @NonNull String authorization) {
-        this(createDefaultParams(context, authorization));
+        this(createDefaultParams(context, authorization, null));
+    }
+
+    public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider) {
+        this(createDefaultParams(context, null, clientTokenProvider));
     }
 
     /**
@@ -91,11 +98,15 @@ public class BraintreeClient {
      * @param returnUrlScheme A custom return url to use for browser and app switching
      */
     public BraintreeClient(@NonNull Context context, @NonNull String authorization, @NonNull String returnUrlScheme) {
-        this(createDefaultParams(context, authorization, returnUrlScheme));
+        this(createDefaultParams(context, authorization, null, returnUrlScheme));
+    }
+
+    public BraintreeClient(@NonNull Context context, @NonNull ClientTokenProvider clientTokenProvider, @NonNull String returnUrlScheme) {
+        this(createDefaultParams(context, null, clientTokenProvider, returnUrlScheme));
     }
 
     BraintreeClient(@NonNull Context context, @NonNull String authorization, @NonNull String sessionId, @NonNull @IntegrationType.Integration String integrationType) {
-        this(createDefaultParams(context, authorization, sessionId, integrationType));
+        this(createDefaultParams(context, authorization, null, sessionId, integrationType));
     }
 
     @VisibleForTesting

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -153,10 +153,6 @@ public class BraintreeClient {
         authorizationLoader.loadAuthorization(callback);
     }
 
-    AuthorizationType getAuthorizationType() {
-        return authorizationLoader.getAuthorizationType();
-    }
-
     void sendAnalyticsEvent(final String eventName) {
         getAuthorization(new AuthorizationCallback() {
             @Override

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.java
@@ -4,7 +4,7 @@ import android.content.Context;
 
 class BraintreeClientParams {
 
-    private Authorization authorization;
+    private AuthorizationLoader authorizationLoader;
     private AnalyticsClient analyticsClient;
     private BraintreeHttpClient httpClient;
     private Context context;
@@ -19,12 +19,12 @@ class BraintreeClientParams {
     private ManifestValidator manifestValidator;
     private UUIDHelper uuidHelper;
 
-    Authorization getAuthorization() {
-        return authorization;
+    AuthorizationLoader getAuthorizationLoader() {
+        return authorizationLoader;
     }
 
-    BraintreeClientParams authorization(Authorization authorization) {
-        this.authorization = authorization;
+    BraintreeClientParams authorizationLoader(AuthorizationLoader authorizationLoader) {
+        this.authorizationLoader = authorizationLoader;
         return this;
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeGraphQLClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeGraphQLClient.java
@@ -8,16 +8,14 @@ import javax.net.ssl.SSLSocketFactory;
 class BraintreeGraphQLClient {
 
     private final HttpClient httpClient;
-    private final Authorization authorization;
 
-    BraintreeGraphQLClient(Authorization authorization) {
-        this(authorization, new HttpClient(getSocketFactory(), new BraintreeGraphQLResponseParser()));
+    BraintreeGraphQLClient() {
+        this(new HttpClient(getSocketFactory(), new BraintreeGraphQLResponseParser()));
     }
 
     @VisibleForTesting
-    BraintreeGraphQLClient(Authorization authorization, HttpClient httpClient) {
+    BraintreeGraphQLClient(HttpClient httpClient) {
         this.httpClient = httpClient;
-        this.authorization = authorization;
     }
 
     private static SSLSocketFactory getSocketFactory() {
@@ -28,7 +26,7 @@ class BraintreeGraphQLClient {
         }
     }
 
-    void post(String path, String data, Configuration configuration, HttpResponseCallback callback) {
+    void post(String path, String data, Configuration configuration, Authorization authorization, HttpResponseCallback callback) {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             callback.onResult(null, new BraintreeException(message));
@@ -46,7 +44,7 @@ class BraintreeGraphQLClient {
         httpClient.sendRequest(request, callback);
     }
 
-    void post(String data, Configuration configuration, HttpResponseCallback callback) {
+    void post(String data, Configuration configuration, Authorization authorization, HttpResponseCallback callback) {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             callback.onResult(null, new BraintreeException(message));
@@ -64,7 +62,7 @@ class BraintreeGraphQLClient {
         httpClient.sendRequest(request, callback);
     }
 
-    String post(String path, String data, Configuration configuration) throws Exception {
+    String post(String path, String data, Configuration configuration, Authorization authorization) throws Exception {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             throw new BraintreeException(message);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.java
@@ -22,16 +22,14 @@ class BraintreeHttpClient {
     private static final String CLIENT_KEY_HEADER = "Client-Key";
 
     private final HttpClient httpClient;
-    private final Authorization authorization;
 
-    BraintreeHttpClient(Authorization authorization) {
-        this(authorization, new HttpClient(getSocketFactory(), new BraintreeHttpResponseParser()));
+    BraintreeHttpClient() {
+        this(new HttpClient(getSocketFactory(), new BraintreeHttpResponseParser()));
     }
 
     @VisibleForTesting
-    BraintreeHttpClient(Authorization authorization, HttpClient httpClient) {
+    BraintreeHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
-        this.authorization = authorization;
     }
 
     private static SSLSocketFactory getSocketFactory() {
@@ -42,32 +40,28 @@ class BraintreeHttpClient {
         }
     }
 
-    Authorization getAuthorization() {
-        return authorization;
-    }
-
     /**
      * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
      * If the path is a full url, it will be used instead of the previously provided url.
-     *
      * @param path The path or url to request from the server via GET
      * @param configuration configuration for the Braintree Android SDK.
+     * @param authorization
      * @param callback {@link HttpResponseCallback}
      */
-    void get(String path, Configuration configuration, HttpResponseCallback callback) {
-        get(path, configuration, HttpClient.NO_RETRY, callback);
+    void get(String path, Configuration configuration, Authorization authorization, HttpResponseCallback callback) {
+        get(path, configuration, authorization, HttpClient.NO_RETRY, callback);
     }
 
     /**
      * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
      * If the path is a full url, it will be used instead of the previously provided url.
-     *
      * @param path The path or url to request from the server via GET
      * @param configuration configuration for the Braintree Android SDK.
-     * @param callback {@link HttpResponseCallback}
+     * @param authorization
      * @param retryStrategy retry strategy
+     * @param callback {@link HttpResponseCallback}
      */
-    void get(String path, Configuration configuration, @RetryStrategy int retryStrategy, HttpResponseCallback callback) {
+    void get(String path, Configuration configuration, Authorization authorization, @RetryStrategy int retryStrategy, HttpResponseCallback callback) {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             callback.onResult(null, new BraintreeException(message));
@@ -111,13 +105,13 @@ class BraintreeHttpClient {
     /**
      * Make a HTTP POST request to Braintree.
      * If the path is a full url, it will be used instead of the previously provided url.
-     *
      * @param path The path or url to request from the server via HTTP POST
      * @param data The body of the POST request
-     * @param callback {@link HttpResponseCallback}
      * @param configuration configuration for the Braintree Android SDK.
+     * @param authorization
+     * @param callback {@link HttpResponseCallback}
      */
-    void post(String path, String data, Configuration configuration, HttpResponseCallback callback) {
+    void post(String path, String data, Configuration configuration, Authorization authorization, HttpResponseCallback callback) {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             callback.onResult(null, new BraintreeException(message));
@@ -169,9 +163,10 @@ class BraintreeHttpClient {
      * @param path the path or url to request from the server via HTTP POST
      * @param data the body of the post request
      * @param configuration configuration for the Braintree Android SDK.
+     * @param authorization
      * @return the HTTP response body
      */
-    String post(String path, String data, Configuration configuration) throws Exception {
+    String post(String path, String data, Configuration configuration, Authorization authorization) throws Exception {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             throw new BraintreeException(message);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
@@ -2,7 +2,21 @@ package com.braintreepayments.api;
 
 import androidx.annotation.NonNull;
 
+/**
+ * Callback used to communicate {@link ClientTokenProvider#getClientToken(ClientTokenCallback)} result
+ * back to {@link BraintreeClient}.
+ */
 public interface ClientTokenCallback {
+
+    /**
+     * Invoke this method once a client token has been successfully fetched from the merchant server.
+     * @param clientToken Client token fetched from merchant server
+     */
     void onSuccess(@NonNull String clientToken);
-    void onFailure(@NonNull Exception exception);
+
+    /**
+     * Invoke this method when an error occurs fetching the client token
+     * @param error An error describing the cause of the client token fetch error
+     */
+    void onFailure(@NonNull Exception error);
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
@@ -3,7 +3,7 @@ package com.braintreepayments.api;
 import androidx.annotation.NonNull;
 
 /**
- * Callback used to communicate {@link ClientTokenProvider#getClientToken(ClientTokenCallback)} result
+ * Callback used to communicate {@link AuthorizationProvider#getClientToken(ClientTokenCallback)} result
  * back to {@link BraintreeClient}.
  */
 public interface ClientTokenCallback {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
@@ -1,0 +1,8 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.NonNull;
+
+public interface ClientTokenCallback {
+    void onSuccess(@NonNull String clientToken);
+    void onFailure(@NonNull Exception exception);
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
@@ -2,6 +2,15 @@ package com.braintreepayments.api;
 
 import androidx.annotation.NonNull;
 
+/**
+ * Implement this interface to provide an asynchronous way for {@link BraintreeClient} to fetch
+ * a client token from your server when it is needed.
+ */
 public interface ClientTokenProvider {
+
+    /**
+     * Method used by {@link BraintreeClient} to fetch a client token.
+     * @param callback {@link ClientTokenCallback} to invoke to notify {@link BraintreeClient} of success (or failure) when fetching a client token
+     */
     void getClientToken(@NonNull ClientTokenCallback callback);
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
@@ -1,0 +1,7 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.NonNull;
+
+public interface ClientTokenProvider {
+    void getClientToken(@NonNull ClientTokenCallback callback);
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
@@ -41,7 +41,7 @@ class ConfigurationLoader {
             callback.onResult(cachedConfig, null);
         } else {
 
-            httpClient.get(configUrl, null, HttpClient.RETRY_MAX_3_TIMES, new HttpResponseCallback() {
+            httpClient.get(configUrl, null, , HttpClient.RETRY_MAX_3_TIMES, new HttpResponseCallback() {
 
                 @Override
                 public void onResult(String responseBody, Exception httpError) {
@@ -61,7 +61,7 @@ class ConfigurationLoader {
                         callback.onResult(null, configurationException);
                     }
                 }
-            });
+            }, );
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
@@ -41,7 +41,7 @@ class ConfigurationLoader {
             callback.onResult(cachedConfig, null);
         } else {
 
-            httpClient.get(configUrl, null, , HttpClient.RETRY_MAX_3_TIMES, new HttpResponseCallback() {
+            httpClient.get(configUrl, null, authorization, HttpClient.RETRY_MAX_3_TIMES, new HttpResponseCallback() {
 
                 @Override
                 public void onResult(String responseBody, Exception httpError) {
@@ -61,7 +61,7 @@ class ConfigurationLoader {
                         callback.onResult(null, configurationException);
                     }
                 }
-            }, );
+            });
         }
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -377,15 +377,12 @@ public class AnalyticsClientUnitTest {
 
     @Test
     public void reportCrash_whenLastKnownAnalyticsUrlMissing_doesNothing() throws JSONException {
-        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
-
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.sendEvent(configuration, eventName, sessionId, integration, authorization);
+        sut.reportCrash(context, sessionId, integration, 123, authorization);
 
-        sut.reportCrash(context, sessionId, integration, 123, null);
         verifyZeroInteractions(httpClient);
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -11,6 +11,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -83,10 +84,9 @@ public class AnalyticsClientUnitTest {
     @Test
     public void sendEvent_enqueuesAnalyticsWriteToDbWorker() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.sendEvent(configuration, eventName, sessionId, integration, 123, );
+        sut.sendEvent(configuration, eventName, sessionId, integration, 123, authorization);
 
         ArgumentCaptor<OneTimeWorkRequest> captor = ArgumentCaptor.forClass(OneTimeWorkRequest.class);
         verify(workManager)
@@ -104,10 +104,9 @@ public class AnalyticsClientUnitTest {
     @Test
     public void sendEvent_enqueuesAnalyticsUploadWorker() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.sendEvent(configuration, eventName, sessionId, integration, 123, );
+        sut.sendEvent(configuration, eventName, sessionId, integration, 123, authorization);
 
         ArgumentCaptor<OneTimeWorkRequest> captor = ArgumentCaptor.forClass(OneTimeWorkRequest.class);
         verify(workManager)
@@ -204,7 +203,6 @@ public class AnalyticsClientUnitTest {
 
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         List<AnalyticsEvent> events = new ArrayList<>();
         events.add(new AnalyticsEvent("event0", 123));
@@ -216,7 +214,7 @@ public class AnalyticsClientUnitTest {
         sut.uploadAnalytics(context, inputData);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class), );
+        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class), authorization);
 
         JSONObject analyticsJson = new JSONObject(captor.getValue());
 
@@ -247,7 +245,6 @@ public class AnalyticsClientUnitTest {
 
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         List<AnalyticsEvent> events = new ArrayList<>();
         events.add(new AnalyticsEvent("event0", 123));
@@ -273,7 +270,6 @@ public class AnalyticsClientUnitTest {
 
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         List<AnalyticsEvent> events = new ArrayList<>();
         events.add(new AnalyticsEvent("event0", 123));
@@ -282,7 +278,7 @@ public class AnalyticsClientUnitTest {
         when(analyticsEventDao.getAllEvents()).thenReturn(events);
 
         Exception httpError = new Exception("error");
-        when(httpClient.post(anyString(), anyString(), any(Configuration.class), )).thenThrow(httpError);
+        when(httpClient.post(anyString(), anyString(), any(Configuration.class), any(Authorization.class))).thenThrow(httpError);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
         ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
@@ -293,16 +289,15 @@ public class AnalyticsClientUnitTest {
     public void reportCrash_whenLastKnownAnalyticsUrlExists_sendsCrashAnalyticsEvent() throws Exception {
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
 
-        sut.sendEvent(configuration, eventName, sessionId, integration, );
-        sut.reportCrash(context, sessionId, integration, 123, );
+        sut.sendEvent(configuration, eventName, sessionId, integration, authorization);
+        sut.reportCrash(context, sessionId, integration, 123, authorization);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpClient).post(eq("analytics_url"), captor.capture(), (Configuration) isNull(), , any(HttpNoResponse.class), );
+        verify(httpClient).post(eq("analytics_url"), captor.capture(), (Configuration) isNull(), same(authorization), any(HttpNoResponse.class));
 
         JSONObject analyticsJson = new JSONObject(captor.getValue());
 
@@ -318,13 +313,26 @@ public class AnalyticsClientUnitTest {
     }
 
     @Test
-    public void reportCrash_whenLastKnownAnalyticsUrlMissing_doesNothing() {
+    public void reportCrash_whenLastKnownAnalyticsUrlMissing_doesNothing() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
-        when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.reportCrash(context, sessionId, integration, 123, );
+        sut.sendEvent(configuration, eventName, sessionId, integration, authorization);
+
+        sut.reportCrash(context, sessionId, integration, 123, null);
+        verifyZeroInteractions(httpClient);
+    }
+
+    @Test
+    public void reportCrash_whenAuthorizationIsNull_doesNothing() {
+        DeviceMetadata metadata = createSampleDeviceMetadata();
+        when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
+
+        AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
+        sut.reportCrash(context, sessionId, integration, 123, authorization);
 
         verifyZeroInteractions(httpClient);
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -327,13 +327,15 @@ public class AnalyticsClientUnitTest {
     }
 
     @Test
-    public void reportCrash_whenAuthorizationIsNull_doesNothing() {
+    public void reportCrash_whenAuthorizationIsNull_doesNothing() throws JSONException {
         DeviceMetadata metadata = createSampleDeviceMetadata();
         when(deviceInspector.getDeviceMetadata(context, sessionId, integration)).thenReturn(metadata);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.reportCrash(context, sessionId, integration, 123, authorization);
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
 
+        sut.sendEvent(configuration, eventName, sessionId, integration, authorization);
+        sut.reportCrash(context, sessionId, integration, 123, null);
         verifyZeroInteractions(httpClient);
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -40,7 +40,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
@@ -217,7 +216,7 @@ public class AnalyticsClientUnitTest {
         sut.uploadAnalytics(context, inputData);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class));
+        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class), );
 
         JSONObject analyticsJson = new JSONObject(captor.getValue());
 
@@ -283,7 +282,7 @@ public class AnalyticsClientUnitTest {
         when(analyticsEventDao.getAllEvents()).thenReturn(events);
 
         Exception httpError = new Exception("error");
-        when(httpClient.post(anyString(), anyString(), any(Configuration.class))).thenThrow(httpError);
+        when(httpClient.post(anyString(), anyString(), any(Configuration.class), )).thenThrow(httpError);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
         ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
@@ -303,7 +302,7 @@ public class AnalyticsClientUnitTest {
         sut.reportCrash(context, sessionId, integration, 123);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpClient).post(eq("analytics_url"), captor.capture(), (Configuration) isNull(), any(HttpNoResponse.class));
+        verify(httpClient).post(eq("analytics_url"), captor.capture(), (Configuration) isNull(), , any(HttpNoResponse.class), );
 
         JSONObject analyticsJson = new JSONObject(captor.getValue());
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -234,6 +234,69 @@ public class AnalyticsClientUnitTest {
     }
 
     @Test
+    public void uploadAnalytics_whenConfigurationIsNull_doesNothing() {
+        Data inputData = new Data.Builder()
+                .putString(WORK_INPUT_KEY_AUTHORIZATION, authorization.toString())
+                .putString(WORK_INPUT_KEY_SESSION_ID, sessionId)
+                .putString(WORK_INPUT_KEY_INTEGRATION, integration)
+                .build();
+
+        AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
+
+        ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
+        assertTrue(result instanceof ListenableWorker.Result.Failure);
+        verifyZeroInteractions(httpClient);
+    }
+
+    @Test
+    public void uploadAnalytics_whenAuthorizationIsNull_doesNothing() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        Data inputData = new Data.Builder()
+                .putString(WORK_INPUT_KEY_CONFIGURATION, configuration.toJson())
+                .putString(WORK_INPUT_KEY_SESSION_ID, sessionId)
+                .putString(WORK_INPUT_KEY_INTEGRATION, integration)
+                .build();
+
+        AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
+
+        ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
+        assertTrue(result instanceof ListenableWorker.Result.Failure);
+        verifyZeroInteractions(httpClient);
+    }
+
+    @Test
+    public void uploadAnalytics_whenSessionIdIsNull_doesNothing() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        Data inputData = new Data.Builder()
+                .putString(WORK_INPUT_KEY_AUTHORIZATION, authorization.toString())
+                .putString(WORK_INPUT_KEY_CONFIGURATION, configuration.toJson())
+                .putString(WORK_INPUT_KEY_INTEGRATION, integration)
+                .build();
+
+        AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
+
+        ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
+        assertTrue(result instanceof ListenableWorker.Result.Failure);
+        verifyZeroInteractions(httpClient);
+    }
+
+    @Test
+    public void uploadAnalytics_whenIntegrationIsNull_doesNothing() throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        Data inputData = new Data.Builder()
+                .putString(WORK_INPUT_KEY_AUTHORIZATION, authorization.toString())
+                .putString(WORK_INPUT_KEY_CONFIGURATION, configuration.toJson())
+                .putString(WORK_INPUT_KEY_SESSION_ID, sessionId)
+                .build();
+
+        AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
+
+        ListenableWorker.Result result = sut.uploadAnalytics(context, inputData);
+        assertTrue(result instanceof ListenableWorker.Result.Failure);
+        verifyZeroInteractions(httpClient);
+    }
+
+    @Test
     public void uploadAnalytics_deletesDatabaseEventsOnSuccessResponse() throws Exception {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
         Data inputData = new Data.Builder()

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -86,7 +86,7 @@ public class AnalyticsClientUnitTest {
         when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.sendEvent(configuration, eventName, sessionId, integration, 123);
+        sut.sendEvent(configuration, eventName, sessionId, integration, 123, );
 
         ArgumentCaptor<OneTimeWorkRequest> captor = ArgumentCaptor.forClass(OneTimeWorkRequest.class);
         verify(workManager)
@@ -107,7 +107,7 @@ public class AnalyticsClientUnitTest {
         when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.sendEvent(configuration, eventName, sessionId, integration, 123);
+        sut.sendEvent(configuration, eventName, sessionId, integration, 123, );
 
         ArgumentCaptor<OneTimeWorkRequest> captor = ArgumentCaptor.forClass(OneTimeWorkRequest.class);
         verify(workManager)
@@ -298,8 +298,8 @@ public class AnalyticsClientUnitTest {
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
 
-        sut.sendEvent(configuration, eventName, sessionId, integration);
-        sut.reportCrash(context, sessionId, integration, 123);
+        sut.sendEvent(configuration, eventName, sessionId, integration, );
+        sut.reportCrash(context, sessionId, integration, 123, );
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(httpClient).post(eq("analytics_url"), captor.capture(), (Configuration) isNull(), , any(HttpNoResponse.class), );
@@ -324,7 +324,7 @@ public class AnalyticsClientUnitTest {
         when(httpClient.getAuthorization()).thenReturn(authorization);
 
         AnalyticsClient sut = new AnalyticsClient(httpClient, analyticsDatabase, workManager, deviceInspector);
-        sut.reportCrash(context, sessionId, integration, 123);
+        sut.reportCrash(context, sessionId, integration, 123, );
 
         verifyZeroInteractions(httpClient);
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.java
@@ -214,7 +214,7 @@ public class AnalyticsClientUnitTest {
         sut.uploadAnalytics(context, inputData);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class), authorization);
+        verify(httpClient).post(anyString(), captor.capture(), any(Configuration.class), any(Authorization.class));
 
         JSONObject analyticsJson = new JSONObject(captor.getValue());
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ApiClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ApiClientUnitTest.java
@@ -80,7 +80,7 @@ public class ApiClientUnitTest {
         Authorization authorization = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(graphQLEnabledConfig)
-                .authorization(authorization)
+                .authorizationSuccess(authorization)
                 .build();
 
         ApiClient sut = new ApiClient(braintreeClient);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -37,7 +37,7 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_callsBackSuccessfulClientTokenFetch() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockAuthorizationProviderBuilder()
                 .clientToken(clientToken)
                 .build();
         sut = new AuthorizationLoader(null, authorizationProvider);
@@ -55,7 +55,7 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_cachesClientTokenInMemory() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockAuthorizationProviderBuilder()
                 .clientToken(clientToken)
                 .build();
         sut = new AuthorizationLoader(null, authorizationProvider);
@@ -70,7 +70,7 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_forwardsClientTokenFetchError() {
         Exception clientTokenFetchError = new Exception("error");
-        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockAuthorizationProviderBuilder()
                 .error(clientTokenFetchError)
                 .build();
         sut = new AuthorizationLoader(null, authorizationProvider);
@@ -111,7 +111,7 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void getAuthorizationFromCache_returnsAuthorizationFromClientTokenProvider() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockAuthorizationProviderBuilder()
                 .clientToken(clientToken)
                 .build();
         sut = new AuthorizationLoader(null, authorizationProvider);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -93,7 +93,9 @@ public class AuthorizationLoaderUnitTest {
 
         Exception error = captor.getValue();
         assertTrue(error instanceof BraintreeException);
-        assertEquals("Unable to fetch client token", error.getMessage());
+        String expectedMessage =
+                "Authorization required. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#initialization for more info.";
+        assertEquals(expectedMessage, error.getMessage());
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -1,8 +1,11 @@
 package com.braintreepayments.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
@@ -16,7 +19,7 @@ public class AuthorizationLoaderUnitTest {
     private AuthorizationLoader sut;
 
     @Test
-    public void loadAuthorization_whenInitialAuthStringExists_callsBackAuth() {
+    public void loadAuthorization_whenInitialAuthExists_callsBackAuth() {
         String initialAuthString = Fixtures.TOKENIZATION_KEY;
         sut = new AuthorizationLoader(initialAuthString, null);
 
@@ -28,5 +31,67 @@ public class AuthorizationLoaderUnitTest {
 
         Authorization authorization = captor.getValue();
         assertEquals(initialAuthString, authorization.toString());
+    }
+
+    @Test
+    public void loadAuthorization_whenInitialAuthDoesNotExist_callsBackSuccessfulClientTokenFetch() {
+        String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
+        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+                .clientToken(clientToken)
+                .build();
+        sut = new AuthorizationLoader(null, clientTokenProvider);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+
+        ArgumentCaptor<Authorization> captor = ArgumentCaptor.forClass(Authorization.class);
+        verify(callback).onAuthorizationResult(captor.capture(), (Exception) isNull());
+
+        Authorization authorization = captor.getValue();
+        assertEquals(clientToken, authorization.toString());
+    }
+
+    @Test
+    public void loadAuthorization_whenInitialAuthDoesNotExist_cachesClientTokenInMemory() {
+        String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
+        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+                .clientToken(clientToken)
+                .build();
+        sut = new AuthorizationLoader(null, clientTokenProvider);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+        sut.loadAuthorization(callback);
+
+        verify(clientTokenProvider, times(1)).getClientToken(any(ClientTokenCallback.class));
+    }
+
+    @Test
+    public void loadAuthorization_whenInitialAuthDoesNotExist_forwardsClientTokenFetchError() {
+        Exception clientTokenFetchError = new Exception("error");
+        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+                .error(clientTokenFetchError)
+                .build();
+        sut = new AuthorizationLoader(null, clientTokenProvider);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+
+        verify(callback).onAuthorizationResult(null, clientTokenFetchError);
+    }
+
+    @Test
+    public void loadAuthorization_whenInitialAuthDoesNotExistAndNoClientTokenProvider_callsBackException() {
+        sut = new AuthorizationLoader(null, null);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(callback).onAuthorizationResult((Authorization)isNull(), captor.capture());
+
+        Exception error = captor.getValue();
+        assertTrue(error instanceof BraintreeException);
+        assertEquals("Unable to fetch client token", error.getMessage());
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -93,5 +94,31 @@ public class AuthorizationLoaderUnitTest {
         Exception error = captor.getValue();
         assertTrue(error instanceof BraintreeException);
         assertEquals("Unable to fetch client token", error.getMessage());
+    }
+
+    @Test
+    public void getAuthorizationFromCache_returnsInitialAuthorization() {
+        String initialAuthString = Fixtures.TOKENIZATION_KEY;
+        sut = new AuthorizationLoader(initialAuthString, null);
+
+        Authorization cachedAuth = sut.getAuthorizationFromCache();
+        assertNotNull(cachedAuth);
+        assertEquals(initialAuthString, cachedAuth.toString());
+    }
+
+    @Test
+    public void getAuthorizationFromCache_returnsAuthorizationFromClientTokenProvider() {
+        String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
+        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+                .clientToken(clientToken)
+                .build();
+        sut = new AuthorizationLoader(null, clientTokenProvider);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+
+        Authorization cachedAuth = sut.getAuthorizationFromCache();
+        assertNotNull(cachedAuth);
+        assertEquals(clientToken, cachedAuth.toString());
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -1,0 +1,32 @@
+package com.braintreepayments.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AuthorizationLoaderUnitTest {
+
+    private AuthorizationLoader sut;
+
+    @Test
+    public void loadAuthorization_whenInitialAuthStringExists_callsBackAuth() {
+        String initialAuthString = Fixtures.TOKENIZATION_KEY;
+        sut = new AuthorizationLoader(initialAuthString, null);
+
+        AuthorizationCallback callback = mock(AuthorizationCallback.class);
+        sut.loadAuthorization(callback);
+
+        ArgumentCaptor<Authorization> captor = ArgumentCaptor.forClass(Authorization.class);
+        verify(callback).onAuthorizationResult(captor.capture(), (Exception) isNull());
+
+        Authorization authorization = captor.getValue();
+        assertEquals(initialAuthString, authorization.toString());
+    }
+}

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -121,31 +121,4 @@ public class AuthorizationLoaderUnitTest {
         assertNotNull(cachedAuth);
         assertEquals(clientToken, cachedAuth.toString());
     }
-
-    @Test
-    public void getAuthorizationType_whenAuthIsTokenizationKey_returnsTOKENIZATION() {
-        String initialAuthString = Fixtures.TOKENIZATION_KEY;
-        sut = new AuthorizationLoader(initialAuthString, null);
-        assertEquals(AuthorizationType.TOKENIZATION_KEY, sut.getAuthorizationType());
-    }
-
-    @Test
-    public void getAuthorizationType_whenAuthIsInvalid_returnsINVALID() {
-        String initialAuthString = "invalid string";
-        sut = new AuthorizationLoader(initialAuthString, null);
-        assertEquals(AuthorizationType.INVALID, sut.getAuthorizationType());
-    }
-
-    @Test
-    public void getAuthorizationType_whenInitialAuthDoesNotExistAndClientTokenProviderExists_returnsCLIENT_TOKEN() {
-        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder().build();
-        sut = new AuthorizationLoader(null, clientTokenProvider);
-        assertEquals(AuthorizationType.CLIENT_TOKEN, sut.getAuthorizationType());
-    }
-
-    @Test
-    public void getAuthorizationType_whenInitialAuthAndClientTokenProviderDoNoExist_returnsINVALID() {
-        sut = new AuthorizationLoader(null, null);
-        assertEquals(AuthorizationType.INVALID, sut.getAuthorizationType());
-    }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -37,10 +37,10 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_callsBackSuccessfulClientTokenFetch() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
                 .clientToken(clientToken)
                 .build();
-        sut = new AuthorizationLoader(null, clientTokenProvider);
+        sut = new AuthorizationLoader(null, authorizationProvider);
 
         AuthorizationCallback callback = mock(AuthorizationCallback.class);
         sut.loadAuthorization(callback);
@@ -55,25 +55,25 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_cachesClientTokenInMemory() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
                 .clientToken(clientToken)
                 .build();
-        sut = new AuthorizationLoader(null, clientTokenProvider);
+        sut = new AuthorizationLoader(null, authorizationProvider);
 
         AuthorizationCallback callback = mock(AuthorizationCallback.class);
         sut.loadAuthorization(callback);
         sut.loadAuthorization(callback);
 
-        verify(clientTokenProvider, times(1)).getClientToken(any(ClientTokenCallback.class));
+        verify(authorizationProvider, times(1)).getClientToken(any(ClientTokenCallback.class));
     }
 
     @Test
     public void loadAuthorization_whenInitialAuthDoesNotExist_forwardsClientTokenFetchError() {
         Exception clientTokenFetchError = new Exception("error");
-        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
                 .error(clientTokenFetchError)
                 .build();
-        sut = new AuthorizationLoader(null, clientTokenProvider);
+        sut = new AuthorizationLoader(null, authorizationProvider);
 
         AuthorizationCallback callback = mock(AuthorizationCallback.class);
         sut.loadAuthorization(callback);
@@ -111,10 +111,10 @@ public class AuthorizationLoaderUnitTest {
     @Test
     public void getAuthorizationFromCache_returnsAuthorizationFromClientTokenProvider() {
         String clientToken = Fixtures.BASE64_CLIENT_TOKEN;
-        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder()
+        AuthorizationProvider authorizationProvider = new MockClientTokenProviderBuilder()
                 .clientToken(clientToken)
                 .build();
-        sut = new AuthorizationLoader(null, clientTokenProvider);
+        sut = new AuthorizationLoader(null, authorizationProvider);
 
         AuthorizationCallback callback = mock(AuthorizationCallback.class);
         sut.loadAuthorization(callback);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AuthorizationLoaderUnitTest.java
@@ -121,4 +121,31 @@ public class AuthorizationLoaderUnitTest {
         assertNotNull(cachedAuth);
         assertEquals(clientToken, cachedAuth.toString());
     }
+
+    @Test
+    public void getAuthorizationType_whenAuthIsTokenizationKey_returnsTOKENIZATION() {
+        String initialAuthString = Fixtures.TOKENIZATION_KEY;
+        sut = new AuthorizationLoader(initialAuthString, null);
+        assertEquals(AuthorizationType.TOKENIZATION_KEY, sut.getAuthorizationType());
+    }
+
+    @Test
+    public void getAuthorizationType_whenAuthIsInvalid_returnsINVALID() {
+        String initialAuthString = "invalid string";
+        sut = new AuthorizationLoader(initialAuthString, null);
+        assertEquals(AuthorizationType.INVALID, sut.getAuthorizationType());
+    }
+
+    @Test
+    public void getAuthorizationType_whenInitialAuthDoesNotExistAndClientTokenProviderExists_returnsCLIENT_TOKEN() {
+        ClientTokenProvider clientTokenProvider = new MockClientTokenProviderBuilder().build();
+        sut = new AuthorizationLoader(null, clientTokenProvider);
+        assertEquals(AuthorizationType.CLIENT_TOKEN, sut.getAuthorizationType());
+    }
+
+    @Test
+    public void getAuthorizationType_whenInitialAuthAndClientTokenProviderDoNoExist_returnsINVALID() {
+        sut = new AuthorizationLoader(null, null);
+        assertEquals(AuthorizationType.INVALID, sut.getAuthorizationType());
+    }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -161,13 +161,30 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
+    public void sendGET_onGetAuthorizationFailure_forwardsErrorToCallback() {
+        Exception authorizationError = new Exception("authorization error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorizationError(authorizationError)
+                .build();
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder().build();
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
+        sut.sendGET("sample-url", httpResponseCallback);
+
+        verify(httpResponseCallback).onResult((String) isNull(), same(authorizationError));
+    }
+
+    @Test
     public void sendGET_onGetConfigurationFailure_forwardsErrorToCallback() {
-        Exception exception = new Exception("configuration error");
+        Exception configError = new Exception("configuration error");
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
                 .authorization(authorization)
                 .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
-                .configurationError(exception)
+                .configurationError(configError)
                 .build();
 
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
@@ -176,7 +193,7 @@ public class BraintreeClientUnitTest {
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendGET("sample-url", httpResponseCallback);
 
-        verify(httpResponseCallback).onResult((String) isNull(), same(exception));
+        verify(httpResponseCallback).onResult((String) isNull(), same(configError));
     }
 
     @Test
@@ -196,6 +213,23 @@ public class BraintreeClientUnitTest {
         sut.sendPOST("sample-url", "{}", httpResponseCallback);
 
         verify(braintreeHttpClient).post(eq("sample-url"), eq("{}"), same(configuration), same(authorization), same(httpResponseCallback));
+    }
+
+    @Test
+    public void sendPOST_onAuthorizationFailure_forwardsErrorToCallback() {
+        Exception authError = new Exception("authorization error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorizationError(authError)
+                .build();
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder().build();
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
+        sut.sendPOST("sample-url", "{}", httpResponseCallback);
+
+        verify(httpResponseCallback).onResult(null, authError);
     }
 
     @Test
@@ -237,6 +271,23 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
+    public void sendGraphQLPOST_onAuthorizationFailure_forwardsErrorToCallback() {
+        Exception authError = new Exception("authorization error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorizationError(authError)
+                .build();
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder().build();
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
+        sut.sendGraphQLPOST("{}", httpResponseCallback);
+
+        verify(httpResponseCallback).onResult(null, authError);
+    }
+
+    @Test
     public void sendGraphQLPOST_onGetConfigurationFailure_forwardsErrorToCallback() {
         Exception exception = new Exception("configuration error");
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
@@ -273,13 +324,11 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void sendAnalyticsEvent_whenConfigurationLoadFails_doesNothing() {
+    public void sendAnalyticsEvent_whenAuthorizationLoadFails_doesNothing() {
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
-                .authorization(authorization)
+                .authorizationError(new Exception("error"))
                 .build();
-        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
-                .configurationError(new Exception("error"))
-                .build();
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder().build();
 
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
@@ -289,15 +338,12 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void sendAnalyticsEvent_whenAnalyticsConfigurationNull_doesNothing() {
-        Configuration configuration = mock(Configuration.class);
-        when(configuration.isAnalyticsEnabled()).thenReturn(false);
-
+    public void sendAnalyticsEvent_whenConfigurationLoadFails_doesNothing() {
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
                 .authorization(authorization)
                 .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
-                .configuration(configuration)
+                .configurationError(new Exception("error"))
                 .build();
 
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -131,17 +131,6 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void getAuthorizationType_forwardsInvocationToAuthorizationLoader() {
-        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder().build();
-        when(authorizationLoader.getAuthorizationType()).thenReturn(AuthorizationType.CLIENT_TOKEN);
-
-        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
-        BraintreeClient sut = new BraintreeClient(params);
-
-        assertEquals(AuthorizationType.CLIENT_TOKEN, sut.getAuthorizationType());
-    }
-
-    @Test
     public void sendGET_onGetConfigurationSuccess_forwardsRequestToHttpClient() {
         Configuration configuration = mock(Configuration.class);
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -408,7 +408,7 @@ public class BraintreeClientUnitTest {
 
     private BraintreeClientParams createDefaultParams(ConfigurationLoader configurationLoader) {
         return new BraintreeClientParams()
-                .authorization(authorization)
+                .authorizationLoader(authorization)
                 .context(context)
                 .sessionId("session-id")
                 .setIntegrationType(IntegrationType.CUSTOM)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -41,6 +41,7 @@ public class BraintreeClientUnitTest {
     private BraintreeHttpClient braintreeHttpClient;
     private BraintreeGraphQLClient braintreeGraphQLClient;
     private ConfigurationLoader configurationLoader;
+    private AuthorizationLoader authorizationLoader;
     private AnalyticsClient analyticsClient;
     private ManifestValidator manifestValidator;
     private BrowserSwitchClient browserSwitchClient;
@@ -54,6 +55,7 @@ public class BraintreeClientUnitTest {
         braintreeHttpClient = mock(BraintreeHttpClient.class);
         braintreeGraphQLClient = mock(BraintreeGraphQLClient.class);
         configurationLoader = mock(ConfigurationLoader.class);
+        authorizationLoader = mock(AuthorizationLoader.class);
         analyticsClient = mock(AnalyticsClient.class);
         manifestValidator = mock(ManifestValidator.class);
         browserSwitchClient = mock(BrowserSwitchClient.class);
@@ -88,7 +90,10 @@ public class BraintreeClientUnitTest {
 
     @Test
     public void getConfiguration_onSuccess_forwardsInvocationToConfigurationLoader() {
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         ConfigurationCallback configurationCallback = mock(ConfigurationCallback.class);
@@ -100,27 +105,33 @@ public class BraintreeClientUnitTest {
     @Test
     public void sendGET_onGetConfigurationSuccess_forwardsRequestToHttpClient() {
         Configuration configuration = mock(Configuration.class);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendGET("sample-url", httpResponseCallback);
 
-        verify(braintreeHttpClient).get(eq("sample-url"), , , same(configuration), same(httpResponseCallback), );
+        verify(braintreeHttpClient).get(eq("sample-url"), same(configuration), same(authorization), same(httpResponseCallback));
     }
 
     @Test
     public void sendGET_onGetConfigurationFailure_forwardsErrorToCallback() {
         Exception exception = new Exception("configuration error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configurationError(exception)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
@@ -132,27 +143,33 @@ public class BraintreeClientUnitTest {
     @Test
     public void sendPOST_onGetConfigurationSuccess_forwardsRequestToHttpClient() {
         Configuration configuration = mock(Configuration.class);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendPOST("sample-url", "{}", httpResponseCallback);
 
-        verify(braintreeHttpClient).post(eq("sample-url"), eq("{}"), same(configuration), , same(httpResponseCallback), );
+        verify(braintreeHttpClient).post(eq("sample-url"), eq("{}"), same(configuration), same(authorization), same(httpResponseCallback));
     }
 
     @Test
     public void sendPOST_onGetConfigurationFailure_forwardsErrorToCallback() {
         Exception exception = new Exception("configuration error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configurationError(exception)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
@@ -164,27 +181,33 @@ public class BraintreeClientUnitTest {
     @Test
     public void sendGraphQLPOST_onGetConfigurationSuccess_forwardsRequestToHttpClient() {
         Configuration configuration = mock(Configuration.class);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendGraphQLPOST("{}", httpResponseCallback);
 
-        verify(braintreeGraphQLClient).post(eq("{}"), same(configuration), , same(httpResponseCallback));
+        verify(braintreeGraphQLClient).post(eq("{}"), same(configuration), same(authorization), same(httpResponseCallback));
     }
 
     @Test
     public void sendGraphQLPOST_onGetConfigurationFailure_forwardsErrorToCallback() {
         Exception exception = new Exception("configuration error");
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configurationError(exception)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
@@ -196,24 +219,30 @@ public class BraintreeClientUnitTest {
     @Test
     public void sendAnalyticsEvent_sendsEventToAnalyticsClient() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
         sut.sendAnalyticsEvent("event.started");
 
-        verify(analyticsClient).sendEvent(configuration, "event.started", "session-id", "custom", );
+        verify(analyticsClient).sendEvent(configuration, "event.started", "session-id", "custom", authorization);
     }
 
     @Test
     public void sendAnalyticsEvent_whenConfigurationLoadFails_doesNothing() {
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configurationError(new Exception("error"))
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
         sut.sendAnalyticsEvent("event.started");
 
@@ -224,11 +253,15 @@ public class BraintreeClientUnitTest {
     public void sendAnalyticsEvent_whenAnalyticsConfigurationNull_doesNothing() {
         Configuration configuration = mock(Configuration.class);
         when(configuration.isAnalyticsEnabled()).thenReturn(false);
+
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
         sut.sendAnalyticsEvent("event.started");
 
@@ -238,11 +271,14 @@ public class BraintreeClientUnitTest {
     @Test
     public void sendAnalyticsEvent_whenAnalyticsNotEnabled_doesNothing() throws JSONException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ANALYTICS);
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
         sut.sendAnalyticsEvent("event.started");
 
@@ -254,7 +290,7 @@ public class BraintreeClientUnitTest {
         FragmentActivity activity = mock(FragmentActivity.class);
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         sut.startBrowserSwitch(activity, browserSwitchOptions);
@@ -267,7 +303,7 @@ public class BraintreeClientUnitTest {
         BrowserSwitchResult browserSwitchResult = createSuccessfulBrowserSwitchResult();
         when(browserSwitchClient.getResult(activity)).thenReturn(browserSwitchResult);
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         assertSame(browserSwitchResult, sut.getBrowserSwitchResult(activity));
@@ -277,7 +313,7 @@ public class BraintreeClientUnitTest {
     public void deliverBrowserSwitchResult_forwardsInvocationToBrowserSwitchClient() {
         FragmentActivity activity = mock(FragmentActivity.class);
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         sut.deliverBrowserSwitchResult(activity);
@@ -286,7 +322,7 @@ public class BraintreeClientUnitTest {
 
     @Test
     public void canPerformBrowserSwitch_assertsBrowserSwitchIsPossible() throws BrowserSwitchException {
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         FragmentActivity activity = mock(FragmentActivity.class);
@@ -305,7 +341,7 @@ public class BraintreeClientUnitTest {
         FragmentActivity activity = mock(FragmentActivity.class);
         doNothing().when(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), any(BrowserSwitchOptions.class));
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         assertTrue(sut.canPerformBrowserSwitch(activity, 123));
@@ -316,7 +352,7 @@ public class BraintreeClientUnitTest {
         FragmentActivity activity = mock(FragmentActivity.class);
         doThrow(new BrowserSwitchException("error")).when(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), any(BrowserSwitchOptions.class));
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         sut.canPerformBrowserSwitch(activity, 123);
@@ -327,7 +363,7 @@ public class BraintreeClientUnitTest {
     public void isUrlSchemeDeclaredInAndroidManifest_forwardsInvocationToManifestValidator() {
         when(manifestValidator.isUrlSchemeDeclaredInAndroidManifest(applicationContext, "a-url-scheme", FragmentActivity.class)).thenReturn(true);
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         assertTrue(sut.isUrlSchemeDeclaredInAndroidManifest("a-url-scheme", FragmentActivity.class));
@@ -338,7 +374,7 @@ public class BraintreeClientUnitTest {
         ActivityInfo activityInfo = new ActivityInfo();
         when(manifestValidator.getActivityInfo(applicationContext, FragmentActivity.class)).thenReturn(activityInfo);
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         assertSame(activityInfo, sut.getManifestActivityInfo(FragmentActivity.class));
@@ -394,21 +430,23 @@ public class BraintreeClientUnitTest {
 
     @Test
     public void reportCrash_reportsCrashViaAnalyticsClient() throws JSONException {
+        when(authorizationLoader.getAuthorizationFromCache()).thenReturn(authorization);
+
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
 
-        BraintreeClientParams params = createDefaultParams(configurationLoader);
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         sut.reportCrash();
-        verify(analyticsClient).reportCrash(applicationContext, "session-id", IntegrationType.CUSTOM, );
+        verify(analyticsClient).reportCrash(applicationContext, "session-id", IntegrationType.CUSTOM, authorization);
     }
 
-    private BraintreeClientParams createDefaultParams(ConfigurationLoader configurationLoader) {
+    private BraintreeClientParams createDefaultParams(ConfigurationLoader configurationLoader, AuthorizationLoader authorizationLoader) {
         return new BraintreeClientParams()
-                .authorizationLoader(authorization)
+                .authorizationLoader(authorizationLoader)
                 .context(context)
                 .sessionId("session-id")
                 .setIntegrationType(IntegrationType.CUSTOM)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -204,7 +204,7 @@ public class BraintreeClientUnitTest {
         BraintreeClient sut = new BraintreeClient(params);
         sut.sendAnalyticsEvent("event.started");
 
-        verify(analyticsClient).sendEvent(configuration, "event.started", "session-id", "custom");
+        verify(analyticsClient).sendEvent(configuration, "event.started", "session-id", "custom", );
     }
 
     @Test
@@ -403,7 +403,7 @@ public class BraintreeClientUnitTest {
         BraintreeClient sut = new BraintreeClient(params);
 
         sut.reportCrash();
-        verify(analyticsClient).reportCrash(applicationContext, "session-id", IntegrationType.CUSTOM);
+        verify(analyticsClient).reportCrash(applicationContext, "session-id", IntegrationType.CUSTOM, );
     }
 
     private BraintreeClientParams createDefaultParams(ConfigurationLoader configurationLoader) {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -110,7 +110,7 @@ public class BraintreeClientUnitTest {
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendGET("sample-url", httpResponseCallback);
 
-        verify(braintreeHttpClient).get(eq("sample-url"), same(configuration), same(httpResponseCallback));
+        verify(braintreeHttpClient).get(eq("sample-url"), , , same(configuration), same(httpResponseCallback), );
     }
 
     @Test
@@ -142,7 +142,7 @@ public class BraintreeClientUnitTest {
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendPOST("sample-url", "{}", httpResponseCallback);
 
-        verify(braintreeHttpClient).post(eq("sample-url"), eq("{}"), same(configuration), same(httpResponseCallback));
+        verify(braintreeHttpClient).post(eq("sample-url"), eq("{}"), same(configuration), , same(httpResponseCallback), );
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -174,7 +174,7 @@ public class BraintreeClientUnitTest {
         HttpResponseCallback httpResponseCallback = mock(HttpResponseCallback.class);
         sut.sendGraphQLPOST("{}", httpResponseCallback);
 
-        verify(braintreeGraphQLClient).post(eq("{}"), same(configuration), same(httpResponseCallback));
+        verify(braintreeGraphQLClient).post(eq("{}"), same(configuration), , same(httpResponseCallback));
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeGraphQLClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeGraphQLClientUnitTest.java
@@ -42,7 +42,7 @@ public class BraintreeGraphQLClientUnitTest {
     @Test
     public void post_withPathAndDataAndConfigurationAndCallback_sendsHttpRequest() throws MalformedURLException, URISyntaxException {
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
-        sut.post("sample/path", "data", configuration, , httpResponseCallback);
+        sut.post("sample/path", "data", configuration, authorization, httpResponseCallback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(httpResponseCallback));
@@ -61,7 +61,7 @@ public class BraintreeGraphQLClientUnitTest {
     @Test
     public void post_withDataAndConfigurationAndCallback_sendsHttpRequest() throws MalformedURLException, URISyntaxException {
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
-        sut.post("data", configuration, , httpResponseCallback);
+        sut.post("data", configuration, authorization, httpResponseCallback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(httpResponseCallback));
@@ -82,7 +82,7 @@ public class BraintreeGraphQLClientUnitTest {
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample response");
 
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
-        String result = sut.post("sample/path", "data", configuration, );
+        String result = sut.post("sample/path", "data", configuration, authorization);
         assertEquals("sample response", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -104,7 +104,7 @@ public class BraintreeGraphQLClientUnitTest {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
-        sut.post("sample/path", "data", configuration, , httpResponseCallback);
+        sut.post("sample/path", "data", configuration, authorization, httpResponseCallback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(httpResponseCallback).onResult((String) isNull(), captor.capture());
@@ -118,7 +118,7 @@ public class BraintreeGraphQLClientUnitTest {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
-        sut.post("sample/path",  configuration, , httpResponseCallback);
+        sut.post("sample/path",  configuration, authorization, httpResponseCallback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(httpResponseCallback).onResult((String) isNull(), captor.capture());
@@ -134,7 +134,7 @@ public class BraintreeGraphQLClientUnitTest {
         BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
 
         try {
-            sut.post("sample/path", "data", configuration, );
+            sut.post("sample/path", "data", configuration, authorization);
         } catch (BraintreeException e) {
             assertEquals("token invalid", e.getMessage());
         }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeGraphQLClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeGraphQLClientUnitTest.java
@@ -41,8 +41,8 @@ public class BraintreeGraphQLClientUnitTest {
 
     @Test
     public void post_withPathAndDataAndConfigurationAndCallback_sendsHttpRequest() throws MalformedURLException, URISyntaxException {
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
-        sut.post("sample/path", "data", configuration, httpResponseCallback);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
+        sut.post("sample/path", "data", configuration, , httpResponseCallback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(httpResponseCallback));
@@ -60,8 +60,8 @@ public class BraintreeGraphQLClientUnitTest {
 
     @Test
     public void post_withDataAndConfigurationAndCallback_sendsHttpRequest() throws MalformedURLException, URISyntaxException {
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
-        sut.post("data", configuration, httpResponseCallback);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
+        sut.post("data", configuration, , httpResponseCallback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(httpResponseCallback));
@@ -81,8 +81,8 @@ public class BraintreeGraphQLClientUnitTest {
     public void post_withPathAndDataAndConfiguration_sendsHttpRequest() throws Exception {
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample response");
 
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
-        String result = sut.post("sample/path", "data", configuration);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
+        String result = sut.post("sample/path", "data", configuration, );
         assertEquals("sample response", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -103,8 +103,8 @@ public class BraintreeGraphQLClientUnitTest {
     public void post_withPathAndDataAndConfigurationAndCallback_withInvalidToken_forwardsExceptionToCallback() {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
-        sut.post("sample/path", "data", configuration, httpResponseCallback);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
+        sut.post("sample/path", "data", configuration, , httpResponseCallback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(httpResponseCallback).onResult((String) isNull(), captor.capture());
@@ -117,8 +117,8 @@ public class BraintreeGraphQLClientUnitTest {
     public void post_withDataAndConfigurationAndCallback_withInvalidToken_forwardsExceptionToCallback() {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
-        sut.post("sample/path",  configuration, httpResponseCallback);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
+        sut.post("sample/path",  configuration, , httpResponseCallback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(httpResponseCallback).onResult((String) isNull(), captor.capture());
@@ -131,10 +131,10 @@ public class BraintreeGraphQLClientUnitTest {
     public void post_withPathAndDataAndConfiguration_withInvalidToken_throwsBraintreeException() throws Exception {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
-        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(authorization, httpClient);
+        BraintreeGraphQLClient sut = new BraintreeGraphQLClient(httpClient);
 
         try {
-            sut.post("sample/path", "data", configuration);
+            sut.post("sample/path", "data", configuration, );
         } catch (BraintreeException e) {
             assertEquals("token invalid", e.getMessage());
         }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.java
@@ -40,10 +40,10 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withNullConfiguration_requiresRequiresRequestToHaveAnAbsolutePath() {
         Authorization tokenizationKey = mock(Authorization.class);
-        BraintreeHttpClient sut = new BraintreeHttpClient(tokenizationKey, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", null, callback);
+        sut.get("sample/path", , , null, callback, );
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -56,10 +56,10 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withNullConfigurationAndAbsoluteURL_doesNotSetABaseURLOnTheRequest() throws Exception {
         Authorization tokenizationKey = TokenizationKey.fromString(Fixtures.TOKENIZATION_KEY);
-        BraintreeHttpClient sut = new BraintreeHttpClient(tokenizationKey, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("https://example.com/sample/path", null, callback);
+        sut.get("https://example.com/sample/path", , , null, callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -71,13 +71,13 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withTokenizationKey_forwardsHttpRequestToHttpClient() throws MalformedURLException, URISyntaxException {
         Authorization tokenizationKey = TokenizationKey.fromString(Fixtures.TOKENIZATION_KEY);
-        BraintreeHttpClient sut = new BraintreeHttpClient(tokenizationKey, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", configuration, callback);
+        sut.get("sample/path", , , configuration, callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -93,13 +93,13 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withClientToken_forwardsHttpRequestToHttpClient() throws MalformedURLException, URISyntaxException {
         Authorization clientToken = Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", configuration, callback);
+        sut.get("sample/path", , , configuration, callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -116,13 +116,13 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withPayPalUAT_forwardsHttpRequestToHttpClient() throws MalformedURLException, URISyntaxException {
         Authorization payPalUAT = Authorization.fromString(Fixtures.BASE64_PAYPAL_UAT);
-        BraintreeHttpClient sut = new BraintreeHttpClient(payPalUAT, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", configuration, callback);
+        sut.get("sample/path", , , configuration, callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -139,11 +139,11 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void get_withInvalidToken_forwardsExceptionToCallback() {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
-        BraintreeHttpClient sut = new BraintreeHttpClient(authorization, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", configuration, callback);
+        sut.get("sample/path", , , configuration, callback, );
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -155,14 +155,14 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postSync_withTokenizationKey_forwardsHttpRequestToHttpClient() throws Exception {
         Authorization tokenizationKey = TokenizationKey.fromString(Fixtures.TOKENIZATION_KEY);
-        BraintreeHttpClient sut = new BraintreeHttpClient(tokenizationKey, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample result");
 
-        String result = sut.post("sample/path", "{}", configuration);
+        String result = sut.post("sample/path", "{}", configuration, );
         assertEquals("sample result", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -180,14 +180,14 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postSync_withClientToken_forwardsHttpRequestToHttpClient() throws Exception {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample result");
 
-        String result = sut.post("sample/path", "{}", configuration);
+        String result = sut.post("sample/path", "{}", configuration, );
         assertEquals("sample result", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -207,10 +207,10 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postSync_withNullConfiguration_andRelativeUrl_throwsError() {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         try {
-            sut.post("sample/path", "{}", null);
+            sut.post("sample/path", "{}", null, );
         } catch (Exception e) {
             assertTrue(e instanceof BraintreeException);
             assertEquals("Braintree HTTP GET request without configuration cannot have a relative path.", e.getMessage());
@@ -220,9 +220,9 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postSync_withNullConfiguration_andAbsoluteURL_doesNotSetABaseURLOnTheRequest() throws Exception {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
-        sut.post("https://example.com/sample/path", "{}", null);
+        sut.post("https://example.com/sample/path", "{}", null, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture());
@@ -234,11 +234,11 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postSync_withInvalidToken_throwsBraintreeException() {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
-        BraintreeHttpClient sut = new BraintreeHttpClient(authorization, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         try {
-            sut.post("https://example.com/sample/path", "{}", configuration);
+            sut.post("https://example.com/sample/path", "{}", configuration, );
         } catch (Exception e) {
             assertTrue(e instanceof BraintreeException);
             assertEquals("token invalid", e.getMessage());
@@ -248,13 +248,13 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postAsync_withTokenizationKey_forwardsHttpRequestToHttpClient() throws MalformedURLException, URISyntaxException {
         Authorization tokenizationKey = TokenizationKey.fromString(Fixtures.TOKENIZATION_KEY);
-        BraintreeHttpClient sut = new BraintreeHttpClient(tokenizationKey, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("sample/path", "{}", configuration, callback);
+        sut.post("sample/path", "{}", configuration, , callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -271,14 +271,14 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postAsync_withClientToken_forwardsHttpRequestToHttpClient() throws MalformedURLException, URISyntaxException {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
-        sut.post("sample/path", "{}", configuration, callback);
+        sut.post("sample/path", "{}", configuration, , callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -297,11 +297,11 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postAsync_withNullConfiguration_andRelativeUrl_postsCallbackError() {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
-        sut.post("sample/path", "{}", null, callback);
+        sut.post("sample/path", "{}", null, , callback, );
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -314,10 +314,10 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postAsync_withNullConfiguration_andAbsoluteURL_doesNotSetABaseURLOnTheRequest() throws Exception {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("https://example.com/sample/path", "{}", null, callback);
+        sut.post("https://example.com/sample/path", "{}", null, , callback, );
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -334,8 +334,8 @@ public class BraintreeHttpClientUnitTest {
         Authorization clientToken = Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
-        BraintreeHttpClient sut = new BraintreeHttpClient(clientToken, httpClient);
-        sut.post("sample/path", "not json", configuration, callback);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
+        sut.post("sample/path", "not json", configuration, , callback, );
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -349,11 +349,11 @@ public class BraintreeHttpClientUnitTest {
     @Test
     public void postAsync_withInvalidToken_forwardsExceptionToCallback() {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
-        BraintreeHttpClient sut = new BraintreeHttpClient(authorization, httpClient);
+        BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         Configuration configuration = mock(Configuration.class);
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("sample/path", "{}", configuration, callback);
+        sut.post("sample/path", "{}", configuration, , callback, );
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(callback).onResult((String) isNull(), captor.capture());

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.java
@@ -43,7 +43,7 @@ public class BraintreeHttpClientUnitTest {
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", , , null, callback, );
+        sut.get("sample/path", null, tokenizationKey, callback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -59,7 +59,7 @@ public class BraintreeHttpClientUnitTest {
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("https://example.com/sample/path", , , null, callback, );
+        sut.get("https://example.com/sample/path", null, tokenizationKey, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -77,7 +77,7 @@ public class BraintreeHttpClientUnitTest {
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", , , configuration, callback, );
+        sut.get("sample/path", configuration, tokenizationKey, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -99,7 +99,7 @@ public class BraintreeHttpClientUnitTest {
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", , , configuration, callback, );
+        sut.get("sample/path", configuration, clientToken, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -122,7 +122,7 @@ public class BraintreeHttpClientUnitTest {
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", , , configuration, callback, );
+        sut.get("sample/path", configuration, payPalUAT, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), eq(HttpClient.NO_RETRY), same(callback));
@@ -143,7 +143,7 @@ public class BraintreeHttpClientUnitTest {
 
         Configuration configuration = mock(Configuration.class);
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.get("sample/path", , , configuration, callback, );
+        sut.get("sample/path",configuration, authorization, callback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -162,7 +162,7 @@ public class BraintreeHttpClientUnitTest {
 
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample result");
 
-        String result = sut.post("sample/path", "{}", configuration, );
+        String result = sut.post("sample/path", "{}", configuration, tokenizationKey);
         assertEquals("sample result", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -187,7 +187,7 @@ public class BraintreeHttpClientUnitTest {
 
         when(httpClient.sendRequest(any(HttpRequest.class))).thenReturn("sample result");
 
-        String result = sut.post("sample/path", "{}", configuration, );
+        String result = sut.post("sample/path", "{}", configuration, clientToken);
         assertEquals("sample result", result);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
@@ -210,7 +210,7 @@ public class BraintreeHttpClientUnitTest {
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         try {
-            sut.post("sample/path", "{}", null, );
+            sut.post("sample/path", "{}", null, clientToken);
         } catch (Exception e) {
             assertTrue(e instanceof BraintreeException);
             assertEquals("Braintree HTTP GET request without configuration cannot have a relative path.", e.getMessage());
@@ -222,7 +222,7 @@ public class BraintreeHttpClientUnitTest {
         ClientToken clientToken = (ClientToken) Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN));
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
-        sut.post("https://example.com/sample/path", "{}", null, );
+        sut.post("https://example.com/sample/path", "{}", null, clientToken);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture());
@@ -238,7 +238,7 @@ public class BraintreeHttpClientUnitTest {
 
         Configuration configuration = mock(Configuration.class);
         try {
-            sut.post("https://example.com/sample/path", "{}", configuration, );
+            sut.post("https://example.com/sample/path", "{}", configuration, authorization);
         } catch (Exception e) {
             assertTrue(e instanceof BraintreeException);
             assertEquals("token invalid", e.getMessage());
@@ -254,7 +254,7 @@ public class BraintreeHttpClientUnitTest {
         when(configuration.getClientApiUrl()).thenReturn("https://example.com");
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("sample/path", "{}", configuration, , callback, );
+        sut.post("sample/path", "{}", configuration, tokenizationKey, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -278,7 +278,7 @@ public class BraintreeHttpClientUnitTest {
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
-        sut.post("sample/path", "{}", configuration, , callback, );
+        sut.post("sample/path", "{}", configuration, clientToken, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -301,7 +301,7 @@ public class BraintreeHttpClientUnitTest {
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
-        sut.post("sample/path", "{}", null, , callback, );
+        sut.post("sample/path", "{}", null, clientToken, callback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -317,7 +317,7 @@ public class BraintreeHttpClientUnitTest {
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
 
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("https://example.com/sample/path", "{}", null, , callback, );
+        sut.post("https://example.com/sample/path", "{}", null, clientToken, callback);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).sendRequest(captor.capture(), same(callback));
@@ -335,7 +335,7 @@ public class BraintreeHttpClientUnitTest {
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
 
         BraintreeHttpClient sut = new BraintreeHttpClient(httpClient);
-        sut.post("sample/path", "not json", configuration, , callback, );
+        sut.post("sample/path", "not json", configuration, clientToken, callback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult((String) isNull(), captor.capture());
@@ -353,7 +353,7 @@ public class BraintreeHttpClientUnitTest {
 
         Configuration configuration = mock(Configuration.class);
         HttpResponseCallback callback = mock(HttpResponseCallback.class);
-        sut.post("sample/path", "{}", configuration, , callback, );
+        sut.post("sample/path", "{}", configuration, authorization, callback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(callback).onResult((String) isNull(), captor.capture());

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -56,7 +56,7 @@ public class ConfigurationLoaderUnitTest {
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
 
-        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
+        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, null);
@@ -75,7 +75,7 @@ public class ConfigurationLoaderUnitTest {
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
 
-        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
+        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, null);
@@ -92,7 +92,7 @@ public class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(context, authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
-        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
+        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult("not json", null);
@@ -108,7 +108,7 @@ public class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(context, authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> httpResponseCaptor = ArgumentCaptor.forClass(HttpResponseCallback.class);
-        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), eq(HttpClient.RETRY_MAX_3_TIMES), httpResponseCaptor.capture());
+        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), httpResponseCaptor.capture(), );
 
         HttpResponseCallback httpResponseCallback = httpResponseCaptor.getValue();
         Exception httpError = new Exception("http error");
@@ -148,7 +148,7 @@ public class ConfigurationLoaderUnitTest {
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
         sut.loadConfiguration(context, authorization, callback);
 
-        verify(braintreeHttpClient, times(0)).get(anyString(), (Configuration) isNull(), anyInt(), any(HttpResponseCallback.class));
+        verify(braintreeHttpClient, times(0)).get(anyString(), (Configuration) isNull(), , anyInt(), any(HttpResponseCallback.class), );
         verify(callback).onResult(any(Configuration.class), (Exception) isNull());
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -56,7 +56,7 @@ public class ConfigurationLoaderUnitTest {
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
 
-        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
+        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, null);
@@ -75,7 +75,7 @@ public class ConfigurationLoaderUnitTest {
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
 
-        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
+        verify(braintreeHttpClient).get(eq(expectedConfigUrl), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, null);
@@ -92,7 +92,7 @@ public class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(context, authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
-        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture(), );
+        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
 
         HttpResponseCallback httpResponseCallback = captor.getValue();
         httpResponseCallback.onResult("not json", null);
@@ -108,7 +108,7 @@ public class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(context, authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> httpResponseCaptor = ArgumentCaptor.forClass(HttpResponseCallback.class);
-        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), , eq(HttpClient.RETRY_MAX_3_TIMES), httpResponseCaptor.capture(), );
+        verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), httpResponseCaptor.capture());
 
         HttpResponseCallback httpResponseCallback = httpResponseCaptor.getValue();
         Exception httpError = new Exception("http error");
@@ -148,7 +148,7 @@ public class ConfigurationLoaderUnitTest {
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
         sut.loadConfiguration(context, authorization, callback);
 
-        verify(braintreeHttpClient, times(0)).get(anyString(), (Configuration) isNull(), , anyInt(), any(HttpResponseCallback.class), );
+        verify(braintreeHttpClient, times(0)).get(anyString(), (Configuration) isNull(), same(authorization), anyInt(), any(HttpResponseCallback.class));
         verify(callback).onResult(any(Configuration.class), (Exception) isNull());
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+* Core
+  * Add `ClientTokenProvider` interface
+  * Add `ClientTokenCallback` interface
+  * Add BraintreeClient constructors that accept a `ClientTokenProvider`
+
 ## 4.8.1
 
 * GooglePay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
+
 * Core
   * Add `ClientTokenProvider` interface
   * Add `ClientTokenCallback` interface
-  * Add BraintreeClient constructors that accept a `ClientTokenProvider`
+  * Add `BraintreeClient` constructors that accept a `ClientTokenProvider`
 
 ## 4.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## unreleased
 
 * Core
-  * Add `ClientTokenProvider` interface
+  * Add `AuthorizationProvider` interface
   * Add `ClientTokenCallback` interface
-  * Add `BraintreeClient` constructors that accept a `ClientTokenProvider`
+  * Add `BraintreeClient` constructors that accept a `AuthorizationProvider`
 
 ## 4.8.1
 

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/ThreeDSecureVerificationTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/ThreeDSecureVerificationTest.java
@@ -35,16 +35,16 @@ public class ThreeDSecureVerificationTest extends TestHelper {
     @Before
     public void setup() {
         super.setup();
-        onDevice(withText("Credit or Debit Cards")).waitForEnabled().perform(click());
-
         PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
                 .edit()
                 .putBoolean("enable_three_d_secure", true)
                 .commit();
+        onDevice(withText("Credit or Debit Cards")).waitForEnabled().perform(click());
     }
 
     @Test(timeout = 40000)
     public void threeDSecure_authenticates() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -63,6 +63,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_authenticationFailed() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_AUTHENTICATION_FAILED));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -109,6 +110,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenSignatureVerificationFails_returnsAFailedAuthentication() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_SIGNATURE_VERIFICATION_FAILURE));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CID")).perform(setText("1234"));
@@ -122,6 +124,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenRequired_requestsAuthentication() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -141,6 +144,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenCardinalReturnsError_returnsAnError() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_MPI_SERVICE_ERROR));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -154,6 +158,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenWebViewIsClosed_callsCancelListener() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -168,6 +173,7 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenBackIsPressed_callsCancelListener() {
+        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/ThreeDSecureVerificationTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/ThreeDSecureVerificationTest.java
@@ -44,7 +44,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_authenticates() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -63,7 +62,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_authenticationFailed() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_AUTHENTICATION_FAILED));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -110,7 +108,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenSignatureVerificationFails_returnsAFailedAuthentication() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_SIGNATURE_VERIFICATION_FAILURE));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CID")).perform(setText("1234"));
@@ -124,7 +121,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenRequired_requestsAuthentication() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -144,7 +140,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenCardinalReturnsError_returnsAnError() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_MPI_SERVICE_ERROR));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -158,7 +153,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenWebViewIsClosed_callsCancelListener() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));
@@ -173,7 +167,6 @@ public class ThreeDSecureVerificationTest extends TestHelper {
 
     @Test(timeout = 40000)
     public void threeDSecure_whenBackIsPressed_callsCancelListener() {
-        // fails
         onDevice(withText("Card Number")).perform(setText(THREE_D_SECURE_VERIFICATON));
         onDevice(withText("Expiration Date")).perform(setText(validExpirationText()));
         onDevice(withText("CVV")).perform(setText("123"));

--- a/Demo/src/main/java/com/braintreepayments/InitializeFeatureClientsCallback.java
+++ b/Demo/src/main/java/com/braintreepayments/InitializeFeatureClientsCallback.java
@@ -1,7 +1,0 @@
-package com.braintreepayments;
-
-import androidx.annotation.Nullable;
-
-public interface InitializeFeatureClientsCallback {
-    void onResult(@Nullable Exception error);
-}

--- a/Demo/src/main/java/com/braintreepayments/demo/BaseFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/BaseFragment.java
@@ -6,6 +6,7 @@ import androidx.annotation.CallSuper;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import com.braintreepayments.api.BraintreeClient;
 import com.braintreepayments.api.PaymentMethodNonce;
 
 public abstract class BaseFragment extends Fragment {
@@ -46,10 +47,11 @@ public abstract class BaseFragment extends Fragment {
         }
     }
 
-    protected void getBraintreeClient(BraintreeClientCallback callback) {
+    protected BraintreeClient getBraintreeClient() {
         DemoActivity demoActivity = getDemoActivity();
         if (demoActivity != null) {
-            demoActivity.getBraintreeClient(callback);
+            return demoActivity.getBraintreeClient();
         }
+        return null;
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -20,8 +20,6 @@ import androidx.navigation.fragment.NavHostFragment;
 import com.braintreepayments.api.AmericanExpressClient;
 import com.braintreepayments.api.AmericanExpressRewardsBalance;
 import com.braintreepayments.api.BraintreeClient;
-import com.braintreepayments.api.Configuration;
-import com.braintreepayments.api.ConfigurationCallback;
 import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.BrowserSwitchResult;
 import com.braintreepayments.api.Card;
@@ -76,6 +74,8 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
     private UnionPayClient unionPayClient;
     private DataCollector dataCollector;
 
+    private String cardFormActionLabel;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -84,6 +84,8 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         cardForm = view.findViewById(R.id.card_form);
         cardForm.setOnFormFieldFocusedListener(this);
         cardForm.setOnCardFormSubmitListener(this);
+
+        cardFormActionLabel = getString(R.string.purchase);
 
         smsCodeContainer = view.findViewById(R.id.sms_code_container);
         smsCode = view.findViewById(R.id.sms_code);
@@ -126,7 +128,6 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         super.onResume();
         safelyCloseLoadingView();
 
-        // initializing clients checks if union pay is enabled
         initializeFeatureClients();
     }
 
@@ -150,6 +151,8 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         autofillButton.setEnabled(true);
 
         final AppCompatActivity activity = (AppCompatActivity) getActivity();
+
+        // check if union pay is enabled
         braintreeClient.getConfiguration((configuration, configError) -> {
             if (configuration != null) {
                 cardForm.cardRequired(true)
@@ -157,7 +160,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
                         .cvvRequired(configuration.isCvvChallengePresent())
                         .postalCodeRequired(configuration.isPostalCodeChallengePresent())
                         .mobileNumberRequired(false)
-                        .actionLabel(getString(R.string.purchase))
+                        .actionLabel(cardFormActionLabel)
                         .setup(activity);
 
                 if (getArguments().getBoolean(MainFragment.EXTRA_COLLECT_DEVICE_DATA, false)) {
@@ -210,8 +213,8 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         smsCode.setText("");
 
         BraintreeClient braintreeClient = getBraintreeClient();
-
         final AppCompatActivity activity = (AppCompatActivity) getActivity();
+
         braintreeClient.getConfiguration((configuration, error) -> {
             if (capabilities.isUnionPay()) {
                 if (!capabilities.isSupported()) {
@@ -226,7 +229,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
                         .cvvRequired(true)
                         .postalCodeRequired(configuration.isPostalCodeChallengePresent())
                         .mobileNumberRequired(true)
-                        .actionLabel(getString(R.string.purchase))
+                        .actionLabel(cardFormActionLabel)
                         .setup(activity);
 
                 sendSmsButton.setVisibility(VISIBLE);
@@ -238,7 +241,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
                         .cvvRequired(configuration.isCvvChallengePresent())
                         .postalCodeRequired(configuration.isPostalCodeChallengePresent())
                         .mobileNumberRequired(false)
-                        .actionLabel(getString(R.string.purchase))
+                        .actionLabel(cardFormActionLabel)
                         .setup(activity);
 
                 if (!configuration.isCvvChallengePresent()) {

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -37,7 +37,7 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
     private static final String EXTRA_CUSTOMER_ID = "com.braintreepayments.demo.EXTRA_CUSTOMER_ID";
 
     private BraintreeClient braintreeClient;
-    private DemoAuthorizationProvider authProvider;
+    private DemoClientTokenProvider authProvider;
 
     private AppBarConfiguration appBarConfiguration;
 
@@ -51,7 +51,7 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         setContentView(R.layout.activity_demo);
 
-        authProvider = new DemoAuthorizationProvider();
+        authProvider = new DemoClientTokenProvider();
         if (savedInstanceState != null) {
             authorization = savedInstanceState.getString(EXTRA_AUTHORIZATION);
             customerId = savedInstanceState.getString(EXTRA_CUSTOMER_ID);

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -2,10 +2,8 @@ package com.braintreepayments.demo;
 
 import android.app.AlertDialog;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.Window;
@@ -74,7 +72,7 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
                 braintreeClient = new BraintreeClient(this, tokenizationKey);
             } else {
                 braintreeClient =
-                        new BraintreeClient(this, new DemoClientTokenProvider(this));
+                        new BraintreeClient(this, new DemoAuthorizationProvider(this));
             }
         }
         return braintreeClient;

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -2,6 +2,7 @@ package com.braintreepayments.demo;
 
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -46,6 +47,10 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
 
         setupActionBar();
         setProgressBarIndeterminateVisibility(true);
+
+        // perform reset on preference change
+        Settings.getPreferences(this)
+                .registerOnSharedPreferenceChangeListener((sharedPreferences, s) -> performReset());
 
         viewModel = new ViewModelProvider(this).get(DemoViewModel.class);
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoAuthorizationProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoAuthorizationProvider.java
@@ -6,14 +6,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import com.braintreepayments.api.ClientTokenCallback;
-import com.braintreepayments.api.ClientTokenProvider;
+import com.braintreepayments.api.AuthorizationProvider;
 
-public class DemoClientTokenProvider implements ClientTokenProvider {
+public class DemoAuthorizationProvider implements AuthorizationProvider {
 
     private final Merchant merchant;
     private final Context appContext;
 
-    public DemoClientTokenProvider(Context context) {
+    public DemoAuthorizationProvider(Context context) {
         merchant = new Merchant();
         appContext = context.getApplicationContext();
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -3,7 +3,6 @@ package com.braintreepayments.demo;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.braintreepayments.api.ClientTokenCallback;

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
-import com.braintreepayments.FetchAuthorizationCallback;
 import com.braintreepayments.api.ClientTokenCallback;
 import com.braintreepayments.api.ClientTokenProvider;
 
@@ -26,50 +25,20 @@ public class DemoClientTokenProvider implements ClientTokenProvider {
         if (authType.equals(getString(appContext, R.string.paypal_uat))) {
             // NOTE: - The PP UAT is fetched from the PPCP sample server
             //       - The only feature that currently works with a PP UAT is Card Tokenization.
-            merchant.fetchPayPalUAT(new FetchPayPalUATCallback() {
-                @Override
-                public void onResult(@Nullable String payPalUAT, @Nullable Exception error) {
-                    if (payPalUAT != null) {
-                        callback.onSuccess(payPalUAT);
-                    } else if (error != null) {
-                        callback.onFailure(error);
-                    }
+            merchant.fetchPayPalUAT((payPalUAT, error) -> {
+                if (payPalUAT != null) {
+                    callback.onSuccess(payPalUAT);
+                } else if (error != null) {
+                    callback.onFailure(error);
                 }
             });
 
         } else if (authType.equals(getString(appContext, R.string.client_token))) {
-            merchant.fetchClientToken(appContext, new FetchClientTokenCallback() {
-                @Override
-                public void onResult(@Nullable String clientToken, @Nullable Exception error) {
-                    if (clientToken != null) {
-                        callback.onSuccess(clientToken);
-                    } else if (error != null) {
-                        callback.onFailure(error);
-                    }
-                }
-            });
-        }
-    }
-
-    public void fetchAuthorization(Context context, final FetchAuthorizationCallback callback) {
-        String authType = Settings.getAuthorizationType(context);
-        if (authType.equals(getString(context, R.string.tokenization_key))) {
-            callback.onResult(Settings.getTokenizationKey(context), null);
-        } else if (authType.equals(getString(context, R.string.paypal_uat))) {
-            // NOTE: - The PP UAT is fetched from the PPCP sample server
-            //       - The only feature that currently works with a PP UAT is Card Tokenization.
-            merchant.fetchPayPalUAT(new FetchPayPalUATCallback() {
-                @Override
-                public void onResult(@Nullable String payPalUAT, @Nullable Exception error) {
-                    callback.onResult(payPalUAT, error);
-                }
-            });
-
-        } else if (authType.equals(getString(context, R.string.client_token))) {
-            merchant.fetchClientToken(context, new FetchClientTokenCallback() {
-                @Override
-                public void onResult(@Nullable String clientToken, @Nullable Exception error) {
-                    callback.onResult(clientToken, error);
+            merchant.fetchClientToken(appContext, (clientToken, error) -> {
+                if (clientToken != null) {
+                    callback.onSuccess(clientToken);
+                } else if (error != null) {
+                    callback.onFailure(error);
                 }
             });
         }

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -7,11 +7,11 @@ import androidx.annotation.StringRes;
 
 import com.braintreepayments.FetchAuthorizationCallback;
 
-public class DemoAuthorizationProvider {
+public class DemoClientTokenProvider {
 
     private final Merchant merchant;
 
-    public DemoAuthorizationProvider() {
+    public DemoClientTokenProvider() {
         merchant = new Merchant();
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -2,17 +2,53 @@ package com.braintreepayments.demo;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.braintreepayments.FetchAuthorizationCallback;
+import com.braintreepayments.api.ClientTokenCallback;
+import com.braintreepayments.api.ClientTokenProvider;
 
-public class DemoClientTokenProvider {
+public class DemoClientTokenProvider implements ClientTokenProvider {
 
     private final Merchant merchant;
+    private final Context appContext;
 
-    public DemoClientTokenProvider() {
+    public DemoClientTokenProvider(Context context) {
         merchant = new Merchant();
+        appContext = context.getApplicationContext();
+    }
+
+    @Override
+    public void getClientToken(@NonNull ClientTokenCallback callback) {
+        String authType = Settings.getAuthorizationType(appContext);
+        if (authType.equals(getString(appContext, R.string.paypal_uat))) {
+            // NOTE: - The PP UAT is fetched from the PPCP sample server
+            //       - The only feature that currently works with a PP UAT is Card Tokenization.
+            merchant.fetchPayPalUAT(new FetchPayPalUATCallback() {
+                @Override
+                public void onResult(@Nullable String payPalUAT, @Nullable Exception error) {
+                    if (payPalUAT != null) {
+                        callback.onSuccess(payPalUAT);
+                    } else if (error != null) {
+                        callback.onFailure(error);
+                    }
+                }
+            });
+
+        } else if (authType.equals(getString(appContext, R.string.client_token))) {
+            merchant.fetchClientToken(appContext, new FetchClientTokenCallback() {
+                @Override
+                public void onResult(@Nullable String clientToken, @Nullable Exception error) {
+                    if (clientToken != null) {
+                        callback.onSuccess(clientToken);
+                    } else if (error != null) {
+                        callback.onFailure(error);
+                    }
+                }
+            });
+        }
     }
 
     public void fetchAuthorization(Context context, final FetchAuthorizationCallback callback) {

--- a/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavDirections;
 import androidx.navigation.fragment.NavHostFragment;
 
+import com.braintreepayments.api.BraintreeClient;
 import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.GooglePayCapabilities;
 import com.braintreepayments.api.GooglePayClient;
@@ -43,32 +44,30 @@ public class GooglePayFragment extends BaseFragment {
     @Override
     public void onResume() {
         super.onResume();
-        getBraintreeClient(braintreeClient -> {
+        BraintreeClient braintreeClient = getBraintreeClient();
+        googlePayClient = new GooglePayClient(braintreeClient);
 
-            googlePayClient = new GooglePayClient(braintreeClient);
+        braintreeClient.getConfiguration((configuration, error) -> {
+            if (configuration == null) {
+                return;
+            }
 
-            braintreeClient.getConfiguration((configuration, error) -> {
-                if (configuration == null) {
-                    return;
-                }
+            if (GooglePayCapabilities.isGooglePayEnabled(getActivity(), configuration)) {
 
-                if (GooglePayCapabilities.isGooglePayEnabled(getActivity(), configuration)) {
-
-                    googlePayClient.isReadyToPay(getActivity(), (isReadyToPay, e) -> {
-                        if (isReadyToPay) {
-                            googlePayButton.setVisibility(View.VISIBLE);
-                        } else {
-                            showDialog("Google Payments are not available. The following issues could be the cause:\n\n" +
-                                    "No user is logged in to the device.\n\n" +
-                                    "Google Play Services is missing or out of date.");
-                        }
-                    });
-                } else {
-                    showDialog("Google Payments are not available. The following issues could be the cause:\n\n" +
-                            "Google Payments are not enabled for the current merchant.\n\n" +
-                            "Google Play Services is missing or out of date.");
-                }
-            });
+                googlePayClient.isReadyToPay(getActivity(), (isReadyToPay, e) -> {
+                    if (isReadyToPay) {
+                        googlePayButton.setVisibility(View.VISIBLE);
+                    } else {
+                        showDialog("Google Payments are not available. The following issues could be the cause:\n\n" +
+                                "No user is logged in to the device.\n\n" +
+                                "Google Play Services is missing or out of date.");
+                    }
+                });
+            } else {
+                showDialog("Google Payments are not available. The following issues could be the cause:\n\n" +
+                        "Google Payments are not enabled for the current merchant.\n\n" +
+                        "Google Play Services is missing or out of date.");
+            }
         });
     }
 
@@ -85,28 +84,27 @@ public class GooglePayFragment extends BaseFragment {
     public void launchGooglePay(View v) {
         FragmentActivity activity = getActivity();
         activity.setProgressBarIndeterminateVisibility(true);
-        getBraintreeClient(braintreeClient -> {
-            GooglePayRequest googlePayRequest = new GooglePayRequest();
-                    googlePayRequest.setTransactionInfo(TransactionInfo.newBuilder()
-                            .setCurrencyCode(Settings.getGooglePayCurrency(activity))
-                            .setTotalPrice("1.00")
-                            .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
-                            .build());
-                    googlePayRequest.setAllowPrepaidCards(Settings.areGooglePayPrepaidCardsAllowed(activity));
-                    googlePayRequest.setBillingAddressFormat(WalletConstants.BILLING_ADDRESS_FORMAT_FULL);
-                    googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
-                    googlePayRequest.setEmailRequired(Settings.isGooglePayEmailRequired(activity));
-                    googlePayRequest.setPhoneNumberRequired(Settings.isGooglePayPhoneNumberRequired(activity));
-                    googlePayRequest.setShippingAddressRequired(Settings.isGooglePayShippingAddressRequired(activity));
-                    googlePayRequest.setShippingAddressRequirements(ShippingAddressRequirements.newBuilder()
-                            .addAllowedCountryCodes(Settings.getGooglePayAllowedCountriesForShipping(activity))
-                            .build());
 
-            googlePayClient.requestPayment(getActivity(), googlePayRequest, (requestPaymentError) -> {
-                if (requestPaymentError != null) {
-                    handleError(requestPaymentError);
-                }
-            });
+        GooglePayRequest googlePayRequest = new GooglePayRequest();
+        googlePayRequest.setTransactionInfo(TransactionInfo.newBuilder()
+                .setCurrencyCode(Settings.getGooglePayCurrency(activity))
+                .setTotalPrice("1.00")
+                .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
+                .build());
+        googlePayRequest.setAllowPrepaidCards(Settings.areGooglePayPrepaidCardsAllowed(activity));
+        googlePayRequest.setBillingAddressFormat(WalletConstants.BILLING_ADDRESS_FORMAT_FULL);
+        googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
+        googlePayRequest.setEmailRequired(Settings.isGooglePayEmailRequired(activity));
+        googlePayRequest.setPhoneNumberRequired(Settings.isGooglePayPhoneNumberRequired(activity));
+        googlePayRequest.setShippingAddressRequired(Settings.isGooglePayShippingAddressRequired(activity));
+        googlePayRequest.setShippingAddressRequirements(ShippingAddressRequirements.newBuilder()
+                .addAllowedCountryCodes(Settings.getGooglePayAllowedCountriesForShipping(activity))
+                .build());
+
+        googlePayClient.requestPayment(getActivity(), googlePayRequest, (requestPaymentError) -> {
+            if (requestPaymentError != null) {
+                handleError(requestPaymentError);
+            }
         });
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/PreferredPaymentMethodsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PreferredPaymentMethodsFragment.java
@@ -35,7 +35,7 @@ public class PreferredPaymentMethodsFragment extends BaseFragment {
     private PreferredPaymentMethodsClient preferredPaymentMethodsClient;
 
     @Override
-    public void onCreate(@Nullable @org.jetbrains.annotations.Nullable Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         BraintreeClient braintreeClient = getBraintreeClient();

--- a/Demo/src/main/java/com/braintreepayments/demo/SamsungPayFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/SamsungPayFragment.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.navigation.NavDirections;
 import androidx.navigation.fragment.NavHostFragment;
 
+import com.braintreepayments.api.BraintreeClient;
 import com.braintreepayments.api.SamsungPayClient;
 import com.braintreepayments.api.SamsungPayError;
 import com.braintreepayments.api.SamsungPayException;
@@ -43,10 +44,9 @@ public class SamsungPayFragment extends BaseFragment implements SamsungPayListen
     @Override
     public void onResume() {
         super.onResume();
-        getBraintreeClient(braintreeClient -> {
-            samsungPayClient = new SamsungPayClient(braintreeClient);
-            setupSamsungPayButton();
-        });
+        BraintreeClient braintreeClient = getBraintreeClient();
+        samsungPayClient = new SamsungPayClient(braintreeClient);
+        setupSamsungPayButton();
     }
 
     private void setupSamsungPayButton() {

--- a/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
@@ -15,14 +15,12 @@ import androidx.navigation.NavDirections;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.braintreepayments.api.BraintreeClient;
-import com.braintreepayments.api.Configuration;
-import com.braintreepayments.api.ConfigurationCallback;
 import com.braintreepayments.api.VenmoAccountNonce;
-import com.braintreepayments.api.VenmoPaymentMethodUsage;
-import com.braintreepayments.api.VenmoTokenizeAccountCallback;
 import com.braintreepayments.api.VenmoClient;
 import com.braintreepayments.api.VenmoOnActivityResultCallback;
+import com.braintreepayments.api.VenmoPaymentMethodUsage;
 import com.braintreepayments.api.VenmoRequest;
+import com.braintreepayments.api.VenmoTokenizeAccountCallback;
 
 public class VenmoFragment extends BaseFragment {
 
@@ -72,36 +70,27 @@ public class VenmoFragment extends BaseFragment {
         boolean shouldVault =
                 Settings.vaultVenmo(activity) && !TextUtils.isEmpty(Settings.getCustomerId(activity));
 
-        getBraintreeClient(new BraintreeClientCallback() {
-            @Override
-            public void onResult(@Nullable BraintreeClient braintreeClient) {
-                if (braintreeClient != null) {
-                    venmoClient = new VenmoClient(braintreeClient);
+        BraintreeClient braintreeClient = getBraintreeClient();
+        venmoClient = new VenmoClient(braintreeClient);
 
-                    braintreeClient.getConfiguration(new ConfigurationCallback() {
-                        @Override
-                        public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
-                            if (venmoClient.isVenmoAppSwitchAvailable(activity)) {
-                                VenmoRequest venmoRequest = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
-                                venmoRequest.setProfileId(null);
-                                venmoRequest.setShouldVault(shouldVault);
+        braintreeClient.getConfiguration((configuration, error) -> {
+            if (venmoClient.isVenmoAppSwitchAvailable(activity)) {
+                VenmoRequest venmoRequest = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
+                venmoRequest.setProfileId(null);
+                venmoRequest.setShouldVault(shouldVault);
 
-                                venmoClient.tokenizeVenmoAccount(activity, venmoRequest, new VenmoTokenizeAccountCallback() {
-                                    @Override
-                                    public void onResult(Exception error) {
-                                        if (error != null) {
-                                            handleError(error);
-                                        }
-                                    }
-                                });
-                            } else if (configuration.isVenmoEnabled()) {
-                                showDialog("Please install the Venmo app first.");
-                            } else {
-                                showDialog("Venmo is not enabled for the current merchant.");
-                            }
+                venmoClient.tokenizeVenmoAccount(activity, venmoRequest, new VenmoTokenizeAccountCallback() {
+                    @Override
+                    public void onResult(Exception error) {
+                        if (error != null) {
+                            handleError(error);
                         }
-                    });
-                }
+                    }
+                });
+            } else if (configuration.isVenmoEnabled()) {
+                showDialog("Please install the Venmo app first.");
+            } else {
+                showDialog("Venmo is not enabled for the current merchant.");
             }
         });
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/VisaCheckoutFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VisaCheckoutFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.navigation.fragment.NavHostFragment;
 
+import com.braintreepayments.api.BraintreeClient;
 import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.VisaCheckoutClient;
 import com.visa.checkout.CheckoutButton;
@@ -30,15 +31,14 @@ public class VisaCheckoutFragment extends BaseFragment {
         View view = inflater.inflate(R.layout.fragment_visa_checkout, container, false);
         checkoutButton = view.findViewById(R.id.visa_checkout_button);
 
-        getBraintreeClient(braintreeClient -> {
-            visaCheckoutClient = new VisaCheckoutClient(braintreeClient);
-            visaCheckoutClient.createProfileBuilder((profileBuilder, error) -> {
-                if (profileBuilder != null) {
-                    setupVisaCheckoutButton(profileBuilder);
-                } else {
-                    handleError(error);
-                }
-            });
+        BraintreeClient braintreeClient = getBraintreeClient();
+        visaCheckoutClient = new VisaCheckoutClient(braintreeClient);
+        visaCheckoutClient.createProfileBuilder((profileBuilder, error) -> {
+            if (profileBuilder != null) {
+                setupVisaCheckoutButton(profileBuilder);
+            } else {
+                handleError(error);
+            }
         });
         return view;
     }

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -301,7 +301,8 @@ public class GooglePayClient {
                 .addParameter("braintree:sdkVersion", version)
                 .addParameter("braintree:metadata", metadata.toString());
 
-        if (braintreeClient.getAuthorization() instanceof TokenizationKey) {
+        if (braintreeClient.getAuthorizationType() == AuthorizationType.TOKENIZATION_KEY) {
+            // TODO: call async getAuthorization here
             parameters.addParameter("braintree:clientKey", braintreeClient.getAuthorization().getBearer());
         }
 
@@ -443,7 +444,8 @@ public class GooglePayClient {
                             .put("version", googlePayVersion)
                             .put("platform", "android")).toString());
 
-            if (braintreeClient.getAuthorization() instanceof TokenizationKey) {
+            if (braintreeClient.getAuthorizationType() == AuthorizationType.TOKENIZATION_KEY) {
+                // TODO: call async getAuthorization here
                 parameters
                         .put("braintree:clientKey", braintreeClient.getAuthorization().toString());
             } else {

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -225,6 +225,7 @@ public class GooglePayClient {
                                     .putExtra(EXTRA_ENVIRONMENT, getGooglePayEnvironment(configuration))
                                     .putExtra(EXTRA_PAYMENT_DATA_REQUEST, paymentDataRequest);
 
+                            // TODO: Use activity result API to launch this activity
                             activity.startActivityForResult(intent, BraintreeRequestCodes.GOOGLE_PAY);
                         }
                     });

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -1151,7 +1151,7 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
 
         assertEquals("braintree", tokenizationParameters.getString("gateway"));
         assertEquals(configuration.getMerchantId(), tokenizationParameters.getString("braintree:merchantId"));
@@ -1179,7 +1179,7 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
         assertNull(tokenizationParameters.getString("braintree:clientKey"));
     }
 
@@ -1201,7 +1201,7 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
         assertEquals(Fixtures.TOKENIZATION_KEY, tokenizationParameters.getString("braintree:clientKey"));
     }
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -1,5 +1,23 @@
 package com.braintreepayments.api;
 
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_FIRST_USER;
+import static android.app.Activity.RESULT_OK;
+import static com.braintreepayments.api.GooglePayClient.EXTRA_ENVIRONMENT;
+import static com.braintreepayments.api.GooglePayClient.EXTRA_PAYMENT_DATA_REQUEST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
@@ -27,24 +45,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Collection;
-
-import static android.app.Activity.RESULT_CANCELED;
-import static android.app.Activity.RESULT_FIRST_USER;
-import static android.app.Activity.RESULT_OK;
-import static com.braintreepayments.api.GooglePayClient.EXTRA_ENVIRONMENT;
-import static com.braintreepayments.api.GooglePayClient.EXTRA_PAYMENT_DATA_REQUEST;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class GooglePayClientUnitTest {
@@ -133,7 +133,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void isReadyToPay_returnsFalseWhenGooglePayIsNotEnabled() throws Exception {
+    public void isReadyToPay_returnsFalseWhenGooglePayIsNotEnabled() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder().enabled(false))
                 .buildConfiguration();
@@ -155,7 +155,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void isReadyToPay_whenActivityIsNull_forwardsErrorToCallback() throws InvalidArgumentException {
+    public void isReadyToPay_whenActivityIsNull_forwardsErrorToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder().enabled(true))
                 .buildConfiguration();
@@ -184,7 +184,7 @@ public class GooglePayClientUnitTest {
     // region requestPayment
 
     @Test
-    public void requestPayment_startsActivity() throws InvalidArgumentException {
+    public void requestPayment_startsActivity() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -211,7 +211,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_startsActivityWithOptionalValues() throws JSONException, InvalidArgumentException {
+    public void requestPayment_startsActivityWithOptionalValues() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -324,7 +324,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_includesATokenizationKeyWhenPresent() throws JSONException, InvalidArgumentException {
+    public void requestPayment_includesATokenizationKeyWhenPresent() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -367,7 +367,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_doesNotIncludeATokenizationKeyWhenNotPresent() throws JSONException, InvalidArgumentException {
+    public void requestPayment_doesNotIncludeATokenizationKeyWhenNotPresent() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -410,7 +410,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_sendsAnalyticsEvent() throws InvalidArgumentException {
+    public void requestPayment_sendsAnalyticsEvent() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -445,7 +445,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_postsExceptionWhenTransactionInfoIsNull() throws InvalidArgumentException {
+    public void requestPayment_postsExceptionWhenTransactionInfoIsNull() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -478,6 +478,7 @@ public class GooglePayClientUnitTest {
         Configuration configuration = new TestConfigurationBuilder().buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .activityInfo(activityInfo)
                 .build();
@@ -495,7 +496,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenSandbox_setsTestEnvironment() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenSandbox_setsTestEnvironment() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -529,7 +530,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenProduction_setsProductionEnvironment() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenProduction_setsProductionEnvironment() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("production")
@@ -563,7 +564,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_withGoogleMerchantId_sendGoogleMerchantId() throws JSONException, InvalidArgumentException {
+    public void requestPayment_withGoogleMerchantId_sendGoogleMerchantId() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -601,7 +602,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_withGoogleMerchantName_sendGoogleMerchantName() throws JSONException, InvalidArgumentException {
+    public void requestPayment_withGoogleMerchantName_sendGoogleMerchantName() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -639,7 +640,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenGooglePayCanProcessPayPal_tokenizationPropertiesIncludePayPal() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenGooglePayCanProcessPayPal_tokenizationPropertiesIncludePayPal() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -675,7 +676,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenPayPalDisabledByRequest_tokenizationPropertiesLackPayPal() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenPayPalDisabledByRequest_tokenizationPropertiesLackPayPal() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -710,7 +711,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenPayPalDisabledInConfigurationAndGooglePayHasPayPalClientId_tokenizationPropertiesContainPayPal() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenPayPalDisabledInConfigurationAndGooglePayHasPayPalClientId_tokenizationPropertiesContainPayPal() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -748,7 +749,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_usesGooglePayConfigurationClientId() throws JSONException, InvalidArgumentException {
+    public void requestPayment_usesGooglePayConfigurationClientId() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -795,7 +796,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenGooglePayConfigurationLacksClientId_tokenizationPropertiesLackPayPal() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenGooglePayConfigurationLacksClientId_tokenizationPropertiesLackPayPal() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -830,7 +831,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenConfigurationContainsElo_addsEloAndEloDebitToAllowedPaymentMethods() throws JSONException, InvalidArgumentException {
+    public void requestPayment_whenConfigurationContainsElo_addsEloAndEloDebitToAllowedPaymentMethods() throws JSONException {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -866,7 +867,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenRequestIsNull_fowardsExceptionToCallback() throws InvalidArgumentException {
+    public void requestPayment_whenRequestIsNull_fowardsExceptionToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -898,7 +899,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void requestPayment_whenManifestInvalid_fowardsExceptionToCallback() throws InvalidArgumentException {
+    public void requestPayment_whenManifestInvalid_fowardsExceptionToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -938,7 +939,7 @@ public class GooglePayClientUnitTest {
     // region tokenize
 
     @Test
-    public void tokenize_withCardToken_returnsGooglePayNonce() throws InvalidArgumentException {
+    public void tokenize_withCardToken_returnsGooglePayNonce() {
         String paymentDataJson = Fixtures.RESPONSE_GOOGLE_PAY_CARD;
 
         Configuration configuration = new TestConfigurationBuilder()
@@ -971,7 +972,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void tokenize_withPayPalToken_returnsPayPalAccountNonce() throws InvalidArgumentException {
+    public void tokenize_withPayPalToken_returnsPayPalAccountNonce() {
         String paymentDataJson = Fixtures.REPSONSE_GOOGLE_PAY_PAYPAL_ACCOUNT;
 
         Configuration configuration = new TestConfigurationBuilder()
@@ -1008,7 +1009,7 @@ public class GooglePayClientUnitTest {
     // region onActivityResult
 
     @Test
-    public void onActivityResult_OnCancel_sendsAnalyticsAndReturnsErrorToCallback() throws InvalidArgumentException {
+    public void onActivityResult_OnCancel_sendsAnalyticsAndReturnsErrorToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -1041,7 +1042,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_OnNonOkOrCanceledResult_sendsAnalyticsAndReturnsErrorToCallback() throws InvalidArgumentException {
+    public void onActivityResult_OnNonOkOrCanceledResult_sendsAnalyticsAndReturnsErrorToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -1074,7 +1075,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_OnOkResponse_sendsAnalytics() throws InvalidArgumentException {
+    public void onActivityResult_OnOkResponse_sendsAnalytics() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .environment("sandbox")
@@ -1103,7 +1104,7 @@ public class GooglePayClientUnitTest {
 
     // region getAllowedCardNetworks
     @Test
-    public void getAllowedCardNetworks_returnsSupportedNetworks() throws InvalidArgumentException {
+    public void getAllowedCardNetworks_returnsSupportedNetworks() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
@@ -1134,7 +1135,7 @@ public class GooglePayClientUnitTest {
     // region getTokenizationParameters
 
     @Test
-    public void getTokenizationParameters_returnsCorrectParameters() throws Exception {
+    public void getTokenizationParameters_returnsCorrectParameters() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
@@ -1142,16 +1143,17 @@ public class GooglePayClientUnitTest {
                 .withAnalytics()
                 .buildConfiguration();
 
+        Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, authorization).getParameters();
 
         assertEquals("braintree", tokenizationParameters.getString("gateway"));
         assertEquals(configuration.getMerchantId(), tokenizationParameters.getString("braintree:merchantId"));
@@ -1162,7 +1164,7 @@ public class GooglePayClientUnitTest {
     }
 
     @Test
-    public void getTokenizationParameters_doesNotIncludeATokenizationKeyWhenNotPresent() throws InvalidArgumentException {
+    public void getTokenizationParameters_doesNotIncludeATokenizationKeyWhenNotPresent() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
@@ -1170,21 +1172,22 @@ public class GooglePayClientUnitTest {
                 .withAnalytics()
                 .buildConfiguration();
 
+        Authorization authorization = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, authorization).getParameters();
         assertNull(tokenizationParameters.getString("braintree:clientKey"));
     }
 
     @Test
-    public void getTokenizationParameters_includesATokenizationKeyWhenPresent() throws Exception {
+    public void getTokenizationParameters_includesATokenizationKeyWhenPresent() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
@@ -1192,21 +1195,22 @@ public class GooglePayClientUnitTest {
                 .withAnalytics()
                 .buildConfiguration();
 
+        Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
         GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient);
 
-        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, ).getParameters();
+        Bundle tokenizationParameters = sut.getTokenizationParameters(configuration, authorization).getParameters();
         assertEquals(Fixtures.TOKENIZATION_KEY, tokenizationParameters.getString("braintree:clientKey"));
     }
 
     @Test
-    public void getTokenizationParameters_forwardsParametersAndAllowedCardsToCallback() throws InvalidArgumentException {
+    public void getTokenizationParameters_forwardsParametersAndAllowedCardsToCallback() {
         Configuration configuration = new TestConfigurationBuilder()
                 .googlePay(new TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
                         .googleAuthorizationFingerprint("google-auth-fingerprint")

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -140,7 +140,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -162,7 +162,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -197,7 +197,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -224,7 +224,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -336,7 +336,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -379,7 +379,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -423,7 +423,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -458,7 +458,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -508,7 +508,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -542,7 +542,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -576,7 +576,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -614,7 +614,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -652,7 +652,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -688,7 +688,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -725,7 +725,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -763,7 +763,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -807,7 +807,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -842,7 +842,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -879,7 +879,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -911,7 +911,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(null)
                 .build();
 
@@ -953,7 +953,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -986,7 +986,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1021,7 +1021,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1054,7 +1054,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1087,7 +1087,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1112,7 +1112,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString("sandbox_tokenization_string"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1144,7 +1144,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1172,7 +1172,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1194,7 +1194,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
@@ -1216,7 +1216,7 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorization(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
@@ -52,7 +52,6 @@ class PayPalInternalClient {
                                         ? SETUP_BILLING_AGREEMENT_ENDPOINT : CREATE_SINGLE_PAYMENT_ENDPOINT;
                                 String url = String.format("/v1/%s", endpoint);
 
-                                // TODO: call async getAuthorization here
                                 String requestBody = payPalRequest.createRequestBody(configuration, authorization, successUrl, cancelUrl);
 
                                 braintreeClient.sendPOST(url, requestBody, new HttpResponseCallback() {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
@@ -48,6 +48,7 @@ class PayPalInternalClient {
                             ? SETUP_BILLING_AGREEMENT_ENDPOINT : CREATE_SINGLE_PAYMENT_ENDPOINT;
                     String url = String.format("/v1/%s", endpoint);
 
+                    // TODO: call async getAuthorization here
                     String requestBody = payPalRequest.createRequestBody(configuration, braintreeClient.getAuthorization(), successUrl, cancelUrl);
 
                     braintreeClient.sendPOST(url, requestBody, new HttpResponseCallback() {

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -54,7 +54,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalVaultRequest_sendsAllParameters() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .returnUrlScheme("sample-scheme")
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
@@ -118,7 +118,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalCheckoutRequest_sendsAllParameters() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .returnUrlScheme("sample-scheme")
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
@@ -205,7 +205,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withTokenizationKey_sendsClientKeyParam() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
         when(tokenizationKey.getBearer()).thenReturn("tokenization-key-bearer");
 
@@ -228,7 +228,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withEmptyDisplayName_fallsBackToPayPalConfigurationDisplayName() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -250,7 +250,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withLocaleNotSpecified_omitsLocale() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -272,7 +272,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withMerchantAccountIdNotSpecified_omitsMerchantAccountId() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -294,7 +294,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withShippingAddressOverrideNotSpecified_sendsAddressOverrideFalse() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -316,7 +316,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withShippingAddressSpecified_sendsAddressOverrideBasedOnShippingAdressEditability() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
@@ -341,7 +341,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalVaultRequest_omitsEmptyBillingAgreementDescription() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -363,7 +363,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalCheckoutRequest_fallsBackToPayPalConfigurationCurrencyCode() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -384,7 +384,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalCheckoutRequest_omitsEmptyLineItems() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -408,7 +408,7 @@ public class PayPalInternalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
@@ -432,7 +432,7 @@ public class PayPalInternalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
@@ -454,7 +454,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalCheckoutRequest_whenRequestBillingAgreementFalse_andBillingAgreementDescriptionSet_doesNotSettBillingAgreementDescription() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(tokenizationKey)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
@@ -480,7 +480,7 @@ public class PayPalInternalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .returnUrlScheme("sample-scheme")
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_BILLING_AGREEMENT_RESPONSE)
                 .build();
@@ -513,7 +513,7 @@ public class PayPalInternalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .returnUrlScheme("sample-scheme")
                 .build();
@@ -547,7 +547,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalCheckoutRequest_setsApprovalUrlUserActionToEmptyStringOnDefault() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
@@ -573,7 +573,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_withPayPalVaultRequest_setsApprovalUrlUserActionToEmptyStringOnDefault() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_BILLING_AGREEMENT_RESPONSE)
                 .build();
 
@@ -598,7 +598,7 @@ public class PayPalInternalClientUnitTest {
         Exception httpError = new Exception("http error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTErrorResponse(httpError)
                 .build();
 
@@ -614,7 +614,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_propagatesMalformedJSONResponseErrors() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL))
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .sendPOSTSuccessfulResponse("{bad:")
                 .build();
 
@@ -630,7 +630,7 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_propagatesGetConfigurationErrors() {
         Exception configurationError = new Exception("configuration error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(clientToken)
+                .authorizationSuccess(clientToken)
                 .configurationError(configurationError)
                 .build();
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -627,7 +627,22 @@ public class PayPalInternalClientUnitTest {
     }
 
     @Test
-    public void sendRequest_propagatesGetConfigurationErrors() {
+    public void sendRequest_onAuthorizationFailure_forwardsError() {
+        Exception authError = new Exception("authorization error");
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .authorizationError(authError)
+                .build();
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+
+        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        verify(payPalInternalClientCallback).onResult(null, authError);
+    }
+
+    @Test
+    public void sendRequest_onConfigurationFailure_forwardsError() {
         Exception configurationError = new Exception("configuration error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorizationSuccess(clientToken)

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationLoaderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationLoaderBuilder.java
@@ -30,7 +30,7 @@ public class MockAuthorizationLoaderBuilder {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
-                AuthorizationCallback callback = (AuthorizationCallback) invocation.getArguments()[2];
+                AuthorizationCallback callback = (AuthorizationCallback) invocation.getArguments()[0];
                 if (authorization != null) {
                     callback.onAuthorizationResult(authorization, null);
                 } else if (authorizationError != null) {

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationLoaderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationLoaderBuilder.java
@@ -1,0 +1,45 @@
+package com.braintreepayments.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import android.content.Context;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class MockAuthorizationLoaderBuilder {
+
+    private Authorization authorization;
+    private Exception authorizationError;
+
+    public MockAuthorizationLoaderBuilder authorization(Authorization authorization) {
+        this.authorization = authorization;
+        return this;
+    }
+
+    public MockAuthorizationLoaderBuilder authorizationError(Exception authorizationError) {
+        this.authorizationError = authorizationError;
+        return this;
+    }
+
+    public AuthorizationLoader build() {
+        AuthorizationLoader authorizationLoader = mock(AuthorizationLoader.class);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                AuthorizationCallback callback = (AuthorizationCallback) invocation.getArguments()[2];
+                if (authorization != null) {
+                    callback.onAuthorizationResult(authorization, null);
+                } else if (authorizationError != null) {
+                    callback.onAuthorizationResult(null, authorizationError);
+                }
+                return null;
+            }
+        }).when(authorizationLoader).loadAuthorization(any(AuthorizationCallback.class));
+
+        return authorizationLoader;
+    }
+}

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationProviderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockAuthorizationProviderBuilder.java
@@ -7,17 +7,17 @@ import static org.mockito.Mockito.mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-public class MockClientTokenProviderBuilder {
+public class MockAuthorizationProviderBuilder {
 
     private String clientToken;
     private Exception error;
 
-    public MockClientTokenProviderBuilder clientToken(String clientToken) {
+    public MockAuthorizationProviderBuilder clientToken(String clientToken) {
         this.clientToken = clientToken;
         return this;
     }
 
-    public MockClientTokenProviderBuilder error(Exception error) {
+    public MockAuthorizationProviderBuilder error(Exception error) {
         this.error = error;
         return this;
     }

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -28,6 +28,7 @@ public class MockBraintreeClientBuilder {
     private Configuration configuration;
     private Exception configurationError;
 
+    private AuthorizationType authorizationType;
     private Authorization authorization;
     private Exception authorizationError;
 
@@ -47,6 +48,11 @@ public class MockBraintreeClientBuilder {
 
     public MockBraintreeClientBuilder configurationError(Exception configurationError) {
         this.configurationError = configurationError;
+        return this;
+    }
+
+    public MockBraintreeClientBuilder authorizationType(AuthorizationType authorizationType) {
+        this.authorizationType = authorizationType;
         return this;
     }
 
@@ -123,6 +129,7 @@ public class MockBraintreeClientBuilder {
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
         when(braintreeClient.getSessionId()).thenReturn(sessionId);
         when(braintreeClient.getIntegrationType()).thenReturn(integration);
+        when(braintreeClient.getAuthorizationType()).thenReturn(authorizationType);
 
         doAnswer(new Answer<Void>() {
             @Override

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -28,7 +28,6 @@ public class MockBraintreeClientBuilder {
     private Configuration configuration;
     private Exception configurationError;
 
-    private AuthorizationType authorizationType;
     private Authorization authorization;
     private Exception authorizationError;
 
@@ -48,11 +47,6 @@ public class MockBraintreeClientBuilder {
 
     public MockBraintreeClientBuilder configurationError(Exception configurationError) {
         this.configurationError = configurationError;
-        return this;
-    }
-
-    public MockBraintreeClientBuilder authorizationType(AuthorizationType authorizationType) {
-        this.authorizationType = authorizationType;
         return this;
     }
 
@@ -129,7 +123,6 @@ public class MockBraintreeClientBuilder {
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
         when(braintreeClient.getSessionId()).thenReturn(sessionId);
         when(braintreeClient.getIntegrationType()).thenReturn(integration);
-        when(braintreeClient.getAuthorizationType()).thenReturn(authorizationType);
 
         doAnswer(new Answer<Void>() {
             @Override

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -114,7 +114,6 @@ public class MockBraintreeClientBuilder {
 
     public BraintreeClient build() {
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
-        when(braintreeClient.getAuthorization()).thenReturn(authorization);
         when(braintreeClient.getSessionId()).thenReturn(sessionId);
         when(braintreeClient.getIntegrationType()).thenReturn(integration);
 

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockClientTokenProviderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockClientTokenProviderBuilder.java
@@ -1,0 +1,43 @@
+package com.braintreepayments.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class MockClientTokenProviderBuilder {
+
+    private String clientToken;
+    private Exception error;
+
+    public MockClientTokenProviderBuilder clientToken(String clientToken) {
+        this.clientToken = clientToken;
+        return this;
+    }
+
+    public MockClientTokenProviderBuilder error(Exception error) {
+        this.error = error;
+        return this;
+    }
+
+    ClientTokenProvider build() {
+        ClientTokenProvider clientTokenProvider = mock(ClientTokenProvider.class);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                ClientTokenCallback callback = (ClientTokenCallback) invocation.getArguments()[0];
+                if (clientToken != null) {
+                    callback.onSuccess(clientToken);
+                } else if (error != null) {
+                    callback.onFailure(error);
+                }
+                return null;
+            }
+        }).when(clientTokenProvider).getClientToken(any(ClientTokenCallback.class));
+
+        return clientTokenProvider;
+    }
+}

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockClientTokenProviderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockClientTokenProviderBuilder.java
@@ -22,8 +22,8 @@ public class MockClientTokenProviderBuilder {
         return this;
     }
 
-    ClientTokenProvider build() {
-        ClientTokenProvider clientTokenProvider = mock(ClientTokenProvider.class);
+    AuthorizationProvider build() {
+        AuthorizationProvider authorizationProvider = mock(AuthorizationProvider.class);
 
         doAnswer(new Answer<Void>() {
             @Override
@@ -36,8 +36,8 @@ public class MockClientTokenProviderBuilder {
                 }
                 return null;
             }
-        }).when(clientTokenProvider).getClientToken(any(ClientTokenCallback.class));
+        }).when(authorizationProvider).getClientToken(any(ClientTokenCallback.class));
 
-        return clientTokenProvider;
+        return authorizationProvider;
     }
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -152,7 +152,6 @@ public class ThreeDSecureClient {
                     final JSONObject lookupJSON = new JSONObject();
                     try {
                         lookupJSON
-                                // TODO: call async getAuthorization here
                                 .put("authorizationFingerprint", authorization.getBearer())
                                 .put("braintreeLibraryVersion", "Android-" + BuildConfig.VERSION_NAME)
                                 .put("nonce", request.getNonce())

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -146,7 +146,7 @@ public class ThreeDSecureClient {
     public void prepareLookup(@NonNull final Context context, @NonNull final ThreeDSecureRequest request, @NonNull final ThreeDSecurePrepareLookupCallback callback) {
         braintreeClient.getAuthorization(new AuthorizationCallback() {
             @Override
-            public void onAuthorizationResult(@Nullable @org.jetbrains.annotations.Nullable Authorization authorization, @Nullable Exception authError) {
+            public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception authError) {
                 if (authorization != null) {
 
                     final JSONObject lookupJSON = new JSONObject();
@@ -164,11 +164,10 @@ public class ThreeDSecureClient {
 
                     braintreeClient.getConfiguration(new ConfigurationCallback() {
                         @Override
-                        public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
+                        public void onResult(@Nullable Configuration configuration, @Nullable Exception configError) {
                             if (configuration == null) {
-                                callback.onResult(null, null, error);
+                                callback.onResult(null, null, configError);
                                 return;
-
                             }
                             if (configuration.getCardinalAuthenticationJwt() == null) {
                                 Exception authError = new BraintreeException("Merchant is not configured for 3DS 2.0. " +

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -147,6 +147,7 @@ public class ThreeDSecureClient {
         final JSONObject lookupJSON = new JSONObject();
         try {
             lookupJSON
+                    // TODO: call async getAuthorization here
                     .put("authorizationFingerprint", braintreeClient.getAuthorization().getBearer())
                     .put("braintreeLibraryVersion", "Android-" + BuildConfig.VERSION_NAME)
                     .put("nonce", request.getNonce())

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
@@ -64,7 +64,7 @@ public class ThreeDSecureV1UnitTest {
     @Test
     public void continuePerformVerification_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
@@ -82,7 +82,7 @@ public class ThreeDSecureV1UnitTest {
     @Test
     public void performVerification_whenVersion1IsRequested_doesNotUseCardinalMobileSDK() throws InvalidArgumentException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE)
                 .configuration(threeDSecureEnabledConfig)
                 .build();
@@ -102,7 +102,7 @@ public class ThreeDSecureV1UnitTest {
         String assetsUrl = "https://www.some-assets.com";
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE)
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme(urlScheme)
@@ -130,7 +130,7 @@ public class ThreeDSecureV1UnitTest {
         String assetsUrl = "https://www.some-assets.com";
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE)
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme(urlScheme)
@@ -158,7 +158,7 @@ public class ThreeDSecureV1UnitTest {
         String assetsUrl = "https://www.some-assets.com";
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE)
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme(urlScheme)

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
@@ -62,7 +62,7 @@ public class ThreeDSecureV1UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void continuePerformVerification_sendsAnalyticsEvent() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
@@ -80,7 +80,7 @@ public class ThreeDSecureV1UnitTest {
     }
 
     @Test
-    public void performVerification_whenVersion1IsRequested_doesNotUseCardinalMobileSDK() throws InvalidArgumentException {
+    public void performVerification_whenVersion1IsRequested_doesNotUseCardinalMobileSDK() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE)
@@ -97,7 +97,7 @@ public class ThreeDSecureV1UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenV1Flow_launchesBrowserSwitch() throws InvalidArgumentException, BrowserSwitchException {
+    public void continuePerformVerification_whenV1Flow_launchesBrowserSwitch() throws BrowserSwitchException {
         String urlScheme = "sample-scheme";
         String assetsUrl = "https://www.some-assets.com";
 
@@ -125,7 +125,7 @@ public class ThreeDSecureV1UnitTest {
     }
 
     @Test
-    public void initializeChallengeWithLookupResponse_whenV1Flow_launchesBrowserSwitch() throws InvalidArgumentException, BrowserSwitchException {
+    public void initializeChallengeWithLookupResponse_whenV1Flow_launchesBrowserSwitch() throws BrowserSwitchException {
         String urlScheme = "sample-scheme";
         String assetsUrl = "https://www.some-assets.com";
 
@@ -153,7 +153,7 @@ public class ThreeDSecureV1UnitTest {
     }
 
     @Test
-    public void initializeChallengeWithLookupResponse_whenV1Flow_and3DSecureRequestIsProvided_launchesBrowserSwitch() throws InvalidArgumentException, BrowserSwitchException {
+    public void initializeChallengeWithLookupResponse_whenV1Flow_and3DSecureRequestIsProvided_launchesBrowserSwitch() throws BrowserSwitchException {
         String urlScheme = "sample-scheme";
         String assetsUrl = "https://www.some-assets.com";
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -20,6 +20,7 @@ import static com.braintreepayments.api.BraintreeRequestCodes.THREE_D_SECURE;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
@@ -61,7 +62,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_returnsValidLookupJSONString() throws InvalidArgumentException, JSONException {
+    public void prepareLookup_returnsValidLookupJSONString() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("fake-df")
                 .build();
@@ -94,7 +95,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_returnsValidLookupJSONString_whenCardinalSetupFails() throws InvalidArgumentException, JSONException {
+    public void prepareLookup_returnsValidLookupJSONString_whenCardinalSetupFails() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("cardinal error"))
                 .build();
@@ -127,7 +128,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_initializesCardinal() throws InvalidArgumentException {
+    public void prepareLookup_initializesCardinal() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("fake-df")
                 .build();
@@ -147,7 +148,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_withoutCardinalJWT_postsException() throws Exception {
+    public void prepareLookup_withoutCardinalJWT_postsException() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         Configuration configuration = new TestConfigurationBuilder()
                 .threeDSecureEnabled(true)
@@ -173,7 +174,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_initializesCardinal() throws InvalidArgumentException {
+    public void performVerification_initializesCardinal() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -191,7 +192,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_whenCardinalSetupCompleted_sendsAnalyticEvent() throws InvalidArgumentException {
+    public void performVerification_whenCardinalSetupCompleted_sendsAnalyticEvent() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -209,7 +210,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_whenCardinalSetupFailed_sendsAnalyticEvent() throws InvalidArgumentException {
+    public void performVerification_whenCardinalSetupFailed_sendsAnalyticEvent() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("cardinal error"))
                 .build();
@@ -227,7 +228,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenAuthenticatingWithCardinal_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void continuePerformVerification_whenAuthenticatingWithCardinal_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -247,7 +248,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsPresented_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void continuePerformVerification_whenChallengeIsPresented_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -268,7 +269,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsNotPresented_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void continuePerformVerification_whenChallengeIsNotPresented_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -288,7 +289,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_when3DSVersionIsVersion2_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void continuePerformVerification_when3DSVersionIsVersion2_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -308,7 +309,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_withoutCardinalJWT_postsException() throws Exception {
+    public void performVerification_withoutCardinalJWT_postsException() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         Configuration configuration = new TestConfigurationBuilder()
@@ -334,7 +335,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void authenticateCardinalJWT_whenSuccess_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenSuccess_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -354,7 +355,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void authenticateCardinalJWT_whenSuccess_returnsThreeDSecureCardNonce() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenSuccess_returnsThreeDSecureCardNonce() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -375,13 +376,16 @@ public class ThreeDSecureV2UnitTest {
         verify(callback).onResult(captor.capture(), (Exception) isNull());
 
         CardNonce cardNonce = captor.getValue().getTokenizedCard();
-        assertTrue(cardNonce.getThreeDSecureInfo().isLiabilityShifted());
-        assertTrue(cardNonce.getThreeDSecureInfo().isLiabilityShiftPossible());
+        assertNotNull(cardNonce);
+
+        ThreeDSecureInfo threeDSecureInfo = cardNonce.getThreeDSecureInfo();
+        assertTrue(threeDSecureInfo.isLiabilityShifted());
+        assertTrue(threeDSecureInfo.isLiabilityShiftPossible());
         assertEquals("12345678-1234-1234-1234-123456789012", cardNonce.getString());
     }
 
     @Test
-    public void authenticateCardinalJWT_whenCustomerFailsAuthentication_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenCustomerFailsAuthentication_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -403,7 +407,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void authenticateCardinalJWT_whenCustomerFailsAuthentication_returnsLookupCardNonce() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenCustomerFailsAuthentication_returnsLookupCardNonce() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         String authResponseJson = Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR;
@@ -427,14 +431,17 @@ public class ThreeDSecureV2UnitTest {
 
         ThreeDSecureResult actualResult = captor.getValue();
         CardNonce cardNonce = actualResult.getTokenizedCard();
-        assertFalse(cardNonce.getThreeDSecureInfo().isLiabilityShifted());
-        assertTrue(cardNonce.getThreeDSecureInfo().isLiabilityShiftPossible());
+        assertNotNull(cardNonce);
+
+        ThreeDSecureInfo threeDSecureInfo = cardNonce.getThreeDSecureInfo();
+        assertFalse(threeDSecureInfo.isLiabilityShifted());
+        assertTrue(threeDSecureInfo.isLiabilityShiftPossible());
         assertEquals("123456-12345-12345-a-adfa", cardNonce.getString());
         assertEquals("Failed to authenticate, please try a different form of payment.", actualResult.getErrorMessage());
     }
 
     @Test
-    public void authenticateCardinalJWT_whenExceptionOccurs_sendsAnalyticsEvent() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenExceptionOccurs_sendsAnalyticsEvent() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -456,7 +463,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void authenticateCardinalJWT_whenExceptionOccurs_returnsException() throws InvalidArgumentException, JSONException {
+    public void authenticateCardinalJWT_whenExceptionOccurs_returnsException() throws JSONException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -67,7 +67,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
@@ -100,7 +100,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
@@ -133,7 +133,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -154,7 +154,7 @@ public class ThreeDSecureV2UnitTest {
                 .buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -179,7 +179,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -197,7 +197,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -215,7 +215,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -233,7 +233,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -253,7 +253,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -274,7 +274,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -294,7 +294,7 @@ public class ThreeDSecureV2UnitTest {
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -316,7 +316,7 @@ public class ThreeDSecureV2UnitTest {
                 .buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
         when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
@@ -338,7 +338,7 @@ public class ThreeDSecureV2UnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
                 .build();
@@ -358,7 +358,7 @@ public class ThreeDSecureV2UnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
                 .build();
@@ -385,7 +385,7 @@ public class ThreeDSecureV2UnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR)
                 .build();
@@ -408,7 +408,7 @@ public class ThreeDSecureV2UnitTest {
 
         String authResponseJson = Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR;
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(authResponseJson)
                 .build();
@@ -438,7 +438,7 @@ public class ThreeDSecureV2UnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTErrorResponse(new BraintreeException("an error occurred!"))
                 .build();
@@ -460,7 +460,7 @@ public class ThreeDSecureV2UnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTErrorResponse(new BraintreeException("an error occurred!"))
                 .build();

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -141,7 +141,7 @@ public class VenmoClient {
     }
 
     private void startVenmoActivityForResult(FragmentActivity activity, VenmoRequest request, Configuration configuration, String venmoProfileId, @Nullable String paymentContextId) {
-        sharedPrefsWriter.persistVenmoVaultOption(activity, request.getShouldVault() && braintreeClient.getAuthorization() instanceof ClientToken);
+        sharedPrefsWriter.persistVenmoVaultOption(activity, request.getShouldVault() && braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN);
 
         Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
         activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
@@ -189,7 +189,7 @@ public class VenmoClient {
                                     VenmoAccountNonce nonce = VenmoAccountNonce.fromJSON(data.getJSONObject("node"));
 
                                     boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                                    boolean isClientToken = braintreeClient.getAuthorization() instanceof ClientToken;
+                                    boolean isClientToken = braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN;
 
                                     if (shouldVault && isClientToken) {
                                         vaultVenmoAccountNonce(nonce.getString(), callback);
@@ -216,7 +216,7 @@ public class VenmoClient {
                 String nonce = data.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
 
                 boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                boolean isClientToken = braintreeClient.getAuthorization() instanceof ClientToken;
+                boolean isClientToken = braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN;
 
                 if (shouldVault && isClientToken) {
                     vaultVenmoAccountNonce(nonce, callback);

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -140,12 +140,21 @@ public class VenmoClient {
         });
     }
 
-    private void startVenmoActivityForResult(FragmentActivity activity, VenmoRequest request, Configuration configuration, String venmoProfileId, @Nullable String paymentContextId) {
-        sharedPrefsWriter.persistVenmoVaultOption(activity, request.getShouldVault() && braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN);
+    private void startVenmoActivityForResult(final FragmentActivity activity, final VenmoRequest request, final Configuration configuration, final String venmoProfileId, @Nullable final String paymentContextId) {
+        braintreeClient.getAuthorization(new AuthorizationCallback() {
+            @Override
+            public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error) {
+                if (authorization != null) {
+                    boolean isClientTokenAuth = (authorization instanceof ClientToken);
+                    boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
+                    sharedPrefsWriter.persistVenmoVaultOption(activity, shouldVault);
 
-        Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
-        activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
-        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
+                    Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
+                    activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
+                }
+            }
+        });
     }
 
     private static String parsePaymentContextId(String createPaymentContextResponse) {
@@ -166,66 +175,73 @@ public class VenmoClient {
      * @param data       Android Intent
      * @param callback   {@link VenmoOnActivityResultCallback}
      */
-    public void onActivityResult(@NonNull final Context context, int resultCode, @Nullable Intent data, @NonNull final VenmoOnActivityResultCallback callback) {
+    public void onActivityResult(@NonNull final Context context, int resultCode, @Nullable final Intent data, @NonNull final VenmoOnActivityResultCallback callback) {
         if (resultCode == AppCompatActivity.RESULT_OK) {
             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success");
 
-            String paymentContextId = data.getStringExtra(EXTRA_RESOURCE_ID);
-            if (paymentContextId != null) {
-                JSONObject params = new JSONObject();
-                try {
-                    params.put("query", "query PaymentContext($id: ID!) { node(id: $id) { ... on VenmoPaymentContext { paymentMethodId userName payerInfo { firstName lastName phoneNumber email externalId userName } } } }");
-                    JSONObject variables = new JSONObject();
-                    variables.put("id", paymentContextId);
-                    params.put("variables", variables);
+            braintreeClient.getAuthorization(new AuthorizationCallback() {
+                @Override
+                public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception authError) {
+                    if (authorization != null) {
+                        final boolean isClientTokenAuth = (authorization instanceof ClientToken);
 
-                    braintreeClient.sendGraphQLPOST(params.toString(), new HttpResponseCallback() {
+                        String paymentContextId = data.getStringExtra(EXTRA_RESOURCE_ID);
+                        if (paymentContextId != null) {
+                            JSONObject params = new JSONObject();
+                            try {
+                                params.put("query", "query PaymentContext($id: ID!) { node(id: $id) { ... on VenmoPaymentContext { paymentMethodId userName payerInfo { firstName lastName phoneNumber email externalId userName } } } }");
+                                JSONObject variables = new JSONObject();
+                                variables.put("id", paymentContextId);
+                                params.put("variables", variables);
 
-                        @Override
-                        public void onResult(String responseBody, Exception httpError) {
-                            if (responseBody != null) {
-                                try {
-                                    JSONObject data = new JSONObject(responseBody).getJSONObject("data");
-                                    VenmoAccountNonce nonce = VenmoAccountNonce.fromJSON(data.getJSONObject("node"));
+                                braintreeClient.sendGraphQLPOST(params.toString(), new HttpResponseCallback() {
 
-                                    boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                                    boolean isClientToken = braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN;
+                                    @Override
+                                    public void onResult(String responseBody, Exception httpError) {
+                                        if (responseBody != null) {
+                                            try {
+                                                JSONObject data = new JSONObject(responseBody).getJSONObject("data");
+                                                VenmoAccountNonce nonce = VenmoAccountNonce.fromJSON(data.getJSONObject("node"));
 
-                                    if (shouldVault && isClientToken) {
-                                        vaultVenmoAccountNonce(nonce.getString(), callback);
-                                    } else {
-                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                        callback.onResult(nonce, null);
+                                                boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
+                                                if (shouldVault && isClientTokenAuth) {
+                                                    vaultVenmoAccountNonce(nonce.getString(), callback);
+                                                } else {
+                                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
+                                                    callback.onResult(nonce, null);
+                                                }
+                                            } catch (JSONException exception) {
+                                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
+                                                callback.onResult(null, exception);
+                                            }
+                                        } else {
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
+                                            callback.onResult(null, httpError);
+                                        }
                                     }
-                                } catch (JSONException exception) {
-                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                    callback.onResult(null, exception);
-                                }
+                                });
+
+                            } catch (JSONException exception) {
+                                callback.onResult(null, exception);
+                            }
+
+                        } else {
+                            String nonce = data.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
+
+                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
+                            if (shouldVault && isClientTokenAuth) {
+                                vaultVenmoAccountNonce(nonce, callback);
                             } else {
-                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                callback.onResult(null, httpError);
+                                String venmoUsername = data.getStringExtra(EXTRA_USERNAME);
+                                VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
+                                callback.onResult(venmoAccountNonce, null);
                             }
                         }
-                    });
-
-                } catch (JSONException exception) {
-                    callback.onResult(null, exception);
+                    } else if (authError != null) {
+                        callback.onResult(null, authError);
+                    }
                 }
-
-            } else {
-                String nonce = data.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
-
-                boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                boolean isClientToken = braintreeClient.getAuthorizationType() == AuthorizationType.CLIENT_TOKEN;
-
-                if (shouldVault && isClientToken) {
-                    vaultVenmoAccountNonce(nonce, callback);
-                } else {
-                    String venmoUsername = data.getStringExtra(EXTRA_USERNAME);
-                    VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
-                    callback.onResult(venmoAccountNonce, null);
-                }
-            }
+            });
 
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -102,7 +102,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -139,7 +139,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -182,7 +182,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -286,7 +286,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -314,7 +314,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -342,7 +342,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -408,7 +408,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -428,7 +428,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -449,7 +449,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorization(Authorization.fromString("sandbox_tk_abcd"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tk_abcd"))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -594,7 +594,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -675,7 +675,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .build();
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
@@ -704,7 +704,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
-                .authorization(Authorization.fromString("sandbox_tk_abcd"))
+                .authorizationSuccess(Authorization.fromString("sandbox_tk_abcd"))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -720,7 +720,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -743,7 +743,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -771,7 +771,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -794,7 +794,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -821,7 +821,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -850,7 +850,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -10,7 +10,6 @@ import static com.braintreepayments.api.VenmoClient.EXTRA_USERNAME;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.endsWith;
 import static org.mockito.Matchers.eq;
@@ -56,6 +55,9 @@ public class VenmoClientUnitTest {
     private ApiClient apiClient;
     private VenmoOnActivityResultCallback onActivityResultCallback;
 
+    private Authorization clientToken;
+    private Authorization tokenizationKey;
+
     @Before
     public void beforeEach() throws JSONException {
         activity = mock(FragmentActivity.class);
@@ -69,6 +71,8 @@ public class VenmoClientUnitTest {
         sharedPrefsWriter = mock(VenmoSharedPrefsWriter.class);
 
         onActivityResultCallback = mock(VenmoOnActivityResultCallback.class);
+        clientToken = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
+        tokenizationKey = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
     }
 
     @Test
@@ -101,7 +105,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -138,7 +142,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -181,7 +185,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -285,7 +289,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -313,7 +317,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -341,7 +345,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -387,6 +391,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_sendsAnalyticsEventWhenStarted() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -407,7 +412,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -427,7 +432,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -448,7 +453,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -529,6 +534,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContextId_queriesGraphQLPaymentContext() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
+                .authorizationSuccess(clientToken)
                 .build();
 
         VenmoClient sut = new VenmoClient(braintreeClient, apiClient, sharedPrefsWriter, deviceInspector);
@@ -551,6 +557,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_onGraphQLPostSuccess_returnsNonceToCallback_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -575,6 +582,7 @@ public class VenmoClientUnitTest {
         BraintreeException graphQLError = new BraintreeException("graphQL error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTErrorResponse(graphQLError)
                 .build();
 
@@ -593,7 +601,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -621,6 +629,9 @@ public class VenmoClientUnitTest {
 
     @Test
     public void onActivityResult_postsPaymentMethodNonceOnSuccess() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .authorizationSuccess(clientToken)
+                .build();
         VenmoClient sut = new VenmoClient(braintreeClient, apiClient, sharedPrefsWriter, deviceInspector);
         Intent intent = new Intent()
                 .putExtra(EXTRA_PAYMENT_METHOD_NONCE, "123456-12345-12345-a-adfa")
@@ -666,7 +677,6 @@ public class VenmoClientUnitTest {
 
         BraintreeException exception = captor.getValue();
         assertEquals("User canceled Venmo.", exception.getMessage());
-        assertTrue(exception instanceof BraintreeException);
     }
 
     @Test
@@ -674,7 +684,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
@@ -703,7 +713,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
-                .authorizationType(AuthorizationType.TOKENIZATION_KEY)
+                .authorizationSuccess(tokenizationKey)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -719,7 +729,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -742,7 +752,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -770,7 +780,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -793,7 +803,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -820,7 +830,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -849,7 +859,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationType(AuthorizationType.CLIENT_TOKEN)
+                .authorizationSuccess(clientToken)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -1,25 +1,5 @@
 package com.braintreepayments.api;
 
-import android.content.ComponentName;
-import android.content.Intent;
-import android.os.Bundle;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentActivity;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-
-import static com.braintreepayments.api.FixturesHelper.base64Encode;
 import static com.braintreepayments.api.VenmoClient.EXTRA_ACCESS_TOKEN;
 import static com.braintreepayments.api.VenmoClient.EXTRA_BRAINTREE_DATA;
 import static com.braintreepayments.api.VenmoClient.EXTRA_ENVIRONMENT;
@@ -41,6 +21,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 @RunWith(RobolectricTestRunner.class)
 public class VenmoClientUnitTest {
@@ -102,7 +101,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -139,7 +138,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -182,7 +181,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(base64Encode(Fixtures.CLIENT_TOKEN)))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -286,7 +285,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -314,7 +313,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -342,7 +341,7 @@ public class VenmoClientUnitTest {
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
                 .integration("custom")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -408,7 +407,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -428,7 +427,7 @@ public class VenmoClientUnitTest {
     public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -449,7 +448,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString("sandbox_tk_abcd"))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
 
@@ -594,7 +593,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -675,7 +674,7 @@ public class VenmoClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
@@ -704,7 +703,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
-                .authorizationSuccess(Authorization.fromString("sandbox_tk_abcd"))
+                .authorizationType(AuthorizationType.TOKENIZATION_KEY)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -720,7 +719,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -743,7 +742,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -771,7 +770,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -794,7 +793,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
@@ -821,7 +820,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
                 .build();
 
@@ -850,7 +849,7 @@ public class VenmoClientUnitTest {
     public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .authorizationType(AuthorizationType.CLIENT_TOKEN)
                 .build();
 
         when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);


### PR DESCRIPTION
### Notes

By taking control of when Client Tokens are fetched, registering and responding to app / browser switches can be further encapsulated by the SDK. This allows us to improve the developer experience for 3DS, PayPal, Venmo, Google Pay, and Local Payments.

### Summary of changes

 - Add `AuthorizationProvider` interface to allow the merchant to define a strategy for asynchronously fetching a client token from their server
 - Add `ClientTokenCallback` interface
 - Add `BraintreeClient` constructors that accept a `ClientTokenProvider`

 ### Checklist

 - [x] Added a changelog entry
