### PR TITLE
Refactor NXO Constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * BraintreeCore
   * Add BraintreeError `code` read-only property.
+* PayPalNativeCheckoutClient
+  * Add new `PayPalNativeCheckoutClient` that requires only a `BraintreeClient` instance.
+  * Add new `PayPalNativeCheckoutClient#launchNativeCheckout` method that launches native checkout without throwing.
+  * Deprecate `PayPalNativeCheckoutClient` constructor that requires both `Fragment` and `BraintreeClient` instances.
+  * Deprecate `PayPalNativeCheckoutClient#tokenizePayPalAccount` method that throws an exception.
 
 ## 4.14.0
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -74,6 +74,9 @@ public class PayPalNativeCheckoutClient {
      */
     @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
+        // NEXT_MAJOR_VERSION: remove tokenizePayPalAccount method and refactor tests to center
+        // around launchNativeCheckout in the future. Keeping the tests as they are for now allows
+        // us to maintain test coverage across both the tokenizePayPalAccount and launchNativeCheckout methods
         boolean isCheckoutRequest = payPalRequest instanceof PayPalNativeCheckoutRequest;
         boolean isVaultRequest = payPalRequest instanceof PayPalNativeCheckoutVaultRequest;
         if (isCheckoutRequest || isVaultRequest) {

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -74,10 +74,10 @@ public class PayPalNativeCheckoutClient {
      */
     @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
-        if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
-            sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
-        } else if (payPalRequest instanceof PayPalNativeCheckoutVaultRequest) {
-            sendVaultRequest(activity, (PayPalNativeCheckoutVaultRequest) payPalRequest);
+        boolean isCheckoutRequest = payPalRequest instanceof PayPalNativeCheckoutRequest;
+        boolean isVaultRequest = payPalRequest instanceof PayPalNativeCheckoutVaultRequest;
+        if (isCheckoutRequest || isVaultRequest) {
+            launchNativeCheckout(activity, payPalRequest);
         } else {
             throw new Exception("Unsupported request type");
         }

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.Lifecycle;
 
 import com.paypal.checkout.PayPalCheckout;
 import com.paypal.checkout.approve.ApprovalData;
@@ -26,17 +25,29 @@ public class PayPalNativeCheckoutClient {
     private PayPalNativeCheckoutListener listener;
 
     /**
+     * @deprecated see {@link PayPalNativeCheckoutClient#PayPalNativeCheckoutClient(BraintreeClient)}
+     *
      * Create a new instance of {@link PayPalNativeCheckoutClient} from within a Fragment using a {@link BraintreeClient}.
      *
      * @param fragment        a {@link Fragment
      * @param braintreeClient a {@link BraintreeClient}
      */
+    @Deprecated
     public PayPalNativeCheckoutClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
-        this(fragment.getActivity(), fragment.getLifecycle(), braintreeClient, new PayPalNativeCheckoutInternalClient(braintreeClient));
+        this(braintreeClient, new PayPalNativeCheckoutInternalClient(braintreeClient));
+    }
+
+    /**
+     * Create a new instance of {@link PayPalNativeCheckoutClient} using a {@link BraintreeClient}.
+     *
+     * @param braintreeClient a {@link BraintreeClient}
+     */
+    public PayPalNativeCheckoutClient(@NonNull BraintreeClient braintreeClient) {
+        this(braintreeClient, new PayPalNativeCheckoutInternalClient(braintreeClient));
     }
 
     @VisibleForTesting
-    PayPalNativeCheckoutClient(FragmentActivity activity, Lifecycle lifecycle, BraintreeClient braintreeClient, PayPalNativeCheckoutInternalClient internalPayPalClient) {
+    PayPalNativeCheckoutClient(BraintreeClient braintreeClient, PayPalNativeCheckoutInternalClient internalPayPalClient) {
         this.braintreeClient = braintreeClient;
         this.internalPayPalClient = internalPayPalClient;
     }
@@ -53,6 +64,8 @@ public class PayPalNativeCheckoutClient {
     }
 
     /**
+     * @deprecated see {@link PayPalNativeCheckoutClient#launchNativeCheckout(FragmentActivity, PayPalNativeRequest)}
+     *
      * Tokenize a PayPal account for vault or checkout.
      * <p>
      * This method must be invoked on a {@link PayPalNativeCheckoutClient (Fragment, BraintreeClient)} or
@@ -61,6 +74,7 @@ public class PayPalNativeCheckoutClient {
      * @param activity      Android FragmentActivity
      * @param payPalRequest a {@link PayPalNativeRequest} used to customize the request.
      */
+    @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
         if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
             sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
@@ -68,6 +82,23 @@ public class PayPalNativeCheckoutClient {
             sendVaultRequest(activity, (PayPalNativeCheckoutVaultRequest) payPalRequest);
         } else {
             throw new Exception("Unsupported request type");
+        }
+    }
+
+    /**
+     * Tokenize a PayPal account for vault or checkout.
+     * <p>
+     * This method must be invoked on a {@link PayPalNativeCheckoutClient (Fragment, BraintreeClient)} or
+     * {@link PayPalNativeCheckoutClient (FragmentActivity, BraintreeClient)} in order to receive results.
+     *
+     * @param activity      Android FragmentActivity
+     * @param payPalRequest a {@link PayPalNativeRequest} used to customize the request.
+     */
+    public void launchNativeCheckout(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) {
+        if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
+            sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
+        } else if (payPalRequest instanceof PayPalNativeCheckoutVaultRequest) {
+            sendVaultRequest(activity, (PayPalNativeCheckoutVaultRequest) payPalRequest);
         }
     }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -25,12 +25,11 @@ public class PayPalNativeCheckoutClient {
     private PayPalNativeCheckoutListener listener;
 
     /**
-     * @deprecated see {@link PayPalNativeCheckoutClient#PayPalNativeCheckoutClient(BraintreeClient)}
-     *
-     * Create a new instance of {@link PayPalNativeCheckoutClient} from within a Fragment using a {@link BraintreeClient}.
-     *
      * @param fragment        a {@link Fragment
      * @param braintreeClient a {@link BraintreeClient}
+     * @deprecated see {@link PayPalNativeCheckoutClient#PayPalNativeCheckoutClient(BraintreeClient)}
+     * <p>
+     * Create a new instance of {@link PayPalNativeCheckoutClient} from within a Fragment using a {@link BraintreeClient}.
      */
     @Deprecated
     public PayPalNativeCheckoutClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
@@ -64,15 +63,14 @@ public class PayPalNativeCheckoutClient {
     }
 
     /**
+     * @param activity      Android FragmentActivity
+     * @param payPalRequest a {@link PayPalNativeRequest} used to customize the request.
      * @deprecated see {@link PayPalNativeCheckoutClient#launchNativeCheckout(FragmentActivity, PayPalNativeRequest)}
-     *
+     * <p>
      * Tokenize a PayPal account for vault or checkout.
      * <p>
      * This method must be invoked on a {@link PayPalNativeCheckoutClient (Fragment, BraintreeClient)} or
      * {@link PayPalNativeCheckoutClient (FragmentActivity, BraintreeClient)} in order to receive results.
-     *
-     * @param activity      Android FragmentActivity
-     * @param payPalRequest a {@link PayPalNativeRequest} used to customize the request.
      */
     @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
@@ -99,6 +97,10 @@ public class PayPalNativeCheckoutClient {
             sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
         } else if (payPalRequest instanceof PayPalNativeCheckoutVaultRequest) {
             sendVaultRequest(activity, (PayPalNativeCheckoutVaultRequest) payPalRequest);
+        } else if (listener != null) {
+            String message = "Unsupported request type. Please use either a "
+                    + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
+            listener.onPayPalFailure(new BraintreeException(message));
         }
     }
 
@@ -110,9 +112,9 @@ public class PayPalNativeCheckoutClient {
 
         braintreeClient.getConfiguration((configuration, error) -> {
             sendPayPalRequest(
-                activity,
-                payPalCheckoutRequest,
-                configuration
+                    activity,
+                    payPalCheckoutRequest,
+                    configuration
             );
         });
     }
@@ -125,17 +127,17 @@ public class PayPalNativeCheckoutClient {
 
         braintreeClient.getConfiguration((configuration, error) -> {
             sendPayPalRequest(
-                activity,
-                payPalVaultRequest,
-                configuration
+                    activity,
+                    payPalVaultRequest,
+                    configuration
             );
         });
     }
 
     private void sendPayPalRequest(
-        final FragmentActivity activity,
-        final PayPalNativeRequest payPalRequest,
-        final Configuration configuration
+            final FragmentActivity activity,
+            final PayPalNativeRequest payPalRequest,
+            final Configuration configuration
     ) {
         internalPayPalClient.sendRequest(activity, payPalRequest, (payPalResponse, error) -> {
             if (payPalResponse != null) {
@@ -151,11 +153,11 @@ public class PayPalNativeCheckoutClient {
 
                 // Start PayPalCheckout flow
                 PayPalCheckout.setConfig(
-                    new CheckoutConfig(
-                        activity.getApplication(),
-                        configuration.getPayPalClientId(),
-                        environment
-                    )
+                        new CheckoutConfig(
+                                activity.getApplication(),
+                                configuration.getPayPalClientId(),
+                                environment
+                        )
                 );
 
                 registerCallbacks(configuration, payPalRequest, payPalResponse);
@@ -172,9 +174,9 @@ public class PayPalNativeCheckoutClient {
     }
 
     private void registerCallbacks(
-        final Configuration configuration,
-        final PayPalNativeRequest payPalRequest,
-        final PayPalNativeCheckoutResponse payPalResponse
+            final Configuration configuration,
+            final PayPalNativeRequest payPalRequest,
+            final PayPalNativeCheckoutResponse payPalResponse
     ) {
         PayPalCheckout.registerCallbacks(
                 approval -> {

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -82,7 +82,9 @@ public class PayPalNativeCheckoutClient {
         if (isCheckoutRequest || isVaultRequest) {
             launchNativeCheckout(activity, payPalRequest);
         } else {
-            throw new Exception("Unsupported request type");
+            String message = "Unsupported request type. Please use either a "
+                    + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
+            throw new Exception(message);
         }
     }
 
@@ -114,11 +116,7 @@ public class PayPalNativeCheckoutClient {
         }
 
         braintreeClient.getConfiguration((configuration, error) -> {
-            sendPayPalRequest(
-                    activity,
-                    payPalCheckoutRequest,
-                    configuration
-            );
+            sendPayPalRequest(activity, payPalCheckoutRequest, configuration);
         });
     }
 
@@ -129,11 +127,7 @@ public class PayPalNativeCheckoutClient {
         }
 
         braintreeClient.getConfiguration((configuration, error) -> {
-            sendPayPalRequest(
-                    activity,
-                    payPalVaultRequest,
-                    configuration
-            );
+            sendPayPalRequest(activity, payPalVaultRequest, configuration);
         });
     }
 

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -71,7 +71,7 @@ public class PayPalNativeCheckoutClientUnitTest {
                 .build();
         PowerMockito.mockStatic(PayPalCheckout.class);
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
         sut.tokenizePayPalAccount(activity, payPalVaultRequest);
 
@@ -127,7 +127,7 @@ public class PayPalNativeCheckoutClientUnitTest {
         PowerMockito.verifyStatic(PayPalCheckout.class);
         PayPalCheckout.registerCallbacks(onApproveCaptor.capture(), onShippingChangeCaptor.capture(), onCancelCaptor.capture(), onErrorCaptor.capture());
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
         sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
 
@@ -155,7 +155,7 @@ public class PayPalNativeCheckoutClientUnitTest {
                 .build();
         PowerMockito.mockStatic(PayPalCheckout.class);
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
         sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
 
@@ -168,7 +168,7 @@ public class PayPalNativeCheckoutClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
         PayPalNativeCheckoutInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00");
         request.setShouldOfferPayLater(true);
         sut.tokenizePayPalAccount(activity, request);
@@ -186,7 +186,7 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         PayPalNativeCheckoutVaultRequest payPalRequest = new PayPalNativeCheckoutVaultRequest();
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalRequest);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest), any(PayPalNativeCheckoutInternalClient.PayPalNativeCheckoutInternalClientCallback.class));
@@ -202,7 +202,7 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         PayPalNativeCheckoutRequest payPalRequest = new PayPalNativeCheckoutRequest("1.00");
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalRequest);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest), any(PayPalNativeCheckoutInternalClient.PayPalNativeCheckoutInternalClientCallback.class));
@@ -216,7 +216,7 @@ public class PayPalNativeCheckoutClientUnitTest {
         PayPalNativeCheckoutVaultRequest payPalRequest = new PayPalNativeCheckoutVaultRequest();
         payPalRequest.setShouldOfferCredit(true);
 
-        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalRequest);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal-native.billing-agreement.credit.offered");

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -70,7 +70,9 @@ public class PayPalNativeCheckoutClientUnitTest {
             capturedException = e;
         }
         assertNotNull(capturedException);
-        assertEquals("Unsupported request type", capturedException.getMessage());
+        String expectedMessage = "Unsupported request type. Please use either a "
+                + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
+        assertEquals(expectedMessage, capturedException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### Summary

NXO can be constructed with less parameters since it doesn't need to app switch.

### Changes

 - Add new `PayPalNativeCheckoutClient` that requires only a `BraintreeClient` instance.
 - Add new `PayPalNativeCheckoutClient#launchNativeCheckout` method that launches native checkout without throwing.
 - Deprecate `PayPalNativeCheckoutClient` constructor that requires both `Fragment` and `BraintreeClient` instances.
 - Deprecate `PayPalNativeCheckoutClient#tokenizePayPalAccount` method that throws an exception.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
