### PR TITLE
Propagate Error Code From GraphQL and REST Responses

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeError.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeError.java
@@ -28,7 +28,8 @@ public class BraintreeError implements Parcelable {
     private String message;
     private List<BraintreeError> fieldErrors;
 
-    private int code;
+    // default value
+    private int code = UNKNOWN_CODE;
 
     static List<BraintreeError> fromJsonArray(JSONArray json) {
         if (json == null) {
@@ -93,13 +94,10 @@ public class BraintreeError implements Parcelable {
             error.field = field;
             error.message = errorJSON.getString(Keys.MESSAGE);
 
-            int code = UNKNOWN_CODE;
             JSONObject extensions = errorJSON.optJSONObject(Keys.EXTENSIONS);
             if (extensions != null) {
-                code = extensions.optInt(Keys.LEGACY_CODE, UNKNOWN_CODE);
+                error.code = extensions.optInt(Keys.LEGACY_CODE, UNKNOWN_CODE);
             }
-            error.code = code;
-
             error.fieldErrors = new ArrayList<>();
 
             errors.add(error);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeError.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeError.java
@@ -20,10 +20,15 @@ public class BraintreeError implements Parcelable {
     private static final String FIELD_KEY = "field";
     private static final String MESSAGE_KEY = "message";
     private static final String FIELD_ERRORS_KEY = "fieldErrors";
+    private static final String CODE_KEY = "code";
+
+    private static final int UNKNOWN_CODE = -1;
 
     private String field;
     private String message;
     private List<BraintreeError> fieldErrors;
+
+    private int code;
 
     static List<BraintreeError> fromJsonArray(JSONArray json) {
         if (json == null) {
@@ -74,6 +79,7 @@ public class BraintreeError implements Parcelable {
         BraintreeError error = new BraintreeError();
         error.field = Json.optString(json, FIELD_KEY, null);
         error.message = Json.optString(json, MESSAGE_KEY, null);
+        error.code = json.optInt(CODE_KEY, UNKNOWN_CODE);
         error.fieldErrors = BraintreeError.fromJsonArray(json.optJSONArray(FIELD_ERRORS_KEY));
 
         return error;
@@ -86,6 +92,14 @@ public class BraintreeError implements Parcelable {
             BraintreeError error = new BraintreeError();
             error.field = field;
             error.message = errorJSON.getString(Keys.MESSAGE);
+
+            int code = UNKNOWN_CODE;
+            JSONObject extensions = errorJSON.optJSONObject(Keys.EXTENSIONS);
+            if (extensions != null) {
+                code = extensions.optInt(Keys.LEGACY_CODE, UNKNOWN_CODE);
+            }
+            error.code = code;
+
             error.fieldErrors = new ArrayList<>();
 
             errors.add(error);
@@ -125,6 +139,13 @@ public class BraintreeError implements Parcelable {
      */
     public String getField() {
         return field;
+    }
+
+    /**
+     * @return Error code if one exists; defaults to {@link #UNKNOWN_CODE} otherwise
+     */
+    public int getCode() {
+        return code;
     }
 
     /**

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ErrorsWithResponseUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ErrorsWithResponseUnitTest.java
@@ -109,6 +109,18 @@ public class ErrorsWithResponseUnitTest {
     }
 
     @Test
+    public void REST_tokenizeCardDuplicate() {
+        ErrorWithResponse errorWithResponse = new ErrorWithResponse(422, Fixtures.ERRORS_CREDIT_CARD_DUPLICATE);
+        assertEquals(81724, errorWithResponse.errorFor("creditCard").errorFor("number").getCode());
+    }
+
+    @Test
+    public void GraphQL_tokenizeCardDuplicate() {
+        ErrorWithResponse errorWithResponse = ErrorWithResponse.fromGraphQLJson(Fixtures.ERRORS_GRAPHQL_CREDIT_CARD_DUPLICATE_ERROR);
+        assertEquals(81724, errorWithResponse.errorFor("creditCard").errorFor("number").getCode());
+    }
+
+    @Test
     public void parcelsCorrectly() throws JSONException {
         ErrorWithResponse error = ErrorWithResponse.fromJson(Fixtures.ERRORS_CREDIT_CARD_ERROR_RESPONSE);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* BraintreeCore
+  * Add BraintreeError `code` read-only property.
+
 ## 4.14.0
 
 * PayPalDataCollector

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -338,8 +338,7 @@ object Fixtures {
     """
 
     // language=JSON
-    const val THREE_D_SECURE_V2_LOOKUP_RESPONSE_WITHOUT_LIABILITY_WITH_LIABILITY_SHIFT_POSSIBLE =
-        """
+    const val THREE_D_SECURE_V2_LOOKUP_RESPONSE_WITHOUT_LIABILITY_WITH_LIABILITY_SHIFT_POSSIBLE = """
         {
           "lookup": {
             "acsUrl": "https://acs-url/",
@@ -409,12 +408,9 @@ object Fixtures {
     // endregion
 
     // region Auth Tokens
-    const val BASE64_CLIENT_TOKEN =
-        "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
-    const val BASE64_CLIENT_TOKEN2 =
-        "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMiIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
-    const val BASE64_CLIENT_TOKEN_WITH_SPACES =
-        " eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0= "
+    const val BASE64_CLIENT_TOKEN = "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
+    const val BASE64_CLIENT_TOKEN2 = "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMiIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
+    const val BASE64_CLIENT_TOKEN_WITH_SPACES = " eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0= "
 
     const val TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn"
     const val TOKENIZATION_KEY_WITH_SPACES = " sandbox_tmxhyf7d_dcpspy2brwdjr3qn "

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -338,7 +338,8 @@ object Fixtures {
     """
 
     // language=JSON
-    const val THREE_D_SECURE_V2_LOOKUP_RESPONSE_WITHOUT_LIABILITY_WITH_LIABILITY_SHIFT_POSSIBLE = """
+    const val THREE_D_SECURE_V2_LOOKUP_RESPONSE_WITHOUT_LIABILITY_WITH_LIABILITY_SHIFT_POSSIBLE =
+        """
         {
           "lookup": {
             "acsUrl": "https://acs-url/",
@@ -408,9 +409,12 @@ object Fixtures {
     // endregion
 
     // region Auth Tokens
-    const val BASE64_CLIENT_TOKEN = "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
-    const val BASE64_CLIENT_TOKEN2 = "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMiIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
-    const val BASE64_CLIENT_TOKEN_WITH_SPACES = " eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0= "
+    const val BASE64_CLIENT_TOKEN =
+        "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
+    const val BASE64_CLIENT_TOKEN2 =
+        "eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMiIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0="
+    const val BASE64_CLIENT_TOKEN_WITH_SPACES =
+        " eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiJlbmNvZGVkX2F1dGhfZmluZ2VycHJpbnQiLCJjaGFsbGVuZ2VzIjpbImN2diIsInBvc3RhbF9jb2RlIl0sImNvbmZpZ1VybCI6ImVuY29kZWRfY2FwaV9jb25maWd1cmF0aW9uX3VybCIsImFzc2V0c1VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMCIsInRocmVlRFNlY3VyZUVuYWJsZWQiOmZhbHNlLCJwYXlwYWxFbmFibGVkIjpmYWxzZX0= "
 
     const val TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn"
     const val TOKENIZATION_KEY_WITH_SPACES = " sandbox_tmxhyf7d_dcpspy2brwdjr3qn "
@@ -1155,6 +1159,27 @@ object Fixtures {
     """
 
     // language=JSON
+    const val ERRORS_CREDIT_CARD_DUPLICATE = """
+        {
+            "error": {
+                "message": "Credit card is invalid"
+            },
+            "fieldErrors": [
+                {
+                    "field": "creditCard",
+                    "fieldErrors": [
+                        {
+                            "field": "number",
+                            "message": "Duplicate card exists in the vault.",
+                            "code": "81724"
+                        }
+                    ]
+                }
+            ]
+        }
+    """
+
+    // language=JSON
     const val ERRORS_COMPLEX_ERROR_RESPONSE = """
         {
             "error": {
@@ -1260,6 +1285,42 @@ object Fixtures {
           "extensions": {
             "requestId": "de1f7c67-4861-455f-89bb-1d208915f270"
           }
+        }
+    """
+
+    // language=JSON
+    const val ERRORS_GRAPHQL_CREDIT_CARD_DUPLICATE_ERROR = """
+        {
+            "errors": [
+                {
+                    "message": "Duplicate card exists in the vault",
+                    "locations": [
+                        {
+                            "line": 2,
+                            "column": 3
+                        }
+                    ],
+                    "path": [
+                        "tokenizeCreditCard"
+                    ],
+                    "extensions": {
+                        "errorClass": "VALIDATION",
+                        "errorType": "user_error",
+                        "inputPath": [
+                            "input",
+                            "creditCard",
+                            "number"
+                        ],
+                        "legacyCode": "81724"
+                    }
+                }
+            ],
+            "data": {
+                "tokenizeCreditCard": "null"
+            },
+            "extensions": {
+                "requestId": "3521c97e-a420-47f4-a8ef-a8cefb0fa635"
+            }
         }
     """
 


### PR DESCRIPTION
### Summary of changes

 - For duplicate payment method tokenization errors, it is helpful to have the actual error code returned to provide more meaningful feedback to the merchant.
 - This work will help resolve [DropIn Issue #357](https://github.com/braintree/braintree-android-drop-in/issues/357)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
