### PR TITLE
Fix Venmo Issue and Hide Authorization Loader

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationProvider.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationProvider.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
  * Implement this interface to provide an asynchronous way for {@link BraintreeClient} to fetch
  * a client token from your server when it is needed.
  */
-public interface AuthorizationProvider {
+interface AuthorizationProvider {
 
     /**
      * Method used by {@link BraintreeClient} to fetch a client token.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -87,7 +87,7 @@ public class BraintreeClient {
      * @param context             Android Context
      * @param authorizationProvider An implementation of {@link AuthorizationProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
      */
-    public BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider) {
+    BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider) {
         this(createDefaultParams(context, null, authorizationProvider));
     }
 
@@ -117,7 +117,7 @@ public class BraintreeClient {
      * @param authorizationProvider An implementation of {@link AuthorizationProvider} that {@link BraintreeClient} will use to fetch a client token on demand.
      * @param returnUrlScheme     A custom return url to use for browser and app switching
      */
-    public BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider, @NonNull String returnUrlScheme) {
+    BraintreeClient(@NonNull Context context, @NonNull AuthorizationProvider authorizationProvider, @NonNull String returnUrlScheme) {
         this(createDefaultParams(context, null, authorizationProvider, returnUrlScheme));
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenCallback.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
  * Callback used to communicate {@link AuthorizationProvider#getClientToken(ClientTokenCallback)} result
  * back to {@link BraintreeClient}.
  */
-public interface ClientTokenCallback {
+interface ClientTokenCallback {
 
     /**
      * Invoke this method once a client token has been successfully fetched from the merchant server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## unreleased
 
-* Core
-  * Add `AuthorizationProvider` interface
-  * Add `ClientTokenCallback` interface
-  * Add `BraintreeClient` constructors that accept a `AuthorizationProvider`
+* Venmo
+  * Fix issue where null value causes VenmoAccountNonce#fromJSON() to throw.
 
 ## 4.8.1
 

--- a/Demo/src/main/java/com/braintreepayments/api/BraintreeClientFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/api/BraintreeClientFactory.java
@@ -1,0 +1,11 @@
+package com.braintreepayments.api;
+
+import android.content.Context;
+
+// TODO: remove when AuthorizationProvider is released
+public class BraintreeClientFactory {
+
+    static public BraintreeClient createBraintreeClientWithAuthorizationProvider(Context context) {
+        return new BraintreeClient(context, new DemoAuthorizationProvider(context));
+    }
+}

--- a/Demo/src/main/java/com/braintreepayments/api/DemoAuthorizationProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/api/DemoAuthorizationProvider.java
@@ -1,13 +1,15 @@
-package com.braintreepayments.demo;
+package com.braintreepayments.api;
 
 import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
-import com.braintreepayments.api.ClientTokenCallback;
-import com.braintreepayments.api.AuthorizationProvider;
+import com.braintreepayments.demo.Merchant;
+import com.braintreepayments.demo.R;
+import com.braintreepayments.demo.Settings;
 
+// TODO: move back to com.braintreepayments.demo when AuthorizationProvider is released
 public class DemoAuthorizationProvider implements AuthorizationProvider {
 
     private final Merchant merchant;
@@ -21,7 +23,7 @@ public class DemoAuthorizationProvider implements AuthorizationProvider {
     @Override
     public void getClientToken(@NonNull ClientTokenCallback callback) {
         String authType = Settings.getAuthorizationType(appContext);
-        if (authType.equals(getString(appContext, R.string.paypal_uat))) {
+        if (authType.equals(getString(appContext, com.braintreepayments.demo.R.string.paypal_uat))) {
             // NOTE: - The PP UAT is fetched from the PPCP sample server
             //       - The only feature that currently works with a PP UAT is Card Tokenization.
             merchant.fetchPayPalUAT((payPalUAT, error) -> {

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -23,7 +23,9 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.BraintreeClientFactory;
 import com.braintreepayments.api.BrowserSwitchResult;
+import com.braintreepayments.api.DemoAuthorizationProvider;
 
 import java.util.Arrays;
 import java.util.List;
@@ -72,7 +74,7 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
                 braintreeClient = new BraintreeClient(this, tokenizationKey);
             } else {
                 braintreeClient =
-                        new BraintreeClient(this, new DemoAuthorizationProvider(this));
+                    BraintreeClientFactory.createBraintreeClientWithAuthorizationProvider(this);
             }
         }
         return braintreeClient;

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -1953,6 +1953,14 @@ object Fixtures {
         }
     """
 
+    const val VENMO_PAYMENT_METHOD_CONTEXT_WITH_NULL_PAYER_INFO_JSON = """
+        {
+          "paymentMethodId": "sample-payment-method-id",
+          "userName": "@sampleuser",
+          "payerInfo": null
+        }
+    """
+
     // language=JSON
     const val PAYMENT_METHOD_VENMO_PLAIN_OBJECT = """
         {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoAccountNonce.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoAccountNonce.java
@@ -65,12 +65,12 @@ public class VenmoAccountNonce extends PaymentMethodNonce {
         return new VenmoAccountNonce(nonce, username, isDefault, json);
     }
 
-    VenmoAccountNonce(String nonce, String username, boolean isDefault, JSONObject json) throws JSONException {
+    VenmoAccountNonce(String nonce, String username, boolean isDefault, JSONObject json) {
         super(nonce, isDefault);
         this.username = username;
 
-        if (json.has(VENMO_PAYER_INFO_KEY)) {
-            JSONObject payerInfo = json.getJSONObject(VENMO_PAYER_INFO_KEY);
+        JSONObject payerInfo = json.optJSONObject(VENMO_PAYER_INFO_KEY);
+        if (payerInfo != null) {
             this.email = payerInfo.optString(VENMO_EMAIL_KEY);
             this.externalId = payerInfo.optString(VENMO_EXTERNAL_ID_KEY);
             this.firstName = payerInfo.optString(VENMO_FIRST_NAME_KEY);

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoAccountNonceUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoAccountNonceUnitTest.java
@@ -11,6 +11,7 @@ import org.robolectric.RobolectricTestRunner;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class VenmoAccountNonceUnitTest {
@@ -41,6 +42,22 @@ public class VenmoAccountNonceUnitTest {
         assertEquals("venmo-first-name", venmoAccountNonce.getFirstName());
         assertEquals("venmo-last-name", venmoAccountNonce.getLastName());
         assertEquals("venmo-phone-number", venmoAccountNonce.getPhoneNumber());
+        assertFalse(venmoAccountNonce.isDefault());
+    }
+
+    @Test
+    public void fromJson_withPaymentMethodIdAndNullPayerInfo_parsesResponse() throws JSONException {
+        JSONObject json =
+            new JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_WITH_NULL_PAYER_INFO_JSON);
+        VenmoAccountNonce venmoAccountNonce = VenmoAccountNonce.fromJSON(json);
+
+        assertEquals("@sampleuser", venmoAccountNonce.getUsername());
+        assertEquals("sample-payment-method-id", venmoAccountNonce.getString());
+        assertNull(venmoAccountNonce.getEmail());
+        assertNull(venmoAccountNonce.getExternalId());
+        assertNull(venmoAccountNonce.getFirstName());
+        assertNull(venmoAccountNonce.getLastName());
+        assertNull(venmoAccountNonce.getPhoneNumber());
         assertFalse(venmoAccountNonce.isDefault());
     }
 


### PR DESCRIPTION
### Summary of changes

 - Fix issue where null value causes VenmoAccountNonce#fromJSON() to throw.
 - Delay release of `AuthorizationProvider` until we finalize the interface (see [discussion](https://github.com/braintree/braintree_android/discussions/496))

 ### Checklist

 - [x] Added a changelog entry
