### PR TITLE
Add Analytics for PayPal Native Checkout

### DIFF
--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -144,8 +144,8 @@ public class PayPalNativeCheckoutClient {
     ) {
         internalPayPalClient.sendRequest(activity, payPalRequest, (payPalResponse, error) -> {
             if (payPalResponse != null) {
-                String analyticsPrefix = getAnalyticsEventPrefix(payPalRequest);
-                braintreeClient.sendAnalyticsEvent(String.format("%s.started", analyticsPrefix));
+                String analyticsPrefix = payPalRequest instanceof PayPalNativeCheckoutVaultRequest ? "billing-agreement" : "single-payment";
+                braintreeClient.sendAnalyticsEvent(String.format("paypal-native.%s.started", analyticsPrefix));
 
                 Environment environment;
                 if ("sandbox".equals(configuration.getEnvironment())) {
@@ -248,9 +248,5 @@ public class PayPalNativeCheckoutClient {
         }
 
         return payPalAccount;
-    }
-
-    private static String getAnalyticsEventPrefix(PayPalNativeRequest request) {
-        return request instanceof PayPalNativeCheckoutVaultRequest ? "paypal-native.billing-agreement" : "paypal-native.single-payment";
     }
 }

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -74,13 +74,12 @@ public class PayPalNativeCheckoutClient {
      */
     @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
+        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started");
         // NEXT_MAJOR_VERSION: remove tokenizePayPalAccount method and refactor tests to center
         // around launchNativeCheckout in the future. Keeping the tests as they are for now allows
         // us to maintain test coverage across both the tokenizePayPalAccount and launchNativeCheckout methods
         boolean isCheckoutRequest = payPalRequest instanceof PayPalNativeCheckoutRequest;
         boolean isVaultRequest = payPalRequest instanceof PayPalNativeCheckoutVaultRequest;
-
-        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started");
         if (isCheckoutRequest || isVaultRequest) {
             launchNativeCheckout(activity, payPalRequest);
         } else {
@@ -102,7 +101,6 @@ public class PayPalNativeCheckoutClient {
      */
     public void launchNativeCheckout(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) {
         braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started");
-
         if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
             sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
             braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.succeeded");

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -76,7 +76,7 @@ public class PayPalNativeCheckoutClientUnitTest {
     }
 
     @Test
-    public void tokenizePayPalAccount_sendsAnalyticsEvents() throws Exception {
+    public void requestBillingAgreement_launchNativeCheckout_sendsAnalyticsEvents() {
         PayPalNativeCheckoutVaultRequest payPalVaultRequest = new PayPalNativeCheckoutVaultRequest();
         payPalVaultRequest.setMerchantAccountId("sample-merchant-account-id");
         payPalVaultRequest.setReturnUrl("returnUrl://paypalpay");
@@ -95,14 +95,16 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
-        sut.tokenizePayPalAccount(activity, payPalVaultRequest);
+        sut.launchNativeCheckout(activity, payPalVaultRequest);
 
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.started");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.succeeded");
         verify(braintreeClient).sendAnalyticsEvent("paypal-native.billing-agreement.selected");
-        verify(braintreeClient).sendAnalyticsEvent("paypal-native.billing-agreement.app-switch.started");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.billing-agreement.started");
     }
 
     @Test
-    public void requestOneTimePayment_startsNativeCheckout() throws Exception {
+    public void requestOneTimePayment_launchNativeCheckout_sendsAnalyticsEvents() {
         PayPalNativeCheckoutRequest payPalCheckoutRequest = new PayPalNativeCheckoutRequest("1.00");
         payPalCheckoutRequest.setIntent("authorize");
         payPalCheckoutRequest.setMerchantAccountId("sample-merchant-account-id");
@@ -151,12 +153,17 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
-        sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
+        sut.launchNativeCheckout(activity, payPalCheckoutRequest);
 
         assertEquals(payPalEnabledConfig.getPayPalClientId(), configCaptor.getValue().getClientId());
         assertEquals(onApprove, onApproveCaptor.getValue());
         assertEquals(onCancel, onCancelCaptor.getValue());
         assertEquals(onError, onErrorCaptor.getValue());
+
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.started");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.succeeded");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.single-payment.selected");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.single-payment.started");
     }
 
     @Test
@@ -179,10 +186,10 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
-        sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
+        sut.launchNativeCheckout(activity, payPalCheckoutRequest);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal-native.single-payment.selected");
-        verify(braintreeClient).sendAnalyticsEvent("paypal-native.single-payment.app-switch.started");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.single-payment.started");
     }
 
     @Test
@@ -245,7 +252,7 @@ public class PayPalNativeCheckoutClientUnitTest {
     }
 
     @Test
-    public void launchNativeCheckout_notifiesErrorWhenPayPalRequestIsBaseClass() {
+    public void launchNativeCheckout_notifiesErrorWhenPayPalRequestIsBaseClass_sendsAnalyticsEvents() {
         PayPalNativeRequest baseRequest = new PayPalNativeRequest() {
             @Override
             String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException {
@@ -267,5 +274,8 @@ public class PayPalNativeCheckoutClientUnitTest {
         String expectedMessage = "Unsupported request type. Please use either a "
                 + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
         assertEquals(expectedMessage, capturedException.getMessage());
+
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.started");
+        verify(braintreeClient).sendAnalyticsEvent("paypal-native.tokenize.invalid-request.failed");
     }
 }


### PR DESCRIPTION
### Summary of changes

- add analytics events for PayPal Native Checkout
- add tests for analytics
- These events match the [iOS analytics PR as closely as possible](https://github.com/braintree/braintree_ios/pull/862) - missing events are due to differences in how iOS vs Android handles the implementation

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
