### PR TITLE
Fix BraintreeSharedPreferences Instant App Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* SharedUtils
+  * Update `BraintreeSharedPreferences` to no-op when a reference to Android `EncryptedSharedPreferences` cannot be obtained (fixes #561)
 * ThreeDSecure
   * Bump Cardinal version to `2.2.6-2`
 

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -6,9 +6,6 @@ import android.content.SharedPreferences;
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
 class BraintreeSharedPreferences {
 
     private static volatile BraintreeSharedPreferences INSTANCE;
@@ -41,7 +38,9 @@ class BraintreeSharedPreferences {
                     EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             );
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (Exception ignored) {
+            // In the rare case that we are unable to obtain a reference to encrypted shared
+            // preferences, all preference update and retrieval logic will no-op
             return null;
         }
     }


### PR DESCRIPTION
### Summary of changes

 - This PR updates `BraintreeSharedPreferences` to defensively no-op when a reference to `EncryptedSharedPreferences` cannot be obtained.
 - Fixes #561

 ### Checklist

 - [x] Added a changelog entry
