### PR TITLE
PayPal - Encapsulate Browser Switch Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
+
 * ThreeDSecure
   * Add `ThreeDSecureListener` to receive results from the 3DS flow
   * Deprecate methods requiring a callback in favor of listener pattern
 * Venmo
   * Add `VenmoListener` to receive results from the Venmo flow
+  * Deprecate methods requiring a callback in favor of listener pattern
+* PayPal
+  * Add `PayPalListener` to receive results from the PayPal flow
   * Deprecate methods requiring a callback in favor of listener pattern
 
 ## 4.8.2

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoViewModel.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoViewModel.java
@@ -13,7 +13,6 @@ import com.braintreepayments.api.BrowserSwitchResult;
 public class DemoViewModel extends ViewModel {
 
     private final MutableLiveData<BrowserSwitchResult> localPaymentBrowserSwitchResult = new MutableLiveData<>();
-    private final MutableLiveData<BrowserSwitchResult> payPalBrowserSwitchResult = new MutableLiveData<>();
     private final MutableLiveData<ActivityResult> googlePayActivityResult = new MutableLiveData<>();
 
     public void onBrowserSwitchResult(BrowserSwitchResult browserSwitchResult) {
@@ -23,9 +22,6 @@ public class DemoViewModel extends ViewModel {
         switch (browserSwitchResult.getRequestCode()) {
             case BraintreeRequestCodes.LOCAL_PAYMENT:
                 localPaymentBrowserSwitchResult.setValue(browserSwitchResult);
-                break;
-            case BraintreeRequestCodes.PAYPAL:
-                payPalBrowserSwitchResult.setValue(browserSwitchResult);
                 break;
         }
     }
@@ -44,9 +40,5 @@ public class DemoViewModel extends ViewModel {
 
     public LiveData<BrowserSwitchResult> getLocalPaymentBrowserSwitchResult() {
         return localPaymentBrowserSwitchResult;
-    }
-
-    public LiveData<BrowserSwitchResult> getPayPalBrowserSwitchResult() {
-        return payPalBrowserSwitchResult;
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -1,5 +1,8 @@
 package com.braintreepayments.demo;
 
+import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalCheckoutRequest;
+import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalVaultRequest;
+
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,19 +12,14 @@ import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.PayPalAccountNonce;
+import com.braintreepayments.api.PayPalClient;
 import com.braintreepayments.api.PayPalListener;
 import com.braintreepayments.api.PaymentMethodNonce;
-import com.braintreepayments.api.BrowserSwitchResult;
-import com.braintreepayments.api.DataCollector;
-import com.braintreepayments.api.PayPalClient;
-
-import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalCheckoutRequest;
-import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalVaultRequest;
 
 public class PayPalFragment extends BaseFragment implements PayPalListener {
 
@@ -30,15 +28,12 @@ public class PayPalFragment extends BaseFragment implements PayPalListener {
     private PayPalClient payPalClient;
     private DataCollector dataCollector;
 
-    private Button billingAgreementButton;
-    private Button singlePaymentButton;
-
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_paypal, container, false);
-        billingAgreementButton = view.findViewById(R.id.paypal_billing_agreement_button);
-        singlePaymentButton = view.findViewById(R.id.paypal_single_payment_button);
+        Button billingAgreementButton = view.findViewById(R.id.paypal_billing_agreement_button);
+        Button singlePaymentButton = view.findViewById(R.id.paypal_single_payment_button);
 
         billingAgreementButton.setOnClickListener(this::launchBillingAgreement);
         singlePaymentButton.setOnClickListener(this::launchSinglePayment);

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -13,6 +13,8 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.PayPalAccountNonce;
+import com.braintreepayments.api.PayPalListener;
 import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.BrowserSwitchResult;
 import com.braintreepayments.api.DataCollector;
@@ -21,9 +23,10 @@ import com.braintreepayments.api.PayPalClient;
 import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalCheckoutRequest;
 import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalVaultRequest;
 
-public class PayPalFragment extends BaseFragment {
+public class PayPalFragment extends BaseFragment implements PayPalListener {
 
     private String deviceData;
+    private BraintreeClient braintreeClient;
     private PayPalClient payPalClient;
     private DataCollector dataCollector;
 
@@ -40,9 +43,9 @@ public class PayPalFragment extends BaseFragment {
         billingAgreementButton.setOnClickListener(this::launchBillingAgreement);
         singlePaymentButton.setOnClickListener(this::launchSinglePayment);
 
-        DemoViewModel viewModel = new ViewModelProvider(getActivity()).get(DemoViewModel.class);
-        viewModel.getPayPalBrowserSwitchResult().observe(getViewLifecycleOwner(), this::handlePayPalBrowserSwitchResult);
-
+        braintreeClient = getBraintreeClient();
+        payPalClient = new PayPalClient(this, braintreeClient);
+        payPalClient.setListener(this);
         return view;
     }
 
@@ -58,8 +61,6 @@ public class PayPalFragment extends BaseFragment {
         FragmentActivity activity = getActivity();
         activity.setProgressBarIndeterminateVisibility(true);
 
-        BraintreeClient braintreeClient = getBraintreeClient();
-        payPalClient = new PayPalClient(braintreeClient);
         dataCollector = new DataCollector(braintreeClient);
 
         braintreeClient.getConfiguration((configuration, configError) -> {
@@ -67,22 +68,14 @@ public class PayPalFragment extends BaseFragment {
                 dataCollector.collectDeviceData(activity, (deviceData, dataCollectorError) -> this.deviceData = deviceData);
             }
             if (isBillingAgreement) {
-                payPalClient.tokenizePayPalAccount(activity, createPayPalVaultRequest(activity), payPalError -> {
-                    if (payPalError != null) {
-                        handleError(payPalError);
-                    }
-                });
+                payPalClient.tokenizePayPalAccount(activity, createPayPalVaultRequest(activity));
             } else {
-                payPalClient.tokenizePayPalAccount(activity, createPayPalCheckoutRequest(activity, "1.00"), payPalError -> {
-                    if (payPalError != null) {
-                        handleError(payPalError);
-                    }
-                });
+                payPalClient.tokenizePayPalAccount(activity, createPayPalCheckoutRequest(activity, "1.00"));
             }
         });
     }
 
-    private void handlePayPalResult(PaymentMethodNonce paymentMethodNonce, Exception error) {
+    private void handlePayPalResult(PaymentMethodNonce paymentMethodNonce) {
         if (paymentMethodNonce != null) {
             super.onPaymentMethodNonceCreated(paymentMethodNonce);
 
@@ -94,9 +87,13 @@ public class PayPalFragment extends BaseFragment {
         }
     }
 
-    public void handlePayPalBrowserSwitchResult(BrowserSwitchResult browserSwitchResult) {
-        if (browserSwitchResult != null) {
-            payPalClient.onBrowserSwitchResult(browserSwitchResult, (payPalAccountNonce, error) -> handlePayPalResult(payPalAccountNonce, error));
-        }
+    @Override
+    public void onPayPalSuccess(@NonNull PayPalAccountNonce payPalAccountNonce) {
+       handlePayPalResult(payPalAccountNonce);
+    }
+
+    @Override
+    public void onPayPalFailure(@NonNull Exception error) {
+        handleError(error);
     }
 }

--- a/LISTENER_MIGRATION.md
+++ b/LISTENER_MIGRATION.md
@@ -61,6 +61,8 @@ class MerchantFragment: Fragment(), VenmoListener {
 
 ## 3DS
 
+## ThreeDSecure
+
 ```kotlin
 // MerchantActivity.kt
 class MerchantActivity : AppCompatActivity(), ThreeDSecureListener {
@@ -122,6 +124,59 @@ class MerchantFragment: Fragment(), ThreeDSecureListener {
     }
     
     override fun onThreeDSecureFailure(error: Exception) {
+        // handle error
+    }
+}
+```
+
+## PayPal
+
+```kotlin
+// MerchantActivity.kt
+class MerchantActivity : AppCompatActivity(), PayPalListener {
+
+    lateinit var braintreeClient: BraintreeClient
+    lateinit var payPalClient: PayPalClient
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        braintreeClient =
+          BraintreeClient(this, MerchantClientTokenProvider())
+          
+        payPalClient = VenmoClient(this, braintreeClient)
+        payPalClient.listener = this
+    }
+   
+    override fun onPayPalSuccess(payPalAccountNonce: PayPalAccountNonce) {
+        // send nonce to server and create a transaction
+    }
+    
+    override fun onPayPalFailure(error: Exception) {
+        // handle error
+    }
+}
+// MerchantFragment.kt
+class MerchantFragment: Fragment(), PayPalListener {
+
+    lateinit var braintreeClient: BraintreeClient
+    lateinit var payPalClient: PayPalClient
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        braintreeClient =
+          BraintreeClient(this, MerchantClientTokenProvider())
+          
+        payPalClient = PayPalClient(this, braintreeClient)
+        payPalClient.listener = this
+    }
+    
+    override fun onPayPalSuccess(payPalAccountNonce: payPalAccountNonce) {
+        // send nonce to server and create a transaction
+    }
+    
+    override fun onPayPalFailure(error: Exception) {
         // handle error
     }
 }

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation deps.powermockMockito
     testImplementation deps.powermockClassloading
     testImplementation deps.jsonAssert
+    testImplementation deps.mockitoCore
     testImplementation project(':TestUtils')
 }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -43,6 +43,10 @@ public class PayPalClient {
     PayPalClient(FragmentActivity activity, Lifecycle lifecycle, BraintreeClient braintreeClient, PayPalInternalClient internalPayPalClient) {
         this.braintreeClient = braintreeClient;
         this.internalPayPalClient = internalPayPalClient;
+        if (activity != null && lifecycle != null) {
+            PayPalLifecycleObserver observer = new PayPalLifecycleObserver(this);
+            lifecycle.addObserver(observer);
+        }
     }
 
     /**

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -90,7 +90,14 @@ public class PayPalClient {
      * @param payPalRequest a {@link PayPalRequest} used to customize the request.
      */
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalRequest payPalRequest) {
-        // TODO: implement
+        tokenizePayPalAccount(activity, payPalRequest, new PayPalFlowStartedCallback() {
+            @Override
+            public void onResult(@Nullable Exception error) {
+                if (error != null) {
+                    listener.onPayPalFailure(error);
+                }
+            }
+        });
     }
 
     /**

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -23,7 +23,9 @@ public class PayPalClient {
     private final PayPalInternalClient internalPayPalClient;
 
     private PayPalListener listener;
-    private BrowserSwitchResult pendingBrowserSwitchResult;
+
+    @VisibleForTesting
+    BrowserSwitchResult pendingBrowserSwitchResult;
 
     public PayPalClient(@NonNull FragmentActivity activity, @NonNull BraintreeClient braintreeClient) {
         this(activity, activity.getLifecycle(), braintreeClient, new PayPalInternalClient(braintreeClient));

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -30,11 +31,11 @@ public class PayPalClient {
     }
     
     public PayPalClient(@NonNull BraintreeClient braintreeClient) {
-        this(braintreeClient, new PayPalInternalClient(braintreeClient));
+        this(null, null, braintreeClient, new PayPalInternalClient(braintreeClient));
     }
 
     @VisibleForTesting
-    PayPalClient(BraintreeClient braintreeClient, PayPalInternalClient internalPayPalClient) {
+    PayPalClient(FragmentActivity activity, Lifecycle lifecycle, BraintreeClient braintreeClient, PayPalInternalClient internalPayPalClient) {
         this.braintreeClient = braintreeClient;
         this.internalPayPalClient = internalPayPalClient;
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import org.json.JSONException;
@@ -17,10 +18,17 @@ import org.json.JSONObject;
  */
 public class PayPalClient {
 
-    private final BraintreeClient braintreeClient;
+    private BraintreeClient braintreeClient;
+    private PayPalInternalClient internalPayPalClient;
 
-    private final PayPalInternalClient internalPayPalClient;
+    public PayPalClient(@NonNull FragmentActivity fragmentActivity, @NonNull BraintreeClient braintreeClient) {
+        // TODO: implement
+    }
 
+    public PayPalClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
+        // TODO: implement
+    }
+    
     public PayPalClient(@NonNull BraintreeClient braintreeClient) {
         this(braintreeClient, new PayPalInternalClient(braintreeClient));
     }
@@ -29,6 +37,17 @@ public class PayPalClient {
     PayPalClient(BraintreeClient braintreeClient, PayPalInternalClient internalPayPalClient) {
         this.braintreeClient = braintreeClient;
         this.internalPayPalClient = internalPayPalClient;
+    }
+
+    /**
+     * Add a {@link PayPalListener} to your client to receive results or errors from the PayPal flow.
+     * This method must be invoked on a {@link PayPalClient(Fragment, BraintreeClient)} or
+     * {@link PayPalClient(FragmentActivity, BraintreeClient)} in order to receive results.
+     *
+     * @param listener a {@link PayPalListener}
+     */
+    public void setListener(PayPalListener listener) {
+        // TODO: implement
     }
 
     private static boolean payPalConfigInvalid(Configuration configuration) {
@@ -54,11 +73,27 @@ public class PayPalClient {
 
     /**
      * Tokenize a PayPal account for vault or checkout.
+     * 
+     * This method must be invoked on a {@link PayPalClient(Fragment, BraintreeClient)} or
+     * {@link PayPalClient(FragmentActivity, BraintreeClient)} in order to receive results.
+     *
+     * @param activity      Android FragmentActivity
+     * @param payPalRequest a {@link PayPalRequest} used to customize the request.
+     */
+    public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalRequest payPalRequest) {
+        // TODO: implement
+    }
+
+    /**
+     * Tokenize a PayPal account for vault or checkout.
+     * 
+     * Deprecated. Use {@link PayPalClient#tokenizePayPalAccount(FragmentActivity, PayPalRequest)}
      *
      * @param activity      Android FragmentActivity
      * @param payPalRequest a {@link PayPalRequest} used to customize the request.
      * @param callback      {@link PayPalFlowStartedCallback}
      */
+    @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalRequest payPalRequest, @NonNull final PayPalFlowStartedCallback callback) {
         if (payPalRequest instanceof PayPalCheckoutRequest) {
             sendCheckoutRequest(activity, (PayPalCheckoutRequest) payPalRequest, callback);
@@ -192,10 +227,17 @@ public class PayPalClient {
         return request instanceof PayPalVaultRequest ? "paypal.billing-agreement" : "paypal.single-payment";
     }
 
+    void onBrowserSwitchResult(FragmentActivity activity) {
+        // TODO: implement
+    }
+
     /**
+     * Deprecated. Use {@link PayPalListener} to handle results.
+     *
      * @param browserSwitchResult a {@link BrowserSwitchResult} with a {@link BrowserSwitchStatus}
      * @param callback            {@link PayPalBrowserSwitchResultCallback}
      */
+    @Deprecated
     public void onBrowserSwitchResult(@NonNull BrowserSwitchResult browserSwitchResult, @NonNull final PayPalBrowserSwitchResultCallback callback) {
         //noinspection ConstantConditions
         if (browserSwitchResult == null) {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -269,6 +269,10 @@ public class PayPalClient {
         this.pendingBrowserSwitchResult = null;
     }
 
+    BrowserSwitchResult getBrowserSwitchResult(FragmentActivity activity) {
+        return braintreeClient.getBrowserSwitchResult(activity);
+    }
+
     /**
      * Deprecated. Use {@link PayPalListener} to handle results.
      *

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -27,6 +27,7 @@ public class PayPalClient {
     @VisibleForTesting
     BrowserSwitchResult pendingBrowserSwitchResult;
 
+    // TODO: doc strings
     public PayPalClient(@NonNull FragmentActivity activity, @NonNull BraintreeClient braintreeClient) {
         this(activity, activity.getLifecycle(), braintreeClient, new PayPalInternalClient(braintreeClient));
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -27,15 +27,35 @@ public class PayPalClient {
     @VisibleForTesting
     BrowserSwitchResult pendingBrowserSwitchResult;
 
-    // TODO: doc strings
+    /**
+     * Create a new instance of {@link PayPalClient} from within an Activity using a {@link BraintreeClient}.
+     *
+     * @param activity a {@link FragmentActivity}
+     * @param braintreeClient a {@link BraintreeClient}
+     */
     public PayPalClient(@NonNull FragmentActivity activity, @NonNull BraintreeClient braintreeClient) {
         this(activity, activity.getLifecycle(), braintreeClient, new PayPalInternalClient(braintreeClient));
     }
 
+    /**
+     * Create a new instance of {@link PayPalClient} from within a Fragment using a {@link BraintreeClient}.
+     *
+     * @param fragment a {@link Fragment
+     * @param braintreeClient a {@link BraintreeClient}
+     */
     public PayPalClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
         this(fragment.getActivity(), fragment.getLifecycle(), braintreeClient, new PayPalInternalClient(braintreeClient));
     }
-    
+
+    /**
+     * Create a new instance of {@link PayPalClient} using a {@link BraintreeClient}.
+     *
+     * Deprecated. Use {@link PayPalClient(Fragment, BraintreeClient)} or
+     * {@link PayPalClient(FragmentActivity, BraintreeClient)}.
+     *
+     * @param braintreeClient a {@link BraintreeClient}
+     */
+    @Deprecated
     public PayPalClient(@NonNull BraintreeClient braintreeClient) {
         this(null, null, braintreeClient, new PayPalInternalClient(braintreeClient));
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
@@ -2,8 +2,12 @@ package com.braintreepayments.api;
 
 import static androidx.lifecycle.Lifecycle.Event.ON_RESUME;
 
+import static com.braintreepayments.api.BraintreeRequestCodes.PAYPAL;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.LifecycleOwner;
@@ -18,9 +22,21 @@ class PayPalLifecycleObserver implements LifecycleEventObserver {
     }
 
     @Override
-    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+    public void onStateChanged(@NonNull LifecycleOwner lifecycleOwner, @NonNull Lifecycle.Event event) {
        if (event == ON_RESUME) {
-           // TODO: implement
+           FragmentActivity activity = null;
+           if (lifecycleOwner instanceof FragmentActivity) {
+               activity = (FragmentActivity) lifecycleOwner;
+           } else if (lifecycleOwner instanceof Fragment) {
+               activity = ((Fragment) lifecycleOwner).getActivity();
+           }
+
+           if (activity != null) {
+               BrowserSwitchResult pendingResult = payPalClient.getBrowserSwitchResult(activity);
+               if (pendingResult != null && pendingResult.getRequestCode() == PAYPAL) {
+                   payPalClient.onBrowserSwitchResult(activity);
+               }
+           }
        }
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
@@ -3,13 +3,15 @@ package com.braintreepayments.api;
 import static androidx.lifecycle.Lifecycle.Event.ON_RESUME;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.LifecycleOwner;
 
 class PayPalLifecycleObserver implements LifecycleEventObserver {
 
-    private final PayPalClient payPalClient;
+    @VisibleForTesting
+    final PayPalClient payPalClient;
 
     PayPalLifecycleObserver(PayPalClient payPalClient) {
         this.payPalClient = payPalClient;

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
@@ -1,0 +1,24 @@
+package com.braintreepayments.api;
+
+import static androidx.lifecycle.Lifecycle.Event.ON_RESUME;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+class PayPalLifecycleObserver implements LifecycleEventObserver {
+
+    private final PayPalClient payPalClient;
+
+    PayPalLifecycleObserver(PayPalClient payPalClient) {
+        this.payPalClient = payPalClient;
+    }
+
+    @Override
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+       if (event == ON_RESUME) {
+           // TODO: implement
+       }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalListener.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalListener.java
@@ -1,0 +1,22 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Implement this interface to receive PayPal result notifications.
+ */
+public interface PayPalListener {
+
+    /**
+     * Called when PayPal tokenization is complete without error.
+     * @param payPalAccountNonce PayPal tokenization result
+     */
+    void onPayPalSuccess(@NonNull PayPalAccountNonce payPalAccountNonce);
+
+    /**
+     * Called when PayPal tokenization has failed with an error.
+     * @param error explains reason for PayPal failure.
+     */
+    void onPayPalFailure(@NonNull Exception error);
+
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/MockPayPalInternalClientBuilder.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/MockPayPalInternalClientBuilder.java
@@ -13,14 +13,20 @@ public class MockPayPalInternalClientBuilder {
 
     private Exception error;
     private PayPalResponse successResponse;
+    private PayPalAccountNonce tokenizeSuccess;
 
-    public MockPayPalInternalClientBuilder success(PayPalResponse successResponse) {
+    public MockPayPalInternalClientBuilder sendRequestSuccess(PayPalResponse successResponse) {
         this.successResponse = successResponse;
         return this;
     }
 
-    public MockPayPalInternalClientBuilder error(Exception error) {
+    public MockPayPalInternalClientBuilder sendRequestError(Exception error) {
         this.error = error;
+        return this;
+    }
+
+    public MockPayPalInternalClientBuilder tokenizeSuccess(PayPalAccountNonce tokenizeSuccess) {
+        this.tokenizeSuccess = tokenizeSuccess;
         return this;
     }
 
@@ -39,6 +45,15 @@ public class MockPayPalInternalClientBuilder {
                 return null;
             }
         }).when(payPalInternalClient).sendRequest(any(Context.class), any(PayPalRequest.class), any(PayPalInternalClientCallback.class));
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                PayPalBrowserSwitchResultCallback callback = (PayPalBrowserSwitchResultCallback) invocation.getArguments()[1];
+                callback.onResult(tokenizeSuccess, null);
+                return null;
+            }
+        }).when(payPalInternalClient).tokenize(any(PayPalAccount.class), any(PayPalBrowserSwitchResultCallback.class));
 
         return payPalInternalClient;
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -37,7 +37,6 @@ public class PayPalClientUnitTest {
     private Configuration payPalDisabledConfig;
 
     private PayPalBrowserSwitchResultCallback payPalBrowserSwitchResultCallback;
-    private PayPalFlowStartedCallback payPalFlowStartedCallback;
 
     @Before
     public void beforeEach() throws JSONException {
@@ -49,7 +48,6 @@ public class PayPalClientUnitTest {
         payPalDisabledConfig = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_DISABLED_PAYPAL);
 
         payPalBrowserSwitchResultCallback = mock(PayPalBrowserSwitchResultCallback.class);
-        payPalFlowStartedCallback = mock(PayPalFlowStartedCallback.class);
     }
 
     @Test
@@ -184,8 +182,6 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalVaultRequest);
 
-        verify(payPalFlowStartedCallback).onResult(null);
-
         ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
         verify(braintreeClient).startBrowserSwitch(same(activity), captor.capture());
 
@@ -248,8 +244,6 @@ public class PayPalClientUnitTest {
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
-
-        verify(payPalFlowStartedCallback).onResult(null);
 
         ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
         verify(braintreeClient).startBrowserSwitch(same(activity), captor.capture());

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -747,4 +747,17 @@ public class PayPalClientUnitTest {
         sut.onBrowserSwitchResult(activity);
         verify(listener).onPayPalSuccess(same(payPalAccountNonce));
     }
+
+    @Test
+    public void getBrowserSwitchResult_getsBrowserSwitchResultFromBraintreeClient() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        BraintreeClient braintreeClient = mock(BraintreeClient.class);
+        when(braintreeClient.getBrowserSwitchResult(activity)).thenReturn(browserSwitchResult);
+
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+
+        BrowserSwitchResult result = sut.getBrowserSwitchResult(activity);
+        assertSame(browserSwitchResult, result);
+    }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -47,14 +47,13 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_whenPayPalNotEnabled_throwsError() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalDisabledConfig)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, new PayPalVaultRequest(), payPalFlowStartedCallback);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -67,7 +66,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_whenDeviceCantPerformBrowserSwitch_throwsError() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -75,7 +73,7 @@ public class PayPalClientUnitTest {
                 .canPerformBrowserSwitch(false)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, new PayPalVaultRequest(), payPalFlowStartedCallback);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -89,8 +87,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_startsBrowser() throws JSONException, BrowserSwitchException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
-
         PayPalVaultRequest payPalVaultRequest = new PayPalVaultRequest();
         payPalVaultRequest.setMerchantAccountId("sample-merchant-account-id");
 
@@ -99,14 +95,14 @@ public class PayPalClientUnitTest {
                 .successUrl("https://example.com/success/url")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
-                .success(payPalResponse)
+                .sendRequestSuccess(payPalResponse)
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalVaultRequest, payPalFlowStartedCallback);
 
         verify(payPalFlowStartedCallback).onResult(null);
@@ -130,8 +126,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_sendsAnalyticsEvents() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
-
         PayPalVaultRequest payPalVaultRequest = new PayPalVaultRequest();
         payPalVaultRequest.setMerchantAccountId("sample-merchant-account-id");
 
@@ -140,7 +134,7 @@ public class PayPalClientUnitTest {
                 .successUrl("https://example.com/success/url")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
-                .success(payPalResponse)
+                .sendRequestSuccess(payPalResponse)
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -148,7 +142,7 @@ public class PayPalClientUnitTest {
                 .canPerformBrowserSwitch(true)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalVaultRequest, payPalFlowStartedCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.selected");
@@ -157,8 +151,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void requestOneTimePayment_startsBrowser() throws JSONException, BrowserSwitchException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
-
         PayPalCheckoutRequest payPalCheckoutRequest = new PayPalCheckoutRequest("1.00");
         payPalCheckoutRequest.setIntent("authorize");
         payPalCheckoutRequest.setMerchantAccountId("sample-merchant-account-id");
@@ -168,14 +160,14 @@ public class PayPalClientUnitTest {
                 .successUrl("https://example.com/success/url")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
-                .success(payPalResponse)
+                .sendRequestSuccess(payPalResponse)
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalCheckoutRequest, payPalFlowStartedCallback);
 
         verify(payPalFlowStartedCallback).onResult(null);
@@ -200,14 +192,13 @@ public class PayPalClientUnitTest {
 
     @Test
     public void requestOneTimePayment_whenPayPalNotEnabled_throwsError() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalDisabledConfig)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, new PayPalCheckoutRequest("1.00"), payPalFlowStartedCallback);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -220,7 +211,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void requestOneTimePayment_whenDeviceCantPerformBrowserSwitch_throwsError() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -228,7 +218,7 @@ public class PayPalClientUnitTest {
                 .canPerformBrowserSwitch(false)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, new PayPalCheckoutRequest("1.00"), payPalFlowStartedCallback);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
@@ -243,8 +233,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void requestOneTimePayment_sendsBrowserSwitchStartAnalyticsEvent() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
-
         PayPalCheckoutRequest payPalCheckoutRequest = new PayPalCheckoutRequest("1.00");
         payPalCheckoutRequest.setIntent("authorize");
         payPalCheckoutRequest.setMerchantAccountId("sample-merchant-account-id");
@@ -254,14 +242,14 @@ public class PayPalClientUnitTest {
                 .successUrl("https://example.com/success/url")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
-                .success(payPalResponse)
+                .sendRequestSuccess(payPalResponse)
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
                 .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalCheckoutRequest, payPalFlowStartedCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.selected");
@@ -271,10 +259,9 @@ public class PayPalClientUnitTest {
     @Test
     public void requestOneTimePayment_sendsPayPalPayLaterOfferedAnalyticsEvent() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00");
         request.setShouldOfferPayLater(true);
         sut.tokenizePayPalAccount(context, request, payPalFlowStartedCallback);
@@ -284,7 +271,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_sendsPayPalRequestViaInternalClient() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -293,7 +279,7 @@ public class PayPalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalRequest, payPalFlowStartedCallback);
 
         verify(payPalInternalClient).sendRequest(same(context), same(payPalRequest), any(PayPalInternalClientCallback.class));
@@ -301,7 +287,6 @@ public class PayPalClientUnitTest {
 
     @Test
     public void requestOneTimePayment_sendsPayPalRequestViaInternalClient() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
@@ -310,7 +295,7 @@ public class PayPalClientUnitTest {
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalRequest, payPalFlowStartedCallback);
 
         verify(payPalInternalClient).sendRequest(same(context), same(payPalRequest), any(PayPalInternalClientCallback.class));
@@ -318,14 +303,13 @@ public class PayPalClientUnitTest {
 
     @Test
     public void tokenizePayPalAccount_sendsPayPalCreditOfferedAnalyticsEvent() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setShouldOfferCredit(true);
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(context, payPalRequest, payPalFlowStartedCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.credit.offered");
@@ -333,11 +317,10 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_withBillingAgreement_tokenizesResponseOnSuccess() throws JSONException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&ba_token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -359,7 +342,7 @@ public class PayPalClientUnitTest {
         sut.onBrowserSwitchResult(browserSwitchResult, payPalBrowserSwitchResultCallback);
 
         ArgumentCaptor<PayPalAccount> captor = ArgumentCaptor.forClass(PayPalAccount.class);
-        verify(apiClient).tokenizeREST(captor.capture(), any(TokenizeCallback.class));
+        verify(payPalInternalClient).tokenize(captor.capture(), any(PayPalBrowserSwitchResultCallback.class));
 
         PayPalAccount payPalAccount = captor.getValue();
         JSONObject tokenizePayload = payPalAccount.buildJSON();
@@ -379,11 +362,10 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_withOneTimePayment_tokenizesResponseOnSuccess() throws JSONException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -405,7 +387,7 @@ public class PayPalClientUnitTest {
         sut.onBrowserSwitchResult(browserSwitchResult, payPalBrowserSwitchResultCallback);
 
         ArgumentCaptor<PayPalAccount> captor = ArgumentCaptor.forClass(PayPalAccount.class);
-        verify(apiClient).tokenizeREST(captor.capture(), any(TokenizeCallback.class));
+        verify(payPalInternalClient).tokenize(captor.capture(), any(PayPalBrowserSwitchResultCallback.class));
 
         PayPalAccount payPalAccount = captor.getValue();
         JSONObject tokenizePayload = payPalAccount.buildJSON();
@@ -428,11 +410,10 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_withBillingAgreement_sendsAnalyticsEvents() throws JSONException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&ba_token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -458,11 +439,10 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_oneTimePayment_sendsAnalyticsEvents() throws JSONException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -488,13 +468,12 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_whenPayPalCreditPresent_sendsAnalyticsEvents() throws JSONException {
-        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
-        ApiClient apiClient = new MockApiClientBuilder()
-                .tokenizeRESTSuccess(new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE))
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
+                .tokenizeSuccess(PayPalAccountNonce.fromJSON(new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE)))
                 .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -520,10 +499,9 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_whenCancelUriReceived_notifiesCancellationAndSendsAnalyticsEvent() throws JSONException {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         String approvalUrl = "sample-scheme://onetouch/v1/cancel";
 
@@ -556,10 +534,9 @@ public class PayPalClientUnitTest {
 
     @Test
     public void onBrowserSwitchResult_whenBrowserSwitchCanceled_forwardsExceptionAndSendsAnalyticsEvent() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
         when(browserSwitchResult.getStatus()).thenReturn(BrowserSwitchStatus.CANCELED);
@@ -578,11 +555,10 @@ public class PayPalClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToCallbak() {
-        ApiClient apiClient = new MockApiClientBuilder().build();
+    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToCallback() {
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, apiClient, payPalInternalClient);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
 
         sut.onBrowserSwitchResult(null, payPalBrowserSwitchResultCallback);
 
@@ -592,5 +568,35 @@ public class PayPalClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof BraintreeException);
         assertEquals("BrowserSwitchResult cannot be null", exception.getMessage());
+    }
+
+    @Test
+    public void onBrowserSwitchResult_whenPayPalInternalClientTokenizeResult_forwardsResultToCallback() throws JSONException {
+        PayPalAccountNonce payPalAccountNonce = mock(PayPalAccountNonce.class);
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
+                .tokenizeSuccess(payPalAccountNonce)
+                .build();
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
+
+        String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN";
+
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        when(browserSwitchResult.getStatus()).thenReturn(BrowserSwitchStatus.SUCCESS);
+
+        when(browserSwitchResult.getRequestMetadata()).thenReturn(new JSONObject()
+                .put("client-metadata-id", "sample-client-metadata-id")
+                .put("merchant-account-id", "sample-merchant-account-id")
+                .put("intent", "authorize")
+                .put("approval-url", approvalUrl)
+                .put("success-url", "https://example.com/success")
+                .put("payment-type", "single-payment")
+        );
+
+        Uri uri = Uri.parse(approvalUrl);
+        when(browserSwitchResult.getDeepLinkUrl()).thenReturn(uri);
+
+        sut.onBrowserSwitchResult(browserSwitchResult, payPalBrowserSwitchResultCallback);
+        verify(payPalBrowserSwitchResultCallback).onResult(same(payPalAccountNonce), (Exception) isNull());
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -380,6 +380,7 @@ public class PayPalClientUnitTest {
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
 
         sut.onBrowserSwitchResult(activity);
 
@@ -428,6 +429,7 @@ public class PayPalClientUnitTest {
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
 
         sut.onBrowserSwitchResult(activity);
 
@@ -471,14 +473,15 @@ public class PayPalClientUnitTest {
                 .put("payment-type", "billing-agreement")
         );
 
+        Uri uri = Uri.parse(approvalUrl);
+        when(browserSwitchResult.getDeepLinkUrl()).thenReturn(uri);
+
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .deliverBrowserSwitchResult(browserSwitchResult)
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
-
-        Uri uri = Uri.parse(approvalUrl);
-        when(browserSwitchResult.getDeepLinkUrl()).thenReturn(uri);
+        sut.setListener(listener);
 
         sut.onBrowserSwitchResult(activity);
 
@@ -511,6 +514,7 @@ public class PayPalClientUnitTest {
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
 
         sut.onBrowserSwitchResult(activity);
 
@@ -522,7 +526,6 @@ public class PayPalClientUnitTest {
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
                 .tokenizeSuccess(PayPalAccountNonce.fromJSON(new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE)))
                 .build();
-
 
         String approvalUrl = "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN";
 
@@ -545,6 +548,7 @@ public class PayPalClientUnitTest {
                 .deliverBrowserSwitchResult(browserSwitchResult)
                 .build();
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
 
         sut.onBrowserSwitchResult(activity);
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -2,6 +2,7 @@ package com.braintreepayments.api;
 
 import android.net.Uri;
 
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Lifecycle;
 
@@ -17,6 +18,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
@@ -52,22 +54,60 @@ public class PayPalClientUnitTest {
 
     @Test
     public void constructor_setsLifecycleObserver() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+
+        ArgumentCaptor<PayPalLifecycleObserver> captor = ArgumentCaptor.forClass(PayPalLifecycleObserver.class);
+        verify(lifecycle).addObserver(captor.capture());
+
+        PayPalLifecycleObserver observer = captor.getValue();
+        assertSame(sut, observer.payPalClient);
     }
 
     @Test
     public void constructor_withFragment_passesFragmentLifecycleAndActivityToObserver() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
+        Fragment fragment = mock(Fragment.class);
+        when(fragment.getActivity()).thenReturn(activity);
+        when(fragment.getLifecycle()).thenReturn(lifecycle);
+
+        PayPalClient sut = new PayPalClient(fragment, braintreeClient);
+
+        ArgumentCaptor<PayPalLifecycleObserver> captor = ArgumentCaptor.forClass(PayPalLifecycleObserver.class);
+        verify(lifecycle).addObserver(captor.capture());
+
+        PayPalLifecycleObserver observer = captor.getValue();
+        assertSame(sut, observer.payPalClient);
     }
 
     @Test
     public void constructor_withFragmentActivity_passesActivityLifecycleAndActivityToObserver() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
+        FragmentActivity activity = mock(FragmentActivity.class);
+        when(activity.getLifecycle()).thenReturn(lifecycle);
+
+        PayPalClient sut = new PayPalClient(activity, braintreeClient);
+
+        ArgumentCaptor<PayPalLifecycleObserver> captor = ArgumentCaptor.forClass(PayPalLifecycleObserver.class);
+        verify(lifecycle).addObserver(captor.capture());
+
+        PayPalLifecycleObserver observer = captor.getValue();
+        assertSame(sut, observer.payPalClient);
     }
 
     @Test
     public void constructor_withoutFragmentOrActivity_doesNotSetObserver() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
+        PayPalClient sut = new PayPalClient(null, null, braintreeClient, payPalInternalClient);
+
+        ArgumentCaptor<PayPalLifecycleObserver> captor = ArgumentCaptor.forClass(PayPalLifecycleObserver.class);
+        verify(lifecycle, never()).addObserver(captor.capture());
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -696,25 +696,6 @@ public class PayPalClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenBrowserSwitchResultIsNull_returnsExceptionToListener() {
-        // TODO: delete this test?
-        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .deliverBrowserSwitchResult(null)
-                .build();
-        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
-
-        sut.onBrowserSwitchResult(activity);
-
-        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(payPalBrowserSwitchResultCallback).onResult((PayPalAccountNonce) isNull(), captor.capture());
-
-        Exception exception = captor.getValue();
-        assertTrue(exception instanceof BraintreeException);
-        assertEquals("BrowserSwitchResult cannot be null", exception.getMessage());
-    }
-
-    @Test
     public void onBrowserSwitchResult_whenPayPalInternalClientTokenizeResult_forwardsResultToListener() throws JSONException {
         PayPalAccountNonce payPalAccountNonce = mock(PayPalAccountNonce.class);
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -20,6 +21,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -37,6 +39,7 @@ public class PayPalInternalClientUnitTest {
     private TokenizationKey tokenizationKey;
 
     private PayPalDataCollector payPalDataCollector;
+    private ApiClient apiClient;
 
     PayPalInternalClientCallback payPalInternalClientCallback;
 
@@ -47,6 +50,7 @@ public class PayPalInternalClientUnitTest {
         tokenizationKey = mock(TokenizationKey.class);
 
         payPalDataCollector = mock(PayPalDataCollector.class);
+        apiClient = mock(ApiClient.class);
         payPalInternalClientCallback = mock(PayPalInternalClientCallback.class);
     }
 
@@ -59,7 +63,7 @@ public class PayPalInternalClientUnitTest {
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PostalAddress shippingAddressOverride = new PostalAddress();
         shippingAddressOverride.setRecipientName("Brianna Tree");
@@ -123,7 +127,7 @@ public class PayPalInternalClientUnitTest {
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PostalAddress shippingAddressOverride = new PostalAddress();
         shippingAddressOverride.setRecipientName("Brianna Tree");
@@ -209,7 +213,7 @@ public class PayPalInternalClientUnitTest {
                 .build();
         when(tokenizationKey.getBearer()).thenReturn("tokenization-key-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -231,7 +235,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setDisplayName("");
@@ -253,7 +257,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setLocaleCode(null);
@@ -275,7 +279,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setMerchantAccountId(null);
@@ -297,7 +301,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setShippingAddressOverride(null);
@@ -320,7 +324,7 @@ public class PayPalInternalClientUnitTest {
                 .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setShippingAddressEditable(false);
@@ -344,7 +348,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setBillingAgreementDescription("");
@@ -366,7 +370,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -387,7 +391,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         payPalRequest.setLineItems(new ArrayList<PayPalLineItem>());
@@ -412,7 +416,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         payPalRequest.setRiskCorrelationId("risk-correlation-id");
@@ -436,7 +440,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
 
@@ -457,7 +461,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationSuccess(tokenizationKey)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         payPalRequest.setShouldRequestBillingAgreement(false);
@@ -485,7 +489,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_BILLING_AGREEMENT_RESPONSE)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
         payPalRequest.setMerchantAccountId("sample-merchant-account-id");
@@ -518,7 +522,7 @@ public class PayPalInternalClientUnitTest {
                 .returnUrlScheme("sample-scheme")
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         payPalRequest.setIntent("authorize");
@@ -551,7 +555,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         payPalRequest.setIntent("authorize");
@@ -577,7 +581,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_BILLING_AGREEMENT_RESPONSE)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
 
@@ -602,7 +606,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTErrorResponse(httpError)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -618,7 +622,7 @@ public class PayPalInternalClientUnitTest {
                 .sendPOSTSuccessfulResponse("{bad:")
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -633,7 +637,7 @@ public class PayPalInternalClientUnitTest {
                 .authorizationError(authError)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -649,11 +653,62 @@ public class PayPalInternalClientUnitTest {
                 .configurationError(configurationError)
                 .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector);
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         verify(payPalInternalClientCallback).onResult(null, configurationError);
+    }
+
+    @Test
+    public void tokenize_tokenizesWithApiClient() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+        PayPalAccount payPalAccount = mock(PayPalAccount.class);
+        PayPalBrowserSwitchResultCallback callback = mock(PayPalBrowserSwitchResultCallback.class);
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        sut.tokenize(payPalAccount, callback);
+
+        verify(apiClient).tokenizeREST(same(payPalAccount), any(TokenizeCallback.class));
+    }
+
+    @Test
+    public void tokenize_onTokenizeResult_returnsAccountNonceToCallback() throws JSONException {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+        ApiClient apiClient = new MockApiClientBuilder()
+                .tokenizeRESTSuccess(new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE))
+                .build();
+        PayPalAccount payPalAccount = mock(PayPalAccount.class);
+        PayPalBrowserSwitchResultCallback callback = mock(PayPalBrowserSwitchResultCallback.class);
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        sut.tokenize(payPalAccount, callback);
+
+        ArgumentCaptor<PayPalAccountNonce> captor = ArgumentCaptor.forClass(PayPalAccountNonce.class);
+        verify(callback).onResult(captor.capture(), (Exception) isNull());
+
+        PayPalAccountNonce expectedNonce = PayPalAccountNonce.fromJSON(new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE));
+        PayPalAccountNonce result = captor.getValue();
+        assertEquals(expectedNonce.getString(), result.getString());
+    }
+
+    @Test
+    public void tokenize_onTokenizeError_returnsErrorToCallback() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
+        Exception error = new Exception("error");
+        ApiClient apiClient = new MockApiClientBuilder()
+                .tokenizeRESTError(error)
+                .build();
+        PayPalAccount payPalAccount = mock(PayPalAccount.class);
+        PayPalBrowserSwitchResultCallback callback = mock(PayPalBrowserSwitchResultCallback.class);
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        sut.tokenize(payPalAccount, callback);
+
+        verify(callback).onResult((PayPalAccountNonce) isNull(), same(error));
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
@@ -1,0 +1,24 @@
+package com.braintreepayments.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class PayPalLifecycleObserverUnitTest {
+
+    @Test
+    public void onResume_whenLifeCycleObserverIsFragment_payPalClientDeliversResultWithFragmentActivity() {
+
+    }
+
+    @Test
+    public void onResume_whenLifeCycleObserverIsActivity_payPalClientDeliversResultWithSameActivity() {
+
+    }
+
+    @Test
+    public void onResume_whenPendingBrowserSwitchResultExists_andRequestCodeNotPayPal_doesNothing() {
+
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
@@ -1,5 +1,18 @@
 package com.braintreepayments.api;
 
+import static com.braintreepayments.api.BraintreeRequestCodes.PAYPAL;
+import static com.braintreepayments.api.BraintreeRequestCodes.THREE_D_SECURE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -9,16 +22,54 @@ public class PayPalLifecycleObserverUnitTest {
 
     @Test
     public void onResume_whenLifeCycleObserverIsFragment_payPalClientDeliversResultWithFragmentActivity() {
+        Fragment fragment = mock(Fragment.class);
+        FragmentActivity activity = mock(FragmentActivity.class);
+        when(fragment.getActivity()).thenReturn(activity);
 
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
+
+        PayPalClient payPalClient = mock(PayPalClient.class);
+        when(payPalClient.getBrowserSwitchResult(activity)).thenReturn(browserSwitchResult);
+
+        PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
+
+        sut.onStateChanged(fragment, Lifecycle.Event.ON_RESUME);
+
+        verify(payPalClient).onBrowserSwitchResult(same(activity));
     }
 
     @Test
     public void onResume_whenLifeCycleObserverIsActivity_payPalClientDeliversResultWithSameActivity() {
+        FragmentActivity activity = mock(FragmentActivity.class);
 
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
+
+        PayPalClient payPalClient = mock(PayPalClient.class);
+        when(payPalClient.getBrowserSwitchResult(activity)).thenReturn(browserSwitchResult);
+
+        PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
+
+        sut.onStateChanged(activity, Lifecycle.Event.ON_RESUME);
+
+        verify(payPalClient).onBrowserSwitchResult(same(activity));
     }
 
     @Test
     public void onResume_whenPendingBrowserSwitchResultExists_andRequestCodeNotPayPal_doesNothing() {
+        FragmentActivity activity = mock(FragmentActivity.class);
 
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        when(browserSwitchResult.getRequestCode()).thenReturn(THREE_D_SECURE);
+
+        PayPalClient payPalClient = mock(PayPalClient.class);
+        when(payPalClient.getBrowserSwitchResult(activity)).thenReturn(browserSwitchResult);
+
+        PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
+
+        sut.onStateChanged(activity, Lifecycle.Event.ON_RESUME);
+
+        verify(payPalClient, never()).onBrowserSwitchResult(any(FragmentActivity.class));
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add `PayPalListener` to receive results from the PayPal flow
- Deprecate methods requiring a callback in favor of listener pattern
- Move API logic to `PayPalInternalClient`

 ### Checklist

 - [x] Added a changelog entry
