### PR TITLE
Lazily Reference Kount

### DIFF
--- a/BraintreeDataCollector/src/main/java/com/braintreepayments/api/KountDataCollector.java
+++ b/BraintreeDataCollector/src/main/java/com/braintreepayments/api/KountDataCollector.java
@@ -11,19 +11,29 @@ import com.kount.api.DataCollector;
 class KountDataCollector {
 
     private final BraintreeClient braintreeClient;
-    private final DataCollector kountDataCollector;
 
     KountDataCollector(BraintreeClient braintreeClient) {
-        this(braintreeClient, DataCollector.getInstance());
+        this.braintreeClient = braintreeClient;
+    }
+
+    void startDataCollection(
+            @NonNull Context context,
+            @NonNull final String merchantId,
+            @NonNull final String deviceSessionId,
+            @NonNull final KountDataCollectorCallback callback
+    ) {
+        // we lazily reference Kount to prevent it from being loaded by the JVM unless we really need it
+        startDataCollection(context, merchantId, deviceSessionId, callback, DataCollector.getInstance());
     }
 
     @VisibleForTesting
-    KountDataCollector(BraintreeClient braintreeClient, DataCollector kountDataCollector) {
-        this.braintreeClient = braintreeClient;
-        this.kountDataCollector = kountDataCollector;
-    }
-
-    void startDataCollection(@NonNull Context context, @NonNull final String merchantId, @NonNull final String deviceSessionId, @NonNull final KountDataCollectorCallback callback) {
+    void startDataCollection(
+            @NonNull Context context,
+            @NonNull final String merchantId,
+            @NonNull final String deviceSessionId,
+            @NonNull final KountDataCollectorCallback callback,
+            @NonNull final DataCollector kountDataCollector
+    ) {
         braintreeClient.sendAnalyticsEvent("data-collector.kount.started");
 
         try {
@@ -41,7 +51,6 @@ class KountDataCollector {
             public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
                 if (configuration != null) {
 
-                    // configure kount
                     kountDataCollector.setContext(applicationContext);
                     kountDataCollector.setMerchantID(Integer.parseInt(merchantId));
                     kountDataCollector.setLocationCollectorConfig(com.kount.api.DataCollector.LocationConfig.COLLECT);

--- a/BraintreeDataCollector/src/test/java/com/braintreepayments/api/KountDataCollectorUnitTest.java
+++ b/BraintreeDataCollector/src/test/java/com/braintreepayments/api/KountDataCollectorUnitTest.java
@@ -25,7 +25,7 @@ public class KountDataCollectorUnitTest {
     private Context context;
     private Context applicationContext;
 
-    DataCollector kountDataCollector;
+    private DataCollector kountDataCollector;
 
     @Before
     public void beforeEach() {
@@ -48,10 +48,10 @@ public class KountDataCollectorUnitTest {
     public void startDataCollection_fetchesConfigurationWithApplicationContext() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         verify(braintreeClient).getConfiguration(any(ConfigurationCallback.class));
     }
@@ -62,10 +62,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configurationError(configurationError)
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         verify(callback).onResult(null, configurationError);
     }
@@ -75,10 +75,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         verify(kountDataCollector).setContext(applicationContext);
         verify(kountDataCollector).setMerchantID(123);
@@ -91,10 +91,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         verify(kountDataCollector).collectForSession(eq("device-session-id"), any(DataCollector.CompletionHandler.class));
     }
@@ -104,13 +104,13 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         ArgumentCaptor<DataCollector.CompletionHandler> captor =
-            ArgumentCaptor.forClass(DataCollector.CompletionHandler.class);
+                ArgumentCaptor.forClass(DataCollector.CompletionHandler.class);
         verify(kountDataCollector).collectForSession(anyString(), captor.capture());
 
         DataCollector.CompletionHandler completionHandler = captor.getValue();
@@ -124,10 +124,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         ArgumentCaptor<DataCollector.CompletionHandler> captor =
                 ArgumentCaptor.forClass(DataCollector.CompletionHandler.class);
@@ -144,10 +144,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         ArgumentCaptor<DataCollector.CompletionHandler> captor =
                 ArgumentCaptor.forClass(DataCollector.CompletionHandler.class);
@@ -164,10 +164,10 @@ public class KountDataCollectorUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_KOUNT))
                 .build();
-        KountDataCollector sut = new KountDataCollector(braintreeClient, kountDataCollector);
+        KountDataCollector sut = new KountDataCollector(braintreeClient);
 
         KountDataCollectorCallback callback = mock(KountDataCollectorCallback.class);
-        sut.startDataCollection(context, "123", "device-session-id", callback);
+        sut.startDataCollection(context, "123", "device-session-id", callback, kountDataCollector);
 
         ArgumentCaptor<DataCollector.CompletionHandler> captor =
                 ArgumentCaptor.forClass(DataCollector.CompletionHandler.class);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* DataCollector
+  * Reference Kount library only when needed to prevent JVM from loading it when it isn't being used by a merchant.
+
 ## 4.12.0
 
 * SharedUtils


### PR DESCRIPTION
### Summary of changes

 - There have been some issues reported with custom Kount integrations that result in duplicate symbol errors.
 - This PR references Kount only when needed, which should prevent the JVM from loading it if it isn't used by the SDK.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
