### PR TITLE
Method on client token provider for caching authorization

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationLoader.java
@@ -6,16 +6,22 @@ import androidx.annotation.Nullable;
 class AuthorizationLoader {
 
     private Authorization authorization;
+
     private final ClientTokenProvider clientTokenProvider;
 
     AuthorizationLoader(@Nullable String initialAuthString, @Nullable ClientTokenProvider clientTokenProvider) {
         this.clientTokenProvider = clientTokenProvider;
         if (initialAuthString != null) {
-            this.authorization = Authorization.fromString(initialAuthString);
+            authorization = Authorization.fromString(initialAuthString);
         }
     }
 
     void loadAuthorization(@NonNull final AuthorizationCallback callback) {
+        // Clear the token prior to making the request if the token shouldn't be cached any longer
+        if (clientTokenProvider != null && clientTokenProvider.shouldUseCachedToken() && authorization != null) {
+            authorization = null;
+        }
+
         if (authorization != null) {
             callback.onAuthorizationResult(authorization, null);
         } else if (clientTokenProvider != null) {
@@ -33,7 +39,7 @@ class AuthorizationLoader {
             });
         } else {
             String clientSDKSetupURL
-                = "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#initialization";
+                    = "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#initialization";
             String message = String.format("Authorization required. See %s for more info.", clientSDKSetupURL);
             callback.onAuthorizationResult(null, new BraintreeException(message));
         }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientTokenProvider.java
@@ -4,13 +4,23 @@ import androidx.annotation.NonNull;
 
 /**
  * Implement this interface to provide an asynchronous way for {@link BraintreeClient} to fetch
- * a client token from your server when it is needed.
+ * a client token from your server when it is needed. A new client token is only fetched in this way
+ * if either an initial value was not passed to {@link BraintreeClient} during instantiation, or if
+ * {@link ClientTokenProvider#shouldUseCachedToken()} returns true
  */
 public interface ClientTokenProvider {
 
     /**
-     * Method used by {@link BraintreeClient} to fetch a client token.
+     * Method used by {@link BraintreeClient} to fetch a client token. This method is only called if
+     * needed (if an initial value was not provided, or if {@link ClientTokenProvider#shouldUseCachedToken()}
+     * returns true.
+     *
      * @param callback {@link ClientTokenCallback} to invoke to notify {@link BraintreeClient} of success (or failure) when fetching a client token
      */
     void getClientToken(@NonNull ClientTokenCallback callback);
+
+    /**
+     * @return true if the {@link BraintreeClient} should use cached client tokens.
+     */
+    boolean shouldUseCachedToken();
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -35,6 +35,11 @@ public class DemoClientTokenProvider implements ClientTokenProvider {
         }
     }
 
+    @Override
+    public boolean shouldUseCachedToken() {
+        return true;
+    }
+
     private static String getString(Context context, @StringRes int id) {
         return context.getResources().getString(id);
     }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

Resolves #544 

There is another option that adds the method `invalidateClientToken` on `BraintreeClient` seen in this PR: #547

I'll add tests and a changelog entry if / when we decide between the two PR's

### Summary of changes

 - Adds a `shouldUseCachedToken` method to the `ClientTokenProvider` that will be checked during the `loadAuthorization` call. If `true`, the cached authorization field will be set to null. 

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @josephyanks
