### PR TITLE
Add Explicit Master Key Alias for Encrypted Shared Prefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * GooglePay
   * Bump `play-services-wallet` version to `19.1.0`
+* SharedUtils
+  * Add explicit key alias for encrypted shared prefs (potential fix for #604)
 
 ## 4.18.0
 

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -9,6 +9,7 @@ import androidx.security.crypto.MasterKey;
 class BraintreeSharedPreferences {
 
     private static volatile BraintreeSharedPreferences INSTANCE;
+    private static final String BRAINTREE_KEY_ALIAS = "com.braintreepayments.api.masterkey";
     private static final String BRAINTREE_SHARED_PREFS_FILENAME = "BraintreeApi";
 
     static BraintreeSharedPreferences getInstance() {
@@ -27,7 +28,7 @@ class BraintreeSharedPreferences {
 
     static SharedPreferences getSharedPreferences(Context context) {
         try {
-            MasterKey masterKey = new MasterKey.Builder(context)
+            MasterKey masterKey = new MasterKey.Builder(context, BRAINTREE_KEY_ALIAS)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                     .build();
 


### PR DESCRIPTION

### Summary of changes

 - This PR adds an explicit key alias for encrypted shared prefs (potential fix for #604)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
