### PR TITLE
Add `isExplicitCancellation` to `UserCanceledException`

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
@@ -5,7 +5,27 @@ package com.braintreepayments.api;
  */
 public class UserCanceledException extends BraintreeException {
 
+    private boolean isExplicitCancellation;
+
     UserCanceledException(String message) {
         super(message);
+    }
+
+    UserCanceledException(String message, boolean isExplicitCancellation) {
+        super(message);
+        this.isExplicitCancellation = isExplicitCancellation;
+    }
+
+    /**
+     * @return whether or not the user explicitly canceled the payment flow.
+     *
+     * {@link true} if the user confirms cancellation of the payment flow.
+     *
+     * {@link false} if the user returns to the app without completing the payment flow and without
+     * performing an explicit cancellation action (i.e. presses the back button or closes the
+     * browser tab)
+     */
+    public boolean isExplicitCancellation() {
+        return isExplicitCancellation;
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
@@ -19,11 +19,12 @@ public class UserCanceledException extends BraintreeException {
     /**
      * @return whether or not the user explicitly canceled the payment flow.
      *
-     * {@link true} if the user confirms cancellation of the payment flow.
+     * {@link true} if the user manually confirms cancellation of the payment flow.
      *
-     * {@link false} if the user returns to the app without completing the payment flow and without
-     * performing an explicit cancellation action (i.e. presses the back button or closes the
-     * browser tab)
+     * {@link false} if the user returns to the app without completing the payment flow and the
+     * action performed to return to the app is unknown. For browser switching flows, this could
+     * mean the user returned to the app through multi-tasking without completing the flow, the user
+     * closed the browser tab, or the user pressed the back button.
      */
     public boolean isExplicitCancellation() {
         return isExplicitCancellation;

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UserCanceledException.java
@@ -5,15 +5,15 @@ package com.braintreepayments.api;
  */
 public class UserCanceledException extends BraintreeException {
 
-    private boolean isExplicitCancellation;
+    private boolean isExplicitCancelation;
 
     UserCanceledException(String message) {
         super(message);
     }
 
-    UserCanceledException(String message, boolean isExplicitCancellation) {
+    UserCanceledException(String message, boolean isExplicitCancelation) {
         super(message);
-        this.isExplicitCancellation = isExplicitCancellation;
+        this.isExplicitCancelation = isExplicitCancelation;
     }
 
     /**
@@ -26,7 +26,7 @@ public class UserCanceledException extends BraintreeException {
      * mean the user returned to the app through multi-tasking without completing the flow, the user
      * closed the browser tab, or the user pressed the back button.
      */
-    public boolean isExplicitCancellation() {
-        return isExplicitCancellation;
+    public boolean isExplicitCancelation() {
+        return isExplicitCancelation;
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
-* Add `isExplicitCancellation` parameter to `UserCanceledException`
+* Add `isExplicitCancelation` parameter to `UserCanceledException`
 
 ## 4.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+* Add `isExplicitCancellation` parameter to `UserCanceledException`
+
 ## 4.10.1
 
 * DataCollector

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayActivityResultContract.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayActivityResultContract.java
@@ -33,7 +33,7 @@ class GooglePayActivityResultContract extends ActivityResultContract<GooglePayIn
                 return new GooglePayResult(PaymentData.getFromIntent(intent), null);
             }
         } else if (resultCode == RESULT_CANCELED) {
-            return new GooglePayResult(null, new UserCanceledException("User canceled Google Pay."));
+            return new GooglePayResult(null, new UserCanceledException("User canceled Google Pay.", true));
         } else if (resultCode == RESULT_ERROR) {
             if (intent != null) {
                 return new GooglePayResult(null, new GooglePayException("An error was encountered during the Google Pay " +

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -383,7 +383,7 @@ public class GooglePayClient {
                     AutoResolveHelper.getStatusFromIntent(data)));
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
             braintreeClient.sendAnalyticsEvent("google-payment.canceled");
-            callback.onResult(null, new UserCanceledException("User canceled Google Pay."));
+            callback.onResult(null, new UserCanceledException("User canceled Google Pay.", true));
         }
     }
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayActivityResultContractUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayActivityResultContractUnitTest.java
@@ -74,7 +74,7 @@ public class GooglePayActivityResultContractUnitTest {
         Exception error = result.getError();
         assertTrue(error instanceof UserCanceledException);
         assertEquals("User canceled Google Pay.", error.getMessage());
-        assertTrue(((UserCanceledException) error).isExplicitCancellation());
+        assertTrue(((UserCanceledException) error).isExplicitCancelation());
         assertNull(result.getPaymentData());
     }
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayActivityResultContractUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayActivityResultContractUnitTest.java
@@ -74,6 +74,7 @@ public class GooglePayActivityResultContractUnitTest {
         Exception error = result.getError();
         assertTrue(error instanceof UserCanceledException);
         assertEquals("User canceled Google Pay.", error.getMessage());
+        assertTrue(((UserCanceledException) error).isExplicitCancellation());
         assertNull(result.getPaymentData());
     }
 

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -1354,7 +1354,7 @@ public class GooglePayClientUnitTest {
         Exception exception = captor.getValue();
         assertEquals("User canceled Google Pay.", exception.getMessage());
         assertTrue(exception instanceof UserCanceledException);
-        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
+        assertTrue(((UserCanceledException) exception).isExplicitCancelation());
     }
 
     @Test

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayClientUnitTest.java
@@ -1354,6 +1354,7 @@ public class GooglePayClientUnitTest {
         Exception exception = captor.getValue();
         assertEquals("User canceled Google Pay.", exception.getMessage());
         assertTrue(exception instanceof UserCanceledException);
+        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
     }
 
     @Test

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -378,7 +378,7 @@ public class PayPalClient {
         String status = uri.getLastPathSegment();
 
         if (!Uri.parse(successUrl).getLastPathSegment().equals(status)) {
-            throw new UserCanceledException("User canceled PayPal.");
+            throw new UserCanceledException("User canceled PayPal.", true);
         }
 
         String requestXoToken = Uri.parse(approvalUrl).getQueryParameter(tokenKey);

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -667,7 +667,7 @@ public class PayPalClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled PayPal.", exception.getMessage());
-        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
+        assertTrue(((UserCanceledException) exception).isExplicitCancelation());
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));
     }
@@ -693,7 +693,7 @@ public class PayPalClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled PayPal.", exception.getMessage());
-        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
+        assertFalse(((UserCanceledException) exception).isExplicitCancelation());
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -17,6 +17,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertSame;
 import static org.mockito.Matchers.any;
@@ -666,6 +667,7 @@ public class PayPalClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled PayPal.", exception.getMessage());
+        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));
     }
@@ -691,6 +693,7 @@ public class PayPalClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled PayPal.", exception.getMessage());
+        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
 
         verify(braintreeClient).sendAnalyticsEvent(eq("paypal.single-payment.browser-switch.canceled"));
     }

--- a/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayInternalClient.java
+++ b/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayInternalClient.java
@@ -151,7 +151,7 @@ class SamsungPayInternalClient {
             @Override
             public void onFailure(int errorCode, Bundle bundle) {
                 if (errorCode == SpaySdk.ERROR_USER_CANCELED) {
-                    UserCanceledException userCanceledError = new UserCanceledException("User canceled Samsung Pay.");
+                    UserCanceledException userCanceledError = new UserCanceledException("User canceled Samsung Pay.", true);
                     listener.onSamsungPayStartError(userCanceledError);
                 } else {
                     SamsungPayException samsungPayError = new SamsungPayException(errorCode);

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -32,6 +32,7 @@ import static com.samsung.android.sdk.samsungpay.v2.SpaySdk.EXTRA_ERROR_REASON;
 import static com.samsung.android.sdk.samsungpay.v2.SpaySdk.SPAY_NOT_READY;
 import static com.samsung.android.sdk.samsungpay.v2.SpaySdk.SPAY_NOT_SUPPORTED;
 import static com.samsung.android.sdk.samsungpay.v2.SpaySdk.SPAY_READY;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -352,5 +353,6 @@ public class SamsungPayInternalClientUnitTest {
 
         UserCanceledException error = captor.getValue();
         assertEquals("User canceled Samsung Pay.", error.getMessage());
+        assertTrue(error.isExplicitCancellation());
     }
 }

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -353,6 +353,6 @@ public class SamsungPayInternalClientUnitTest {
 
         UserCanceledException error = captor.getValue();
         assertEquals("User canceled Samsung Pay.", error.getMessage());
-        assertTrue(error.isExplicitCancellation());
+        assertTrue(error.isExplicitCancelation());
     }
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -522,7 +522,7 @@ public class ThreeDSecureClient {
                 braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.failed");
                 break;
             case CANCEL:
-                callback.onResult(null, new UserCanceledException("User canceled 3DS."));
+                callback.onResult(null, new UserCanceledException("User canceled 3DS.", true));
                 braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.canceled");
                 break;
         }
@@ -595,7 +595,7 @@ public class ThreeDSecureClient {
                     braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.failed");
                     break;
                 case CANCEL:
-                    listener.onThreeDSecureFailure(new UserCanceledException("User canceled 3DS."));
+                    listener.onThreeDSecureFailure(new UserCanceledException("User canceled 3DS.", true));
                     braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.canceled");
                     break;
             }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -281,6 +281,7 @@ public class ThreeDSecureClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
+        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
     }
 
     @Test
@@ -404,6 +405,7 @@ public class ThreeDSecureClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
+        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
     }
 
     @Test
@@ -498,8 +500,10 @@ public class ThreeDSecureClientUnitTest {
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onThreeDSecureFailure(captor.capture());
-        assertTrue(captor.getValue() instanceof UserCanceledException);
-        assertEquals("User canceled 3DS.", captor.getValue().getMessage());
+        Exception exception = captor.getValue();
+        assertTrue(exception instanceof UserCanceledException);
+        assertEquals("User canceled 3DS.", exception.getMessage());
+        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
 
         verify(braintreeClient).sendAnalyticsEvent("three-d-secure.verification-flow.canceled");
     }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -6,7 +6,6 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -281,7 +280,7 @@ public class ThreeDSecureClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
-        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
+        assertFalse(((UserCanceledException) exception).isExplicitCancelation());
     }
 
     @Test
