### PR TITLE
Bumping native version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## 4.16.0
+
+* PayPalNativeCheckoutClient
+  * Adding in Native checkout support for one time password
+
 ## 4.15.0
 
 * BraintreeCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * PayPalNativeCheckoutClient
+  * Bumping native-checkout version to 0.8.1 
   * Adding in Native checkout support for one time password
 
 ## 4.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree Android SDK Release Notes
 
-## 4.16.0
+## unreleased
 
 * PayPalNativeCheckoutClient
   * Adding in Native checkout support for one time password

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation deps.appCompat
     implementation project(':PayPalDataCollector')
 
-    implementation('com.paypal.checkout:android-sdk:0.7.2') {
+    implementation('com.paypal.checkout:android-sdk:0.8.1') {
         exclude group: 'com.paypal.android.sdk', module: 'data-collector'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
-            "room"           : "2.2.6",
+            "room"           : "2.4.1",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "18.1.3"
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
-            "room"           : "2.4.1",
+            "room"           : "2.2.6",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "18.1.3"
     ]


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Bumping the native version to add support for OTP

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
