### PR TITLE
Remove Build Tools Version From build.gradle Files

### DIFF
--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -8,7 +8,6 @@ def DEVELOPMENT_URL = System.properties['DEVELOPMENT_URL'] ?: '"http://10.0.2.2:
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId "com.braintreepayments.demo"

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/PayPalDataCollector/build.gradle
+++ b/PayPalDataCollector/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -6,7 +6,6 @@
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion


### PR DESCRIPTION
### Summary of changes

 - This PR removes explicit declaration of the `buildToolsVersion` property for all modules
 - This property has not been needed since Android [Gradle Plugin Version 3.0.0](https://developer.android.com/studio/releases/gradle-plugin#3-0-0)

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