@@ -405,7 +404,7 @@ public class ThreeDSecureClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
-        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
+        assertFalse(((UserCanceledException) exception).isExplicitCancelation());
     }
 
     @Test
@@ -503,7 +502,7 @@ public class ThreeDSecureClientUnitTest {
         Exception exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled 3DS.", exception.getMessage());
-        assertTrue(((UserCanceledException) exception).isExplicitCancellation());
+        assertTrue(((UserCanceledException) exception).isExplicitCancelation());
 
         verify(braintreeClient).sendAnalyticsEvent("three-d-secure.verification-flow.canceled");
     }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
@@ -9,6 +9,7 @@ import static com.braintreepayments.api.VenmoClient.EXTRA_MERCHANT_ID;
 import static com.braintreepayments.api.VenmoClient.EXTRA_RESOURCE_ID;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 
 import android.app.Activity;
@@ -86,5 +87,6 @@ public class VenmoActivityResultContractUnitTest {
 
         UserCanceledException error = (UserCanceledException) venmoResult.getError();
         assertNotNull("User canceled Venmo.", error.getMessage());
+        assertFalse(error.isExplicitCancellation());
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
@@ -87,6 +87,6 @@ public class VenmoActivityResultContractUnitTest {
 
         UserCanceledException error = (UserCanceledException) venmoResult.getError();
         assertNotNull("User canceled Venmo.", error.getMessage());
-        assertFalse(error.isExplicitCancellation());
+        assertFalse(error.isExplicitCancelation());
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -835,7 +835,9 @@ public class VenmoClientUnitTest {
         verify(onActivityResultCallback).onResult((VenmoAccountNonce) isNull(), captor.capture());
 
         BraintreeException exception = captor.getValue();
+        assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled Venmo.", exception.getMessage());
+        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
     }
 
     @Test

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -837,7 +837,7 @@ public class VenmoClientUnitTest {
         BraintreeException exception = captor.getValue();
         assertTrue(exception instanceof UserCanceledException);
         assertEquals("User canceled Venmo.", exception.getMessage());
-        assertFalse(((UserCanceledException) exception).isExplicitCancellation());
+        assertFalse(((UserCanceledException) exception).isExplicitCancelation());
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven {
             url = "https://plugins.gradle.org/m2/"
@@ -92,7 +92,7 @@ allprojects {
         }
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
### Summary of changes

 - Add `isExplicitCancellation` parameter to `UserCanceledException`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @mattwylder 
- @sarahkoop 
