### PR TITLE
Remove mention of setGoogleMerchantId in MIGRATION guides.

### DIFF
--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -541,7 +541,6 @@ public class GooglePayActivity extends AppCompatActivity implements GooglePayLis
       .setCurrencyCode("USD")
       .build());
     googlePayRequest.setBillingAddressRequired(true);
-    googlePayRequest.setGoogleMerchantId("merchant-id-from-google");
 
     googlePayClient.requestPayment(this, googlePayRequest);
   }

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -467,7 +467,6 @@ public class GooglePayActivity extends AppCompatActivity {
       .setCurrencyCode("USD")
       .build());
     googlePayRequest.setBillingAddressRequired(true);
-    googlePayRequest.setGoogleMerchantId("merchant-id-from-google");
 
     googlePayClient.requestPayment(this, googlePayRequest, (success, error) -> {
       if (error != null) {


### PR DESCRIPTION
### Summary of changes

 - This PR removes mention of `setGoogleMerchantId` for setting up a `GooglePayRequest`. This is no longer required for Google Pay integrations.

 ### Checklist

 ~- [ ] Added a changelog entry~