### PR TITLE
Disable PayPal Native Checkout Exit Survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPalNativeCheckout (BETA)
+  * Remove exit survey when canceling Native Checkout flow
+
 ## 4.16.0
 
 * PayPalNativeCheckoutClient

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -9,6 +9,8 @@ import com.paypal.checkout.PayPalCheckout;
 import com.paypal.checkout.approve.ApprovalData;
 import com.paypal.checkout.config.CheckoutConfig;
 import com.paypal.checkout.config.Environment;
+import com.paypal.checkout.config.SettingsConfig;
+import com.paypal.checkout.config.UIConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -159,7 +161,14 @@ public class PayPalNativeCheckoutClient {
                         new CheckoutConfig(
                                 activity.getApplication(),
                                 configuration.getPayPalClientId(),
-                                environment
+                                environment,
+                                null,
+                                null,
+                                null,
+                                new SettingsConfig(),
+                                new UIConfig(
+                                        false
+                                )
                         )
                 );
 


### PR DESCRIPTION
### Summary of changes

 - Remove exit survey when canceling PayPal Native Checkout flow

### Visuals
| Before | After |
|-----|-----|
|![better_with_survey](https://user-images.githubusercontent.com/20733831/193057069-bbb79aaf-f42c-4fd2-839d-bc1938a2ed0f.gif)|![no-exit-survey](https://user-images.githubusercontent.com/20733831/193057139-7771f574-23f4-40ba-99a9-bbe96577409f.gif)|


 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
