### PR TITLE
Rename `clientMetadataId` parameter to `riskCorrelationId`

### DIFF
--- a/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
+++ b/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
@@ -45,8 +45,8 @@ public class PayPalDataCollector {
      * "future payment") from a mobile device. Pass the result to your server, to include in the
      * payment request sent to PayPal. Do not otherwise cache or store this value.
      *
-     * @param context          Android Context
-     * @param configuration    the merchant configuration
+     * @param context       Android Context
+     * @param configuration the merchant configuration
      */
     @MainThread
     String getClientMetadataId(Context context, Configuration configuration) {
@@ -96,11 +96,11 @@ public class PayPalDataCollector {
      * <p>
      * Use the return value on your server, e.g. with `Transaction.sale`.
      *
-     * @param context          Android Context
-     * @param clientMetadataId Optional client metadata id
-     * @param callback         {@link PayPalDataCollectorCallback}
+     * @param context           Android Context
+     * @param riskCorrelationId Optional client metadata id
+     * @param callback          {@link PayPalDataCollectorCallback}
      */
-    public void collectDeviceData(@NonNull final Context context, @Nullable final String clientMetadataId, @NonNull final PayPalDataCollectorCallback callback) {
+    public void collectDeviceData(@NonNull final Context context, @Nullable final String riskCorrelationId, @NonNull final PayPalDataCollectorCallback callback) {
         braintreeClient.getConfiguration(new ConfigurationCallback() {
             @Override
             public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
@@ -109,12 +109,12 @@ public class PayPalDataCollector {
                     try {
                         PayPalDataCollectorRequest request = new PayPalDataCollectorRequest()
                                 .setApplicationGuid(getPayPalInstallationGUID(context));
-                        if (clientMetadataId != null) {
-                            request.setClientMetadataId(clientMetadataId);
+                        if (riskCorrelationId != null) {
+                            request.setClientMetadataId(riskCorrelationId);
                         }
 
                         String correlationId =
-                            magnesInternalClient.getClientMetadataId(context, configuration, request);
+                                magnesInternalClient.getClientMetadataId(context, configuration, request);
                         if (!TextUtils.isEmpty(correlationId)) {
                             deviceData.put(CORRELATION_ID_KEY, correlationId);
                         }

--- a/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
+++ b/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
@@ -110,7 +110,7 @@ public class PayPalDataCollector {
                         PayPalDataCollectorRequest request = new PayPalDataCollectorRequest()
                                 .setApplicationGuid(getPayPalInstallationGUID(context));
                         if (riskCorrelationId != null) {
-                            request.setClientMetadataId(riskCorrelationId);
+                            request.setRiskCorrelationId(riskCorrelationId);
                         }
 
                         String correlationId =

--- a/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
+++ b/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollector.java
@@ -46,7 +46,7 @@ public class PayPalDataCollector {
      * payment request sent to PayPal. Do not otherwise cache or store this value.
      *
      * @param context       Android Context
-     * @param configuration the merchant configuration
+     * @param configuration The merchant configuration
      */
     @MainThread
     String getClientMetadataId(Context context, Configuration configuration) {

--- a/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollectorRequest.java
+++ b/PayPalDataCollector/src/main/java/com/braintreepayments/api/PayPalDataCollectorRequest.java
@@ -34,10 +34,10 @@ class PayPalDataCollectorRequest {
     }
 
     /**
-     * @param clientMetadataId The desired pairing ID, trimmed to 32 characters.
+     * @param riskCorrelationId The desired pairing ID, trimmed to 32 characters.
      */
-    PayPalDataCollectorRequest setClientMetadataId(@NonNull String clientMetadataId) {
-        this.clientMetadataId = clientMetadataId.substring(0, Math.min(clientMetadataId.length(), 32));
+    PayPalDataCollectorRequest setRiskCorrelationId(@NonNull String riskCorrelationId) {
+        this.clientMetadataId = riskCorrelationId.substring(0, Math.min(riskCorrelationId.length(), 32));
 
         return this;
     }

--- a/PayPalDataCollector/src/test/java/com/braintreepayments/api/MagnesInternalClientUnitTest.java
+++ b/PayPalDataCollector/src/test/java/com/braintreepayments/api/MagnesInternalClientUnitTest.java
@@ -61,7 +61,7 @@ public class MagnesInternalClientUnitTest {
         additionalData = new HashMap<>();
 
         payPalDataCollectorRequest = new PayPalDataCollectorRequest()
-                .setClientMetadataId("sample-client-metadata-id")
+                .setRiskCorrelationId("sample-client-metadata-id")
                 .setDisableBeacon(true)
                 .setAdditionalData(additionalData)
                 .setApplicationGuid(validApplicationGUID);

--- a/PayPalDataCollector/src/test/java/com/braintreepayments/api/PayPalDataCollectorRequestUnitTest.java
+++ b/PayPalDataCollector/src/test/java/com/braintreepayments/api/PayPalDataCollectorRequestUnitTest.java
@@ -9,7 +9,7 @@ public class PayPalDataCollectorRequestUnitTest {
     @Test
     public void setClientMetadataId_trimsId_to_32characters() {
         PayPalDataCollectorRequest request = new PayPalDataCollectorRequest()
-                .setClientMetadataId("pairing-id-pairing-id-pairing-idXXX");
+                .setRiskCorrelationId("pairing-id-pairing-id-pairing-idXXX");
 
         assertEquals("pairing-id-pairing-id-pairing-id", request.getClientMetadataId());
         assertEquals(32, request.getClientMetadataId().length());


### PR DESCRIPTION
### Summary of changes

 - This PR updates the `clientMetadataId` to `riskCorrelationId` on `PayPalDataCollector` to make it clearer.
 - This shouldn't be considered a breaking change since Java / Kotlin interop [doesn't generate named parameters](https://discuss.kotlinlang.org/t/what-is-the-reason-for-not-allowing-named-arguments-for-java-interop/4571) for Java methods. (also verified this in a sample project)

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
