### PR TITLE
Adding analytics for nxo and bumping native version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## unreleased
 
 * PayPalNativeCheckout
-  * Bumping native-checkout version to 0.8.1
+  * Bumping native-checkout version to 0.8.2
   * Bugfix to support logging out of session when client ID changes
-  * Bugfix for auth-sdk obfuscation
 
 ## 4.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* PayPalNativeCheckout
+* PayPalNativeCheckout (BETA)
   * Bumping native-checkout version to 0.8.2
   * Bugfix to support logging out of session when client ID changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * PayPalNativeCheckout (BETA)
   * Bumping native-checkout version to 0.8.2
-  * Bugfix to support logging out of session when client ID changes
+  * Fixes an issue where merchants with multiple client IDs would fallback to web on subsequent checkout sessions
 
 ## 4.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree Android SDK Release Notes
 
-## Unreleased
+## unreleased
 
 * PayPalNativeCheckout
   * Bumping native-checkout version to 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Braintree Android SDK Release Notes
 
+## Unreleased
+
+* PayPalNativeCheckout
+  * Bumping native-checkout version to 0.8.1
+  * Bugfix to support logging out when client id's switch
+  * Bugfix for auth-sdk obfuscation
+
 ## 4.16.0
 
 * PayPalNativeCheckoutClient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * PayPalNativeCheckout
   * Bumping native-checkout version to 0.8.1
-  * Bugfix to support logging out when client id's switch
+  * Bugfix to support logging out of session when client ID changes
   * Bugfix for auth-sdk obfuscation
 
 ## 4.16.0

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation deps.appCompat
     implementation project(':PayPalDataCollector')
 
-    implementation('com.paypal.checkout:android-sdk:0.8.1') {
+    implementation('com.paypal.checkout:android-sdk:0.8.2') {
         exclude group: 'com.paypal.android.sdk', module: 'data-collector'
     }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -9,6 +9,8 @@ import com.paypal.checkout.PayPalCheckout;
 import com.paypal.checkout.approve.ApprovalData;
 import com.paypal.checkout.config.CheckoutConfig;
 import com.paypal.checkout.config.Environment;
+import com.paypal.pyplcheckout.common.instrumentation.PEnums;
+import com.paypal.pyplcheckout.common.instrumentation.PLog;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -161,6 +163,20 @@ public class PayPalNativeCheckoutClient {
                                 configuration.getPayPalClientId(),
                                 environment
                         )
+                );
+
+                PLog.transition(
+                    PEnums.TransitionName.BRAINTREE_ROUTING,
+                    PEnums.Outcome.THIRD_PARTY,
+                    PEnums.EventCode.E233,
+                    Statename.BRAINTREE,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "BrainTree"
                 );
 
                 registerCallbacks(configuration, payPalRequest, payPalResponse);

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -169,7 +169,7 @@ public class PayPalNativeCheckoutClient {
                     PEnums.TransitionName.BRAINTREE_ROUTING,
                     PEnums.Outcome.THIRD_PARTY,
                     PEnums.EventCode.E233,
-                    Statename.BRAINTREE,
+                    PEnums.StateName.BRAINTREE,
                     null,
                     null,
                     null,

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -165,6 +165,8 @@ public class PayPalNativeCheckoutClient {
                         )
                 );
 
+                String infoMessage = "BrainTree";
+
                 PLog.transition(
                     PEnums.TransitionName.BRAINTREE_ROUTING,
                     PEnums.Outcome.THIRD_PARTY,
@@ -176,7 +178,7 @@ public class PayPalNativeCheckoutClient {
                     null,
                     null,
                     null,
-                    "BrainTree"
+                    infoMessage
                 );
 
                 registerCallbacks(configuration, payPalRequest, payPalResponse);

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -127,6 +127,7 @@ public class PayPalNativeCheckoutClientUnitTest {
         ArgumentCaptor<OnError> onErrorCaptor = ArgumentCaptor.forClass(OnError.class);
 
         PowerMockito.mockStatic(PayPalCheckout.class);
+
         PayPalCheckout.setConfig(
             new CheckoutConfig(
                 activity.getApplication(),

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -4,6 +4,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,6 +20,8 @@ import com.paypal.checkout.config.CheckoutConfig;
 import com.paypal.checkout.config.Environment;
 import com.paypal.checkout.error.OnError;
 import com.paypal.checkout.shipping.OnShippingChange;
+import com.paypal.pyplcheckout.common.instrumentation.PEnums;
+import com.paypal.pyplcheckout.common.instrumentation.PLog;
 
 import org.json.JSONException;
 import org.junit.Before;
@@ -30,7 +33,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( { PayPalCheckout.class })
+@PrepareForTest( { PayPalCheckout.class, PLog.class })
 public class PayPalNativeCheckoutClientUnitTest {
 
     private FragmentActivity activity;
@@ -92,7 +95,21 @@ public class PayPalNativeCheckoutClientUnitTest {
                 .canPerformBrowserSwitch(true)
                 .build();
         PowerMockito.mockStatic(PayPalCheckout.class);
-
+        PowerMockito.mockStatic(PLog.class);
+        PLog.transition(
+            PEnums.TransitionName.BRAINTREE_ROUTING,
+            PEnums.Outcome.THIRD_PARTY,
+            PEnums.EventCode.E233,
+            PEnums.StateName.BRAINTREE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "BrainTree"
+        );
+        PowerMockito.verifyStatic(PLog.class);
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
         sut.launchNativeCheckout(activity, payPalVaultRequest);
@@ -152,6 +169,22 @@ public class PayPalNativeCheckoutClientUnitTest {
         PowerMockito.verifyStatic(PayPalCheckout.class);
         PayPalCheckout.registerCallbacks(onApproveCaptor.capture(), onShippingChangeCaptor.capture(), onCancelCaptor.capture(), onErrorCaptor.capture());
 
+        PowerMockito.mockStatic(PLog.class);
+        PLog.transition(
+                PEnums.TransitionName.BRAINTREE_ROUTING,
+                PEnums.Outcome.THIRD_PARTY,
+                PEnums.EventCode.E233,
+                PEnums.StateName.BRAINTREE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "BrainTree"
+        );
+        PowerMockito.verifyStatic(PLog.class);
+
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);
         sut.launchNativeCheckout(activity, payPalCheckoutRequest);
@@ -184,6 +217,22 @@ public class PayPalNativeCheckoutClientUnitTest {
                 .configuration(payPalEnabledConfig)
                 .build();
         PowerMockito.mockStatic(PayPalCheckout.class);
+
+        PowerMockito.mockStatic(PLog.class);
+        PLog.transition(
+                PEnums.TransitionName.BRAINTREE_ROUTING,
+                PEnums.Outcome.THIRD_PARTY,
+                PEnums.EventCode.E233,
+                PEnums.StateName.BRAINTREE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "BrainTree"
+        );
+        PowerMockito.verifyStatic(PLog.class);
 
         PayPalNativeCheckoutClient sut = new PayPalNativeCheckoutClient(braintreeClient, payPalInternalClient);
         sut.setListener(listener);

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
-            "room"           : "2.2.6",
+            "room"           : "2.4.1",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "18.1.3"
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
-            "room"           : "2.4.1",
+            "room"           : "2.2.6",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "18.1.3"
     ]


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Bumping the native version
 - Adding in a call to be able to distinguish between nxo and bt sessions

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
