### PR TITLE
Add Defensive Guards to Prevent Crashes Related to Jetpack Security Crypto

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -186,12 +186,14 @@ public class BraintreeClient {
                             if (result != null) {
                                 Configuration configuration = result.getConfiguration();
                                 callback.onResult(configuration, null);
+
                                 if (result.getLoadFromCacheError() != null) {
                                     sendAnalyticsEvent("configuration.cache.load.failed", configuration, authorization);
                                 }
                                 if (result.getSaveToCacheError() != null) {
                                     sendAnalyticsEvent("configuration.cache.save.failed", configuration, authorization);
                                 }
+
                             } else {
                                 callback.onResult(null, error);
                             }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -85,7 +85,7 @@ public class BraintreeClient {
                 .browserSwitchClient(new BrowserSwitchClient())
                 .manifestValidator(new ManifestValidator())
                 .UUIDHelper(new UUIDHelper())
-                .configurationLoader(new ConfigurationLoader(httpClient));
+                .configurationLoader(new ConfigurationLoader(context, httpClient));
     }
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -180,7 +180,7 @@ public class BraintreeClient {
             @Override
             public void onAuthorizationResult(@Nullable final Authorization authorization, @Nullable Exception error) {
                 if (authorization != null) {
-                    configurationLoader.loadConfiguration(applicationContext, authorization, new ConfigurationLoaderCallback() {
+                    configurationLoader.loadConfiguration(authorization, new ConfigurationLoaderCallback() {
                         @Override
                         public void onResult(@Nullable ConfigurationLoaderResult result, @Nullable Exception error) {
                             if (result != null) {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -186,10 +186,10 @@ public class BraintreeClient {
                             if (result != null) {
                                 callback.onResult(result.getConfiguration(), null);
                                 if (result.getLoadFromCacheError() != null) {
-                                    sendAnalyticsEvent("config cache loading failed");
+                                    sendAnalyticsEvent("configuration.cache.load.failed");
                                 }
                                 if (result.getSaveToCacheError() != null) {
-                                    sendAnalyticsEvent("config cache saving failed");
+                                    sendAnalyticsEvent("configuration.cache.save.failed");
                                 }
                             } else {
                                 callback.onResult(null, error);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -180,7 +180,22 @@ public class BraintreeClient {
             @Override
             public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error) {
                 if (authorization != null) {
-                    configurationLoader.loadConfiguration(applicationContext, authorization, callback);
+                    configurationLoader.loadConfiguration(applicationContext, authorization, new ConfigurationLoaderCallback() {
+                        @Override
+                        public void onResult(@Nullable ConfigurationLoaderResult result, @Nullable Exception error) {
+                            if (result != null) {
+                                callback.onResult(result.getConfiguration(), null);
+                                if (result.getLoadFromCacheError() != null) {
+                                    sendAnalyticsEvent("config cache loading failed");
+                                }
+                                if (result.getSaveToCacheError() != null) {
+                                    sendAnalyticsEvent("config cache saving failed");
+                                }
+                            } else {
+                                callback.onResult(null, error);
+                            }
+                        }
+                    });
                 } else {
                     callback.onResult(null, error);
                 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -185,7 +185,7 @@ public class BraintreeClient {
                         public void onResult(@Nullable ConfigurationLoaderResult result, @Nullable Exception error) {
                             if (result != null) {
                                 Configuration configuration = result.getConfiguration();
-                                callback.onResult(result.getConfiguration(), null);
+                                callback.onResult(configuration, null);
                                 if (result.getLoadFromCacheError() != null) {
                                     sendAnalyticsEvent("configuration.cache.load.failed", configuration, authorization);
                                 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -178,18 +178,19 @@ public class BraintreeClient {
     public void getConfiguration(@NonNull final ConfigurationCallback callback) {
         getAuthorization(new AuthorizationCallback() {
             @Override
-            public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error) {
+            public void onAuthorizationResult(@Nullable final Authorization authorization, @Nullable Exception error) {
                 if (authorization != null) {
                     configurationLoader.loadConfiguration(applicationContext, authorization, new ConfigurationLoaderCallback() {
                         @Override
                         public void onResult(@Nullable ConfigurationLoaderResult result, @Nullable Exception error) {
                             if (result != null) {
+                                Configuration configuration = result.getConfiguration();
                                 callback.onResult(result.getConfiguration(), null);
                                 if (result.getLoadFromCacheError() != null) {
-                                    sendAnalyticsEvent("configuration.cache.load.failed");
+                                    sendAnalyticsEvent("configuration.cache.load.failed", configuration, authorization);
                                 }
                                 if (result.getSaveToCacheError() != null) {
-                                    sendAnalyticsEvent("configuration.cache.save.failed");
+                                    sendAnalyticsEvent("configuration.cache.save.failed", configuration, authorization);
                                 }
                             } else {
                                 callback.onResult(null, error);
@@ -215,14 +216,18 @@ public class BraintreeClient {
                     getConfiguration(new ConfigurationCallback() {
                         @Override
                         public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
-                            if (isAnalyticsEnabled(configuration)) {
-                                analyticsClient.sendEvent(configuration, eventName, sessionId, getIntegrationType(), authorization);
-                            }
+                            sendAnalyticsEvent(eventName, configuration, authorization);
                         }
                     });
                 }
             }
         });
+    }
+
+    private void sendAnalyticsEvent(String eventName, Configuration configuration, Authorization authorization) {
+        if (isAnalyticsEnabled(configuration)) {
+            analyticsClient.sendEvent(configuration, eventName, sessionId, getIntegrationType(), authorization);
+        }
     }
 
     void sendGET(final String url, final HttpResponseCallback responseCallback) {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -25,14 +25,9 @@ class ConfigurationCache {
     }
 
     String getConfiguration(Context context, String cacheKey) {
-        return getConfiguration(context, cacheKey, System.currentTimeMillis());
-    }
-
-    @VisibleForTesting
-    String getConfiguration(Context context, String cacheKey, long currentTimeMillis) {
         BraintreeSharedPreferences sharedPreferences =
-            BraintreeSharedPreferences.getInstance(context);
-        return getConfiguration(sharedPreferences, cacheKey, currentTimeMillis);
+                BraintreeSharedPreferences.getInstance(context);
+        return getConfiguration(sharedPreferences, cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -31,12 +31,12 @@ class ConfigurationCache {
         this.sharedPreferences = sharedPreferences;
     }
 
-    String getConfiguration(String cacheKey) throws UnexpectedException {
+    String getConfiguration(String cacheKey) throws BraintreeSharedPreferencesException {
         return getConfiguration(cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    String getConfiguration(String cacheKey, long currentTimeMillis) throws UnexpectedException {
+    String getConfiguration(String cacheKey, long currentTimeMillis) throws BraintreeSharedPreferencesException {
         String timestampKey = cacheKey + "_timestamp";
         if (sharedPreferences.containsKey(timestampKey)) {
             long timeInCache = (currentTimeMillis - sharedPreferences.getLong(timestampKey));
@@ -47,12 +47,12 @@ class ConfigurationCache {
         return null;
     }
 
-    void saveConfiguration(Configuration configuration, String cacheKey) throws UnexpectedException {
+    void saveConfiguration(Configuration configuration, String cacheKey) throws BraintreeSharedPreferencesException {
         saveConfiguration(configuration, cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    void saveConfiguration(Configuration configuration, String cacheKey, long currentTimeMillis) throws UnexpectedException {
+    void saveConfiguration(Configuration configuration, String cacheKey, long currentTimeMillis) throws BraintreeSharedPreferencesException {
         String timestampKey = String.format("%s_timestamp", cacheKey);
         sharedPreferences.putStringAndLong(cacheKey, configuration.toJson(), timestampKey, currentTimeMillis);
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -24,42 +24,33 @@ class ConfigurationCache {
         return INSTANCE;
     }
 
-    String getConfiguration(Context context, String cacheKey) {
+    String getConfiguration(Context context, String cacheKey) throws UnexpectedException {
         BraintreeSharedPreferences sharedPreferences =
                 BraintreeSharedPreferences.getInstance(context);
         return getConfiguration(sharedPreferences, cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    String getConfiguration(BraintreeSharedPreferences sharedPreferences, String cacheKey, long currentTimeMillis) {
+    String getConfiguration(BraintreeSharedPreferences sharedPreferences, String cacheKey, long currentTimeMillis) throws UnexpectedException {
         String timestampKey = cacheKey + "_timestamp";
-        try {
-            if (sharedPreferences.containsKey(timestampKey)) {
-                long timeInCache = (currentTimeMillis - sharedPreferences.getLong(timestampKey));
-                if (timeInCache < TIME_TO_LIVE) {
-                    return sharedPreferences.getString(cacheKey, "");
-                }
+        if (sharedPreferences.containsKey(timestampKey)) {
+            long timeInCache = (currentTimeMillis - sharedPreferences.getLong(timestampKey));
+            if (timeInCache < TIME_TO_LIVE) {
+                return sharedPreferences.getString(cacheKey, "");
             }
-        } catch (UnexpectedException ignored) {
-            // protect against shared prefs failure: no-op when we're unable to fetch config from cache
         }
-
         return null;
     }
 
-    void saveConfiguration(Context context, Configuration configuration, String cacheKey) {
+    void saveConfiguration(Context context, Configuration configuration, String cacheKey) throws UnexpectedException {
         BraintreeSharedPreferences sharedPreferences =
             BraintreeSharedPreferences.getInstance(context);
         saveConfiguration(sharedPreferences, configuration, cacheKey, System.currentTimeMillis());
     }
 
     @VisibleForTesting
-    void saveConfiguration(BraintreeSharedPreferences sharedPreferences, Configuration configuration, String cacheKey, long currentTimeMillis) {
+    void saveConfiguration(BraintreeSharedPreferences sharedPreferences, Configuration configuration, String cacheKey, long currentTimeMillis) throws UnexpectedException {
         String timestampKey = String.format("%s_timestamp", cacheKey);
-        try {
-            sharedPreferences.putStringAndLong(cacheKey, configuration.toJson(), timestampKey, currentTimeMillis);
-        } catch (UnexpectedException ignored) {
-            // protect against shared prefs failure: no-op when we're unable to store config in cache
-        }
+        sharedPreferences.putStringAndLong(cacheKey, configuration.toJson(), timestampKey, currentTimeMillis);
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationCache.java
@@ -38,10 +38,10 @@ class ConfigurationCache {
     String getConfiguration(Context context, String cacheKey, long currentTimeMillis) {
         String timestampKey = cacheKey + "_timestamp";
         try {
-            if (braintreeSharedPreferences.containsKey(context, timestampKey)) {
-                long timeInCache = (currentTimeMillis - braintreeSharedPreferences.getLong(context, timestampKey));
+            if (braintreeSharedPreferences.containsKey(timestampKey)) {
+                long timeInCache = (currentTimeMillis - braintreeSharedPreferences.getLong(timestampKey));
                 if (timeInCache < TIME_TO_LIVE) {
-                    return braintreeSharedPreferences.getString(context, cacheKey, "");
+                    return braintreeSharedPreferences.getString(cacheKey, "");
                 }
             }
         } catch (UnexpectedException ignored) {
@@ -59,7 +59,7 @@ class ConfigurationCache {
     void saveConfiguration(Context context, Configuration configuration, String cacheKey, long currentTimeMillis) {
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
-            braintreeSharedPreferences.putStringAndLong(context, cacheKey, configuration.toJson(), timestampKey, currentTimeMillis);
+            braintreeSharedPreferences.putStringAndLong(cacheKey, configuration.toJson(), timestampKey, currentTimeMillis);
         } catch (UnexpectedException ignored) {
             // protect against shared prefs failure: no-op when we're unable to store config in cache
         }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
@@ -38,10 +38,10 @@ class ConfigurationLoader {
 
 
         Configuration cachedConfig = null;
-        UnexpectedException loadFromCacheException = null;
+        BraintreeSharedPreferencesException loadFromCacheException = null;
         try {
             cachedConfig = getCachedConfiguration(authorization, configUrl);
-        } catch (UnexpectedException e) {
+        } catch (BraintreeSharedPreferencesException e) {
             loadFromCacheException = e;
         }
 
@@ -50,7 +50,7 @@ class ConfigurationLoader {
             callback.onResult(resultFromCache, null);
         } else {
 
-            final UnexpectedException finalLoadFromCacheException = loadFromCacheException;
+            final BraintreeSharedPreferencesException finalLoadFromCacheException = loadFromCacheException;
             httpClient.get(configUrl, null, authorization, HttpClient.RETRY_MAX_3_TIMES, new HttpResponseCallback() {
 
                 @Override
@@ -59,10 +59,10 @@ class ConfigurationLoader {
                         try {
                             Configuration configuration = Configuration.fromJson(responseBody);
 
-                            UnexpectedException saveToCacheException = null;
+                            BraintreeSharedPreferencesException saveToCacheException = null;
                             try {
                                 saveConfigurationToCache(configuration, authorization, configUrl);
-                            } catch (UnexpectedException e) {
+                            } catch (BraintreeSharedPreferencesException e) {
                                 saveToCacheException = e;
                             }
 
@@ -84,12 +84,12 @@ class ConfigurationLoader {
         }
     }
 
-    private void saveConfigurationToCache(Configuration configuration, Authorization authorization, String configUrl) throws UnexpectedException {
+    private void saveConfigurationToCache(Configuration configuration, Authorization authorization, String configUrl) throws BraintreeSharedPreferencesException {
         String cacheKey = createCacheKey(authorization, configUrl);
         configurationCache.saveConfiguration(configuration, cacheKey);
     }
 
-    private Configuration getCachedConfiguration(Authorization authorization, String configUrl) throws UnexpectedException {
+    private Configuration getCachedConfiguration(Authorization authorization, String configUrl) throws BraintreeSharedPreferencesException {
         String cacheKey = createCacheKey(authorization, configUrl);
         String cachedConfigResponse = configurationCache.getConfiguration(cacheKey);
         try {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
@@ -23,7 +23,7 @@ class ConfigurationLoader {
         this.configurationCache = configurationCache;
     }
 
-    void loadConfiguration(final Context context, final Authorization authorization, final ConfigurationLoaderCallback callback) {
+    void loadConfiguration(final Authorization authorization, final ConfigurationLoaderCallback callback) {
         if (authorization instanceof InvalidAuthorization) {
             String message = ((InvalidAuthorization) authorization).getErrorMessage();
             callback.onResult(null, new BraintreeException(message));
@@ -40,7 +40,7 @@ class ConfigurationLoader {
         Configuration cachedConfig = null;
         UnexpectedException loadFromCacheException = null;
         try {
-            cachedConfig = getCachedConfiguration(context, authorization, configUrl);
+            cachedConfig = getCachedConfiguration(authorization, configUrl);
         } catch (UnexpectedException e) {
             loadFromCacheException = e;
         }
@@ -61,7 +61,7 @@ class ConfigurationLoader {
 
                             UnexpectedException saveToCacheException = null;
                             try {
-                                saveConfigurationToCache(context, configuration, authorization, configUrl);
+                                saveConfigurationToCache(configuration, authorization, configUrl);
                             } catch (UnexpectedException e) {
                                 saveToCacheException = e;
                             }
@@ -84,12 +84,12 @@ class ConfigurationLoader {
         }
     }
 
-    private void saveConfigurationToCache(Context context, Configuration configuration, Authorization authorization, String configUrl) throws UnexpectedException {
+    private void saveConfigurationToCache(Configuration configuration, Authorization authorization, String configUrl) throws UnexpectedException {
         String cacheKey = createCacheKey(authorization, configUrl);
         configurationCache.saveConfiguration(configuration, cacheKey);
     }
 
-    private Configuration getCachedConfiguration(Context context, Authorization authorization, String configUrl) throws UnexpectedException {
+    private Configuration getCachedConfiguration(Authorization authorization, String configUrl) throws UnexpectedException {
         String cacheKey = createCacheKey(authorization, configUrl);
         String cachedConfigResponse = configurationCache.getConfiguration(cacheKey);
         try {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoader.java
@@ -13,8 +13,8 @@ class ConfigurationLoader {
     private final BraintreeHttpClient httpClient;
     private final ConfigurationCache configurationCache;
 
-    ConfigurationLoader(BraintreeHttpClient httpClient) {
-        this(httpClient, ConfigurationCache.getInstance());
+    ConfigurationLoader(Context context, BraintreeHttpClient httpClient) {
+        this(httpClient, ConfigurationCache.getInstance(context));
     }
 
     @VisibleForTesting
@@ -86,12 +86,12 @@ class ConfigurationLoader {
 
     private void saveConfigurationToCache(Context context, Configuration configuration, Authorization authorization, String configUrl) throws UnexpectedException {
         String cacheKey = createCacheKey(authorization, configUrl);
-        configurationCache.saveConfiguration(context, configuration, cacheKey);
+        configurationCache.saveConfiguration(configuration, cacheKey);
     }
 
     private Configuration getCachedConfiguration(Context context, Authorization authorization, String configUrl) throws UnexpectedException {
         String cacheKey = createCacheKey(authorization, configUrl);
-        String cachedConfigResponse = configurationCache.getConfiguration(context, cacheKey);
+        String cachedConfigResponse = configurationCache.getConfiguration(cacheKey);
         try {
             return Configuration.fromJson(cachedConfigResponse);
         } catch (JSONException e) {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.java
@@ -1,0 +1,8 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.Nullable;
+
+interface ConfigurationLoaderCallback {
+
+    void onResult(@Nullable ConfigurationLoaderResult result, @Nullable Exception error);
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderResult.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderResult.java
@@ -1,0 +1,33 @@
+package com.braintreepayments.api;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+class ConfigurationLoaderResult {
+
+    private final Configuration configuration;
+    private final Exception loadFromCacheError;
+    private final Exception saveToCacheError;
+
+    ConfigurationLoaderResult(@NonNull Configuration configuration) {
+        this(configuration, null, null);
+    }
+
+    ConfigurationLoaderResult(@NonNull Configuration configuration, @Nullable Exception loadFromCacheError, @Nullable Exception saveToCacheError) {
+        this.configuration = configuration;
+        this.loadFromCacheError = loadFromCacheError;
+        this.saveToCacheError = saveToCacheError;
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public Exception getLoadFromCacheError() {
+        return loadFromCacheError;
+    }
+
+    public Exception getSaveToCacheError() {
+        return saveToCacheError;
+    }
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -16,11 +16,11 @@ class UUIDHelper {
      * @return A persistent UUID for this application install.
      */
     String getPersistentUUID(Context context) {
-        return getPersistentUUID(context, BraintreeSharedPreferences.getInstance());
+        return getPersistentUUID(BraintreeSharedPreferences.getInstance(context));
     }
 
     @VisibleForTesting
-    String getPersistentUUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
+    String getPersistentUUID(BraintreeSharedPreferences braintreeSharedPreferences) {
         String uuid = null;
         try {
             uuid = braintreeSharedPreferences.getString(BRAINTREE_UUID_KEY, null);
@@ -45,11 +45,11 @@ class UUIDHelper {
     }
 
     String getInstallationGUID(Context context) {
-        return getInstallationGUID(context, BraintreeSharedPreferences.getInstance());
+        return getInstallationGUID(BraintreeSharedPreferences.getInstance(context));
     }
 
     @VisibleForTesting
-    String getInstallationGUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
+    String getInstallationGUID(BraintreeSharedPreferences braintreeSharedPreferences) {
         String installationGUID = null;
         try {
             installationGUID = braintreeSharedPreferences.getString(INSTALL_GUID, null);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -21,11 +21,20 @@ class UUIDHelper {
 
     @VisibleForTesting
     String getPersistentUUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
-        String uuid = braintreeSharedPreferences.getString(context, BRAINTREE_UUID_KEY, null);
+        String uuid = null;
+        try {
+            uuid = braintreeSharedPreferences.getString(context, BRAINTREE_UUID_KEY, null);
+        } catch (UnexpectedException ignored) {
+            // protect against shared prefs failure: default to creating a new UUID in this scenario
+        }
 
         if (uuid == null) {
             uuid = getFormattedUUID();
-            braintreeSharedPreferences.putString(context, BRAINTREE_UUID_KEY, uuid);
+            try {
+                braintreeSharedPreferences.putString(context, BRAINTREE_UUID_KEY, uuid);
+            } catch (UnexpectedException ignored) {
+                // protect against shared prefs failure: no-op when we're unable to persist the UUID
+            }
         }
 
         return uuid;
@@ -41,13 +50,21 @@ class UUIDHelper {
 
     @VisibleForTesting
     String getInstallationGUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
-        String existingGUID = braintreeSharedPreferences.getString(context, INSTALL_GUID, null);
-        if (existingGUID != null) {
-            return existingGUID;
-        } else {
-            String newGuid = UUID.randomUUID().toString();
-            braintreeSharedPreferences.putString(context, INSTALL_GUID, newGuid);
-            return newGuid;
+        String installationGUID = null;
+        try {
+            installationGUID = braintreeSharedPreferences.getString(context, INSTALL_GUID, null);
+        } catch (UnexpectedException ignored) {
+            // protect against shared prefs failure: default to creating a new GUID in this scenario
         }
+
+        if (installationGUID == null) {
+            installationGUID = UUID.randomUUID().toString();
+            try {
+                braintreeSharedPreferences.putString(context, INSTALL_GUID, installationGUID);
+            } catch (UnexpectedException ignored) {
+                // protect against shared prefs failure: no-op when we're unable to persist the GUID
+            }
+        }
+        return installationGUID;
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -24,7 +24,7 @@ class UUIDHelper {
         String uuid = null;
         try {
             uuid = braintreeSharedPreferences.getString(BRAINTREE_UUID_KEY, null);
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
             // protect against shared prefs failure: default to creating a new UUID in this scenario
         }
 
@@ -32,7 +32,7 @@ class UUIDHelper {
             uuid = getFormattedUUID();
             try {
                 braintreeSharedPreferences.putString(BRAINTREE_UUID_KEY, uuid);
-            } catch (UnexpectedException ignored) {
+            } catch (BraintreeSharedPreferencesException ignored) {
                 // protect against shared prefs failure: no-op when we're unable to persist the UUID
             }
         }
@@ -53,7 +53,7 @@ class UUIDHelper {
         String installationGUID = null;
         try {
             installationGUID = braintreeSharedPreferences.getString(INSTALL_GUID, null);
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
             // protect against shared prefs failure: default to creating a new GUID in this scenario
         }
 
@@ -61,7 +61,7 @@ class UUIDHelper {
             installationGUID = UUID.randomUUID().toString();
             try {
                 braintreeSharedPreferences.putString(INSTALL_GUID, installationGUID);
-            } catch (UnexpectedException ignored) {
+            } catch (BraintreeSharedPreferencesException ignored) {
                 // protect against shared prefs failure: no-op when we're unable to persist the GUID
             }
         }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.java
@@ -23,7 +23,7 @@ class UUIDHelper {
     String getPersistentUUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         String uuid = null;
         try {
-            uuid = braintreeSharedPreferences.getString(context, BRAINTREE_UUID_KEY, null);
+            uuid = braintreeSharedPreferences.getString(BRAINTREE_UUID_KEY, null);
         } catch (UnexpectedException ignored) {
             // protect against shared prefs failure: default to creating a new UUID in this scenario
         }
@@ -31,7 +31,7 @@ class UUIDHelper {
         if (uuid == null) {
             uuid = getFormattedUUID();
             try {
-                braintreeSharedPreferences.putString(context, BRAINTREE_UUID_KEY, uuid);
+                braintreeSharedPreferences.putString(BRAINTREE_UUID_KEY, uuid);
             } catch (UnexpectedException ignored) {
                 // protect against shared prefs failure: no-op when we're unable to persist the UUID
             }
@@ -52,7 +52,7 @@ class UUIDHelper {
     String getInstallationGUID(Context context, BraintreeSharedPreferences braintreeSharedPreferences) {
         String installationGUID = null;
         try {
-            installationGUID = braintreeSharedPreferences.getString(context, INSTALL_GUID, null);
+            installationGUID = braintreeSharedPreferences.getString(INSTALL_GUID, null);
         } catch (UnexpectedException ignored) {
             // protect against shared prefs failure: default to creating a new GUID in this scenario
         }
@@ -60,7 +60,7 @@ class UUIDHelper {
         if (installationGUID == null) {
             installationGUID = UUID.randomUUID().toString();
             try {
-                braintreeSharedPreferences.putString(context, INSTALL_GUID, installationGUID);
+                braintreeSharedPreferences.putString(INSTALL_GUID, installationGUID);
             } catch (UnexpectedException ignored) {
                 // protect against shared prefs failure: no-op when we're unable to persist the GUID
             }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -89,17 +89,23 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void getConfiguration_onAuthorizationLoaderSuccess_forwardsInvocationToConfigurationLoader() {
+    public void getConfiguration_onAuthorizationAndConfigurationLoadSuccess_forwardsResult() {
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
                 .authorization(authorization)
                 .build();
+
+        Configuration configuration = mock(Configuration.class);
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
+                .configuration(configuration)
+                .build();
+
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
         ConfigurationCallback callback = mock(ConfigurationCallback.class);
         sut.getConfiguration(callback);
 
-        verify(configurationLoader).loadConfiguration(applicationContext, authorization, callback);
+        verify(callback).onResult(configuration, null);
     }
 
     @Test
@@ -115,6 +121,24 @@ public class BraintreeClientUnitTest {
         sut.getConfiguration(callback);
 
         verify(callback).onResult(null, authFetchError);
+    }
+
+    @Test
+    public void getConfiguration_forwardsConfigurationLoaderError() {
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
+        Exception configFetchError = new Exception("config fetch error");
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
+                .configurationError(configFetchError)
+                .build();
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        ConfigurationCallback callback = mock(ConfigurationCallback.class);
+        sut.getConfiguration(callback);
+
+        verify(callback).onResult(null, configFetchError);
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -115,7 +115,8 @@ public class BraintreeClientUnitTest {
                 .build();
 
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
-        UnexpectedException loadFromCacheError = new UnexpectedException("cache load error");
+        BraintreeSharedPreferencesException loadFromCacheError =
+            new BraintreeSharedPreferencesException("cache load error");
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .loadFromCacheError(loadFromCacheError)
@@ -138,7 +139,8 @@ public class BraintreeClientUnitTest {
                 .build();
 
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
-        UnexpectedException saveToCacheError = new UnexpectedException("cache save error");
+        BraintreeSharedPreferencesException saveToCacheError =
+            new BraintreeSharedPreferencesException("cache save error");
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .saveToCacheError(saveToCacheError)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -89,12 +89,12 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void getConfiguration_onAuthorizationAndConfigurationLoadSuccess_forwardsResult() {
+    public void getConfiguration_onAuthorizationAndConfigurationLoadSuccess_forwardsResult() throws JSONException {
         AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
                 .authorization(authorization)
                 .build();
 
-        Configuration configuration = mock(Configuration.class);
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .build();
@@ -106,6 +106,52 @@ public class BraintreeClientUnitTest {
         sut.getConfiguration(callback);
 
         verify(callback).onResult(configuration, null);
+    }
+
+    @Test
+    public void getConfiguration_onAuthorizationAndConfigurationLoadSuccess_sendsAnalyticsEventForCacheLoadErrors() throws JSONException {
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
+
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        UnexpectedException loadFromCacheError = new UnexpectedException("cache load error");
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
+                .configuration(configuration)
+                .loadFromCacheError(loadFromCacheError)
+                .build();
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        ConfigurationCallback callback = mock(ConfigurationCallback.class);
+        sut.getConfiguration(callback);
+
+        String expectedEventName = "configuration.cache.load.failed";
+        verify(analyticsClient).sendEvent(configuration, expectedEventName, "session-id", "custom", authorization);
+    }
+
+    @Test
+    public void getConfiguration_onAuthorizationAndConfigurationLoadSuccess_sendsAnalyticsEventForCacheSaveErrors() throws JSONException {
+        AuthorizationLoader authorizationLoader = new MockAuthorizationLoaderBuilder()
+                .authorization(authorization)
+                .build();
+
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
+        UnexpectedException saveToCacheError = new UnexpectedException("cache save error");
+        ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
+                .configuration(configuration)
+                .saveToCacheError(saveToCacheError)
+                .build();
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        ConfigurationCallback callback = mock(ConfigurationCallback.class);
+        sut.getConfiguration(callback);
+
+        String expectedEventName = "configuration.cache.save.failed";
+        verify(analyticsClient).sendEvent(configuration, expectedEventName, "session-id", "custom", authorization);
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -2,7 +2,6 @@ package com.braintreepayments.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -37,7 +36,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException, UnexpectedException {
+    public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException, BraintreeSharedPreferencesException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
@@ -46,13 +45,14 @@ public class ConfigurationCacheUnitTest {
         verify(braintreeSharedPreferences).putStringAndLong("cacheKey", configuration.toJson(), "cacheKey_timestamp", 123L);
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void saveConfiguration_whenSharedPreferencesFails_forwardsException() throws JSONException, UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void saveConfiguration_whenSharedPreferencesFails_forwardsException() throws JSONException, BraintreeSharedPreferencesException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
 
-        UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
+        BraintreeSharedPreferencesException unexpectedException
+            = new BraintreeSharedPreferencesException("unexpected exception");
         doThrow(unexpectedException)
                 .when(braintreeSharedPreferences)
                 .putStringAndLong(anyString(), anyString(), anyString(), anyLong());
@@ -61,7 +61,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void getConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException, UnexpectedException {
+    public void getConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException, BraintreeSharedPreferencesException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         when(braintreeSharedPreferences.containsKey("cacheKey_timestamp")).thenReturn(true);
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(0L);
@@ -74,7 +74,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void getConfiguration_whenCacheEntryExpires_returnsNull() throws JSONException, UnexpectedException {
+    public void getConfiguration_whenCacheEntryExpires_returnsNull() throws JSONException, BraintreeSharedPreferencesException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         when(braintreeSharedPreferences.containsKey("cacheKey_timestamp")).thenReturn(true);
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));
@@ -86,9 +86,10 @@ public class ConfigurationCacheUnitTest {
         assertNull(sut.getConfiguration("cacheKey", TimeUnit.MINUTES.toMillis(20)));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getConfiguration_whenSharedPreferencesFails_forwardsException() throws UnexpectedException {
-        UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getConfiguration_whenSharedPreferencesFails_forwardsException() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferencesException unexpectedException =
+            new BraintreeSharedPreferencesException("unexpected exception");
         when(braintreeSharedPreferences.containsKey(anyString())).thenThrow(unexpectedException);
         when(braintreeSharedPreferences.getLong(anyString())).thenThrow(unexpectedException);
         when(braintreeSharedPreferences.getString(anyString(), anyString())).thenThrow(unexpectedException);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -40,28 +40,24 @@ public class ConfigurationCacheUnitTest {
     public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
-        ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 123L);
+        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        sut.saveConfiguration(configuration, "cacheKey", 123L);
 
         verify(braintreeSharedPreferences).putStringAndLong("cacheKey", configuration.toJson(), "cacheKey_timestamp", 123L);
     }
 
-    @Test
+    @Test(expected = UnexpectedException.class)
     public void saveConfiguration_whenSharedPreferencesFails_forwardsException() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
-        ConfigurationCache sut = new ConfigurationCache();
+        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
 
         UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
         doThrow(unexpectedException)
                 .when(braintreeSharedPreferences)
                 .putStringAndLong(anyString(), anyString(), anyString(), anyLong());
 
-        try {
-            sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 123);
-        } catch (Exception e) {
-            fail("This method should not throw.");
-        }
+        sut.saveConfiguration(configuration, "cacheKey", 123);
     }
 
     @Test
@@ -71,10 +67,10 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(0L);
         when(braintreeSharedPreferences.getString("cacheKey", "")).thenReturn(configuration.toJson());
 
-        ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
+        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        sut.saveConfiguration(configuration, "cacheKey", 0);
 
-        assertEquals(configuration.toJson(), sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5) - 1));
+        assertEquals(configuration.toJson(), sut.getConfiguration("cacheKey", TimeUnit.MINUTES.toMillis(5) - 1));
     }
 
     @Test
@@ -84,10 +80,10 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));
         when(braintreeSharedPreferences.getString("cacheKey", "")).thenReturn(configuration.toJson());
 
-        ConfigurationCache sut = new ConfigurationCache();
-        sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
+        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        sut.saveConfiguration(configuration, "cacheKey", 0);
 
-        assertNull(sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(20)));
+        assertNull(sut.getConfiguration("cacheKey", TimeUnit.MINUTES.toMillis(20)));
     }
 
     @Test(expected = UnexpectedException.class)
@@ -97,7 +93,7 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong(anyString())).thenThrow(unexpectedException);
         when(braintreeSharedPreferences.getString(anyString(), anyString())).thenThrow(unexpectedException);
 
-        ConfigurationCache sut = new ConfigurationCache();
-        assertNull(sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5) - 1));
+        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        assertNull(sut.getConfiguration("cacheKey", TimeUnit.MINUTES.toMillis(5) - 1));
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -63,7 +63,7 @@ public class ConfigurationCacheUnitTest {
         ConfigurationCache sut = new ConfigurationCache();
         sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
 
-        assertEquals(configuration.toJson(), sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
+        assertEquals(configuration.toJson(), sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class ConfigurationCacheUnitTest {
         ConfigurationCache sut = new ConfigurationCache();
         sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
 
-        assertNull(sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(20)));
+        assertNull(sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(20)));
     }
 
     @Test
@@ -87,6 +87,6 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getString(anyString(),anyString())).thenThrow(unexpectedException);
 
         ConfigurationCache sut = new ConfigurationCache();
-        assertNull(sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
+        assertNull(sut.getConfiguration(braintreeSharedPreferences, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -45,7 +45,7 @@ public class ConfigurationCacheUnitTest {
         UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
         doThrow(unexpectedException)
                 .when(braintreeSharedPreferences)
-                .putStringAndLong(any(Context.class), anyString(), anyString(), anyString(), anyLong());
+                .putStringAndLong(anyString(), anyString(), anyString(), anyLong());
 
         try {
             sut.saveConfiguration(context, configuration, "cacheKey", 123);
@@ -57,9 +57,9 @@ public class ConfigurationCacheUnitTest {
     @Test
     public void getConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        when(braintreeSharedPreferences.containsKey(context, "cacheKey_timestamp")).thenReturn(true);
-        when(braintreeSharedPreferences.getLong(context, "cacheKey_timestamp")).thenReturn(0L);
-        when(braintreeSharedPreferences.getString(context, "cacheKey", "")).thenReturn(configuration.toJson());
+        when(braintreeSharedPreferences.containsKey("cacheKey_timestamp")).thenReturn(true);
+        when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(0L);
+        when(braintreeSharedPreferences.getString("cacheKey", "")).thenReturn(configuration.toJson());
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
         sut.saveConfiguration(context, configuration, "cacheKey", 0);
@@ -70,9 +70,9 @@ public class ConfigurationCacheUnitTest {
     @Test
     public void getConfiguration_whenCacheEntryExpires_returnsNull() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        when(braintreeSharedPreferences.containsKey(context, "cacheKey_timestamp")).thenReturn(true);
-        when(braintreeSharedPreferences.getLong(context, "cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));
-        when(braintreeSharedPreferences.getString(context, "cacheKey","")).thenReturn(configuration.toJson());
+        when(braintreeSharedPreferences.containsKey("cacheKey_timestamp")).thenReturn(true);
+        when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));
+        when(braintreeSharedPreferences.getString("cacheKey","")).thenReturn(configuration.toJson());
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
         sut.saveConfiguration(context, configuration, "cacheKey", 0);
@@ -83,9 +83,9 @@ public class ConfigurationCacheUnitTest {
     @Test
     public void getConfiguration_whenEncryptedSharedPrefsFails_returnsNull() throws UnexpectedException {
         UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
-        when(braintreeSharedPreferences.containsKey(any(Context.class), anyString())).thenThrow(unexpectedException);
-        when(braintreeSharedPreferences.getLong(any(Context.class), anyString())).thenThrow(unexpectedException);
-        when(braintreeSharedPreferences.getString(any(Context.class), anyString(),anyString())).thenThrow(unexpectedException);
+        when(braintreeSharedPreferences.containsKey(anyString())).thenThrow(unexpectedException);
+        when(braintreeSharedPreferences.getLong(anyString())).thenThrow(unexpectedException);
+        when(braintreeSharedPreferences.getString(anyString(),anyString())).thenThrow(unexpectedException);
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
         assertNull(sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -33,7 +33,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException {
+    public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
@@ -42,7 +42,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void getCacheConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException {
+    public void getCacheConfiguration_returnsConfigurationFromSharedPrefs() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         when(braintreeSharedPreferences.containsKey(context, "cacheKey_timestamp")).thenReturn(true);
         when(braintreeSharedPreferences.getLong(context, "cacheKey_timestamp")).thenReturn(0L);
@@ -55,7 +55,7 @@ public class ConfigurationCacheUnitTest {
     }
 
     @Test
-    public void getCacheConfiguration_returnsNullIfCacheEntryExpires() throws JSONException {
+    public void getCacheConfiguration_returnsNullIfCacheEntryExpires() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         when(braintreeSharedPreferences.containsKey(context, "cacheKey_timestamp")).thenReturn(true);
         when(braintreeSharedPreferences.getLong(context, "cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -51,9 +51,9 @@ public class ConfigurationCacheUnitTest {
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
 
-        BraintreeSharedPreferencesException unexpectedException
-            = new BraintreeSharedPreferencesException("unexpected exception");
-        doThrow(unexpectedException)
+        BraintreeSharedPreferencesException sharedPrefsException =
+            new BraintreeSharedPreferencesException("unexpected exception");
+        doThrow(sharedPrefsException)
                 .when(braintreeSharedPreferences)
                 .putStringAndLong(anyString(), anyString(), anyString(), anyLong());
 
@@ -88,11 +88,11 @@ public class ConfigurationCacheUnitTest {
 
     @Test(expected = BraintreeSharedPreferencesException.class)
     public void getConfiguration_whenSharedPreferencesFails_forwardsException() throws BraintreeSharedPreferencesException {
-        BraintreeSharedPreferencesException unexpectedException =
+        BraintreeSharedPreferencesException sharedPrefsException =
             new BraintreeSharedPreferencesException("unexpected exception");
-        when(braintreeSharedPreferences.containsKey(anyString())).thenThrow(unexpectedException);
-        when(braintreeSharedPreferences.getLong(anyString())).thenThrow(unexpectedException);
-        when(braintreeSharedPreferences.getString(anyString(), anyString())).thenThrow(unexpectedException);
+        when(braintreeSharedPreferences.containsKey(anyString())).thenThrow(sharedPrefsException);
+        when(braintreeSharedPreferences.getLong(anyString())).thenThrow(sharedPrefsException);
+        when(braintreeSharedPreferences.getString(anyString(), anyString())).thenThrow(sharedPrefsException);
 
         ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
         assertNull(sut.getConfiguration("cacheKey", TimeUnit.MINUTES.toMillis(5) - 1));

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationCacheUnitTest.java
@@ -3,7 +3,6 @@ package com.braintreepayments.api;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -40,7 +39,7 @@ public class ConfigurationCacheUnitTest {
     public void saveConfiguration_savesConfigurationInSharedPrefs() throws JSONException, UnexpectedException {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
 
-        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        ConfigurationCache sut = new ConfigurationCache();
 
         UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
         doThrow(unexpectedException)
@@ -48,7 +47,7 @@ public class ConfigurationCacheUnitTest {
                 .putStringAndLong(anyString(), anyString(), anyString(), anyLong());
 
         try {
-            sut.saveConfiguration(context, configuration, "cacheKey", 123);
+            sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 123);
         } catch (Exception e) {
             fail("This method should not throw.");
         }
@@ -61,8 +60,8 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(0L);
         when(braintreeSharedPreferences.getString("cacheKey", "")).thenReturn(configuration.toJson());
 
-        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
-        sut.saveConfiguration(context, configuration, "cacheKey", 0);
+        ConfigurationCache sut = new ConfigurationCache();
+        sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
 
         assertEquals(configuration.toJson(), sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
     }
@@ -74,8 +73,8 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong("cacheKey_timestamp")).thenReturn(TimeUnit.MINUTES.toMillis(5));
         when(braintreeSharedPreferences.getString("cacheKey","")).thenReturn(configuration.toJson());
 
-        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
-        sut.saveConfiguration(context, configuration, "cacheKey", 0);
+        ConfigurationCache sut = new ConfigurationCache();
+        sut.saveConfiguration(braintreeSharedPreferences, configuration, "cacheKey", 0);
 
         assertNull(sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(20)));
     }
@@ -87,7 +86,7 @@ public class ConfigurationCacheUnitTest {
         when(braintreeSharedPreferences.getLong(anyString())).thenThrow(unexpectedException);
         when(braintreeSharedPreferences.getString(anyString(),anyString())).thenThrow(unexpectedException);
 
-        ConfigurationCache sut = new ConfigurationCache(braintreeSharedPreferences);
+        ConfigurationCache sut = new ConfigurationCache();
         assertNull(sut.getConfiguration(context, "cacheKey", TimeUnit.MINUTES.toMillis(5)-1));
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -51,7 +51,7 @@ public class ConfigurationLoaderUnitTest {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
@@ -70,7 +70,7 @@ public class ConfigurationLoaderUnitTest {
         when(authorization.getBearer()).thenReturn("bearer");
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         String expectedConfigUrl = "https://example.com/config?configVersion=3";
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
@@ -89,7 +89,7 @@ public class ConfigurationLoaderUnitTest {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> captor = ArgumentCaptor.forClass(HttpResponseCallback.class);
         verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), captor.capture());
@@ -105,7 +105,7 @@ public class ConfigurationLoaderUnitTest {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         ArgumentCaptor<HttpResponseCallback> httpResponseCaptor = ArgumentCaptor.forClass(HttpResponseCallback.class);
         verify(braintreeHttpClient).get(anyString(), (Configuration) isNull(), same(authorization), eq(HttpClient.RETRY_MAX_3_TIMES), httpResponseCaptor.capture());
@@ -127,7 +127,7 @@ public class ConfigurationLoaderUnitTest {
         Authorization authorization = new InvalidAuthorization("invalid", "token invalid");
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         ArgumentCaptor<BraintreeException> captor = ArgumentCaptor.forClass(BraintreeException.class);
         verify(callback).onResult((ConfigurationLoaderResult) isNull(), captor.capture());
@@ -146,7 +146,7 @@ public class ConfigurationLoaderUnitTest {
         when(configurationCache.getConfiguration(cacheKey)).thenReturn(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN);
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
-        sut.loadConfiguration(context, authorization, callback);
+        sut.loadConfiguration(authorization, callback);
 
         verify(braintreeHttpClient, times(0)).get(anyString(), (Configuration) isNull(), same(authorization), anyInt(), any(HttpResponseCallback.class));
         verify(callback).onResult(any(ConfigurationLoaderResult.class), (Exception) isNull());

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -81,7 +81,7 @@ public class ConfigurationLoaderUnitTest {
         httpResponseCallback.onResult(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, null);
 
         String cacheKey = Base64.encodeToString(String.format("%s%s", "https://example.com/config?configVersion=3", "bearer").getBytes(), 0);
-        verify(configurationCache).saveConfiguration(same(context), any(Configuration.class), eq(cacheKey));
+        verify(configurationCache).saveConfiguration(any(Configuration.class), eq(cacheKey));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ConfigurationLoaderUnitTest {
 
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
         when(authorization.getBearer()).thenReturn("bearer");
-        when(configurationCache.getConfiguration(context, cacheKey)).thenReturn(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN);
+        when(configurationCache.getConfiguration(cacheKey)).thenReturn(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN);
 
         ConfigurationLoader sut = new ConfigurationLoader(braintreeHttpClient, configurationCache);
         sut.loadConfiguration(context, authorization, callback);

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -156,11 +156,13 @@ public class ConfigurationLoaderUnitTest {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
         when(authorization.getBearer()).thenReturn("bearer");
 
-        UnexpectedException cacheLoadError = new UnexpectedException("cache load error");
+        BraintreeSharedPreferencesException cacheLoadError =
+            new BraintreeSharedPreferencesException("cache load error");
         when(configurationCache.getConfiguration(anyString()))
                 .thenThrow(cacheLoadError);
 
-        UnexpectedException cacheSaveError = new UnexpectedException("cache save error");
+        BraintreeSharedPreferencesException cacheSaveError =
+            new BraintreeSharedPreferencesException("cache save error");
         doThrow(cacheSaveError)
                 .when(configurationCache).saveConfiguration(any(Configuration.class), anyString());
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ConfigurationLoaderUnitTest.java
@@ -1,19 +1,5 @@
 package com.braintreepayments.api;
 
-import android.content.Context;
-import android.util.Base64;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.robolectric.RobolectricTestRunner;
-import org.skyscreamer.jsonassert.JSONAssert;
-
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -28,6 +14,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.util.Base64;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.robolectric.RobolectricTestRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({"org.powermock.*", "org.mockito.*", "org.robolectric.*", "android.*", "androidx.*"})
 public class ConfigurationLoaderUnitTest {
@@ -37,15 +35,12 @@ public class ConfigurationLoaderUnitTest {
     private BraintreeHttpClient braintreeHttpClient;
     private ConfigurationLoaderCallback callback;
 
-    private Context context;
     private Authorization authorization;
 
     @Before
     public void beforeEach() {
         configurationCache = mock(ConfigurationCache.class);
-
         authorization = mock(Authorization.class);
-        context = mock(Context.class);
 
         braintreeHttpClient = mock(BraintreeHttpClient.class);
         callback = mock(ConfigurationLoaderCallback.class);
@@ -70,7 +65,7 @@ public class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    public void loadConfiguration_savesFetchedConfigurationToCache() throws UnexpectedException {
+    public void loadConfiguration_savesFetchedConfigurationToCache() throws BraintreeSharedPreferencesException {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
         when(authorization.getBearer()).thenReturn("bearer");
 
@@ -142,9 +137,8 @@ public class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    public void loadConfiguration_whenCachedConfigurationAvailable_loadsConfigurationFromCache() throws UnexpectedException {
+    public void loadConfiguration_whenCachedConfigurationAvailable_loadsConfigurationFromCache() throws BraintreeSharedPreferencesException {
         String cacheKey = Base64.encodeToString(String.format("%s%s", "https://example.com/config?configVersion=3", "bearer").getBytes(), 0);
-        Context context = mock(Context.class);
 
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
         when(authorization.getBearer()).thenReturn("bearer");
@@ -158,7 +152,7 @@ public class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    public void loadConfiguration_forwardsConfigurationCacheErrors() throws UnexpectedException, JSONException {
+    public void loadConfiguration_forwardsConfigurationCacheErrors() throws BraintreeSharedPreferencesException, JSONException {
         when(authorization.getConfigUrl()).thenReturn("https://example.com/config");
         when(authorization.getBearer()).thenReturn("bearer");
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -28,7 +28,7 @@ public class UUIDHelperUnitTest {
     }
 
     @Test
-    public void getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() throws UnexpectedException {
+    public void getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() throws BraintreeSharedPreferencesException {
         when(braintreeSharedPreferences.getString("InstallationGUID", null)).thenReturn(null);
 
         UUIDHelper sut = new UUIDHelper();
@@ -39,8 +39,10 @@ public class UUIDHelperUnitTest {
     }
 
     @Test
-    public void getInstallationGUID_whenSharedPrefsFails_returnsNewGUID() throws UnexpectedException {
-        UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
+    public void getInstallationGUID_whenSharedPrefsFails_returnsNewGUID() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferencesException unexpectedException =
+                new BraintreeSharedPreferencesException("unexpected exception");
+
         when(
                 braintreeSharedPreferences.getString(anyString(), anyString())
         ).thenThrow(unexpectedException);
@@ -56,7 +58,7 @@ public class UUIDHelperUnitTest {
     }
 
     @Test
-    public void getInstallationGUID_returnsExistingGUIDWhenOneExist() throws UnexpectedException {
+    public void getInstallationGUID_returnsExistingGUIDWhenOneExist() throws BraintreeSharedPreferencesException {
         String uuid = UUID.randomUUID().toString();
         when(braintreeSharedPreferences.getString("InstallationGUID", null)).thenReturn(uuid);
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -2,6 +2,9 @@ package com.braintreepayments.api;
 
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +36,23 @@ public class UUIDHelperUnitTest {
         String uuid = sut.getInstallationGUID(context, braintreeSharedPreferences);
         assertNotNull(uuid);
         verify(braintreeSharedPreferences).putString(context, "InstallationGUID", uuid);
+    }
+
+    @Test
+    public void getInstallationGUID_whenSharedPrefsFails_returnsNewGUID() throws UnexpectedException {
+        UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
+        when(
+                braintreeSharedPreferences.getString(any(Context.class), anyString(), anyString())
+        ).thenThrow(unexpectedException);
+
+        doThrow(unexpectedException)
+                .when(braintreeSharedPreferences)
+                .putString(any(Context.class), anyString(), anyString());
+
+        UUIDHelper sut = new UUIDHelper();
+
+        String uuid = sut.getInstallationGUID(context, braintreeSharedPreferences);
+        assertNotNull(uuid);
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -29,25 +29,25 @@ public class UUIDHelperUnitTest {
 
     @Test
     public void getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() throws UnexpectedException {
-        when(braintreeSharedPreferences.getString(context, "InstallationGUID", null)).thenReturn(null);
+        when(braintreeSharedPreferences.getString("InstallationGUID", null)).thenReturn(null);
 
         UUIDHelper sut = new UUIDHelper();
 
         String uuid = sut.getInstallationGUID(context, braintreeSharedPreferences);
         assertNotNull(uuid);
-        verify(braintreeSharedPreferences).putString(context, "InstallationGUID", uuid);
+        verify(braintreeSharedPreferences).putString("InstallationGUID", uuid);
     }
 
     @Test
     public void getInstallationGUID_whenSharedPrefsFails_returnsNewGUID() throws UnexpectedException {
         UnexpectedException unexpectedException = new UnexpectedException("unexpected exception");
         when(
-                braintreeSharedPreferences.getString(any(Context.class), anyString(), anyString())
+                braintreeSharedPreferences.getString(anyString(), anyString())
         ).thenThrow(unexpectedException);
 
         doThrow(unexpectedException)
                 .when(braintreeSharedPreferences)
-                .putString(any(Context.class), anyString(), anyString());
+                .putString(anyString(), anyString());
 
         UUIDHelper sut = new UUIDHelper();
 
@@ -58,7 +58,7 @@ public class UUIDHelperUnitTest {
     @Test
     public void getInstallationGUID_returnsExistingGUIDWhenOneExist() throws UnexpectedException {
         String uuid = UUID.randomUUID().toString();
-        when(braintreeSharedPreferences.getString(context, "InstallationGUID", null)).thenReturn(uuid);
+        when(braintreeSharedPreferences.getString("InstallationGUID", null)).thenReturn(uuid);
 
         UUIDHelper sut = new UUIDHelper();
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -33,7 +33,7 @@ public class UUIDHelperUnitTest {
 
         UUIDHelper sut = new UUIDHelper();
 
-        String uuid = sut.getInstallationGUID(context, braintreeSharedPreferences);
+        String uuid = sut.getInstallationGUID(braintreeSharedPreferences);
         assertNotNull(uuid);
         verify(braintreeSharedPreferences).putString("InstallationGUID", uuid);
     }
@@ -51,7 +51,7 @@ public class UUIDHelperUnitTest {
 
         UUIDHelper sut = new UUIDHelper();
 
-        String uuid = sut.getInstallationGUID(context, braintreeSharedPreferences);
+        String uuid = sut.getInstallationGUID(braintreeSharedPreferences);
         assertNotNull(uuid);
     }
 
@@ -62,6 +62,6 @@ public class UUIDHelperUnitTest {
 
         UUIDHelper sut = new UUIDHelper();
 
-        assertEquals(uuid, sut.getInstallationGUID(context, braintreeSharedPreferences));
+        assertEquals(uuid, sut.getInstallationGUID(braintreeSharedPreferences));
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -40,14 +40,14 @@ public class UUIDHelperUnitTest {
 
     @Test
     public void getInstallationGUID_whenSharedPrefsFails_returnsNewGUID() throws BraintreeSharedPreferencesException {
-        BraintreeSharedPreferencesException unexpectedException =
+        BraintreeSharedPreferencesException sharedPrefsException =
                 new BraintreeSharedPreferencesException("unexpected exception");
 
         when(
                 braintreeSharedPreferences.getString(anyString(), anyString())
-        ).thenThrow(unexpectedException);
+        ).thenThrow(sharedPrefsException);
 
-        doThrow(unexpectedException)
+        doThrow(sharedPrefsException)
                 .when(braintreeSharedPreferences)
                 .putString(anyString(), anyString());
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/UUIDHelperUnitTest.java
@@ -25,7 +25,7 @@ public class UUIDHelperUnitTest {
     }
 
     @Test
-    public void getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() {
+    public void getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() throws UnexpectedException {
         when(braintreeSharedPreferences.getString(context, "InstallationGUID", null)).thenReturn(null);
 
         UUIDHelper sut = new UUIDHelper();
@@ -36,7 +36,7 @@ public class UUIDHelperUnitTest {
     }
 
     @Test
-    public void getInstallationGUID_returnsExistingGUIDWhenOneExist() {
+    public void getInstallationGUID_returnsExistingGUIDWhenOneExist() throws UnexpectedException {
         String uuid = UUID.randomUUID().toString();
         when(braintreeSharedPreferences.getString(context, "InstallationGUID", null)).thenReturn(uuid);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## unreleased
 
 * SharedUtils
-  * Add new `BraintreeSharedPreferencesException` to notify when an error occurs while interacting with shared preferences
   * Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)
+  * Add new `BraintreeSharedPreferencesException` to notify when an error occurs while interacting with shared preferences
 
 ## 4.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* SharedUtils
+  * Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)
+
 ## 4.19.0
 
 * GooglePay
   * Bump `play-services-wallet` version to `19.1.0`
 * SharedUtils
   * Add explicit key alias for encrypted shared prefs (potential fix for #604)
-  * Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)
 
 ## 4.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Bump `play-services-wallet` version to `19.1.0`
 * SharedUtils
   * Add explicit key alias for encrypted shared prefs (potential fix for #604)
+  * Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)
 
 ## 4.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * SharedUtils
+  * Add new `BraintreeSharedPreferencesException` to notify when an error occurs while interacting with shared preferences
   * Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)
 
 ## 4.19.0

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -54,6 +54,12 @@ public class BraintreeSharedPreferencesTest {
         assertEquals("fallbackValue", sut.getString("stringKey", "fallbackValue"));
     }
 
+    @Test(expected = UnexpectedException.class)
+    public void getString_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.getString("stringKey", "fallbackValue");
+    }
+
     @Test
     public void putString_storesStringInSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
@@ -62,10 +68,22 @@ public class BraintreeSharedPreferencesTest {
         assertEquals("stringValue", sut.getString("stringKey", ""));
     }
 
+    @Test(expected = UnexpectedException.class)
+    public void putString_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.putString("stringKey", "stringValue");
+    }
+
     @Test
     public void getBoolean_returnsFalseByDefault() throws UnexpectedException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
         assertFalse(sut.getBoolean("booleanKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void getBoolean_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.getBoolean("booleanKey");
     }
 
     @Test
@@ -74,6 +92,12 @@ public class BraintreeSharedPreferencesTest {
         sut.putBoolean("booleanKey", true);
 
         assertTrue(sut.getBoolean("booleanKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void putBoolean_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.putBoolean("booleanKey", true);
     }
 
     @Test
@@ -90,6 +114,12 @@ public class BraintreeSharedPreferencesTest {
         assertFalse(sut.containsKey("booleanKey"));
     }
 
+    @Test(expected = UnexpectedException.class)
+    public void containsKey_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.containsKey("booleanKey");
+    }
+
     @Test
     public void putStringAndLong_storesStringInSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
@@ -99,10 +129,22 @@ public class BraintreeSharedPreferencesTest {
         assertEquals(123L, sut.getLong("longKey"));
     }
 
+    @Test(expected = UnexpectedException.class)
+    public void putStringAndLong_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
+    }
+
     @Test
     public void getLong_returnsZeroByDefault() throws UnexpectedException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
         assertEquals(0L, sut.getLong("longKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void getLong_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.getLong("longKey");
     }
 
     @Test
@@ -118,5 +160,11 @@ public class BraintreeSharedPreferencesTest {
         assertFalse(sut.containsKey("booleanKey"));
         assertFalse(sut.containsKey("stringKey2"));
         assertFalse(sut.containsKey("longKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void clearSharedPreferences_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+        sut.clearSharedPreferences();
     }
 }

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -78,83 +78,83 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void getString_returnsFallbackStringByDefault() throws UnexpectedException {
+    public void getString_returnsFallbackStringByDefault() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertEquals("fallbackValue", sut.getString("stringKey", "fallbackValue"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getString_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getString_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.getString("stringKey", "fallbackValue");
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getString_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getString_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.getString("stringKey", "fallbackValue");
     }
 
     @Test
-    public void putString_storesStringInSharedPreferences() throws UnexpectedException {
+    public void putString_storesStringInSharedPreferences() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putString("stringKey", "stringValue");
 
         assertEquals("stringValue", sut.getString("stringKey", ""));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putString_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putString_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.putString("stringKey", "stringValue");
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putString_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putString_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.putString("stringKey", "stringValue");
     }
 
     @Test
-    public void getBoolean_returnsFalseByDefault() throws UnexpectedException {
+    public void getBoolean_returnsFalseByDefault() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertFalse(sut.getBoolean("booleanKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getBoolean_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getBoolean_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.getBoolean("booleanKey");
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getBoolean_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getBoolean_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.getBoolean("booleanKey");
     }
 
     @Test
-    public void putBoolean_storesBooleanInSharedPreferences() throws UnexpectedException {
+    public void putBoolean_storesBooleanInSharedPreferences() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putBoolean("booleanKey", true);
 
         assertTrue(sut.getBoolean("booleanKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putBoolean_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putBoolean_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.putBoolean("booleanKey", true);
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putBoolean_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putBoolean_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.putBoolean("booleanKey", true);
     }
 
     @Test
-    public void containsKey_whenKeyExists_returnsTrue() throws UnexpectedException {
+    public void containsKey_whenKeyExists_returnsTrue() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putBoolean("booleanKey", true);
 
@@ -162,25 +162,25 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void containsKey_whenKeyDoesNotExist_returnsTrue() throws UnexpectedException {
+    public void containsKey_whenKeyDoesNotExist_returnsTrue() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertFalse(sut.containsKey("booleanKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void containsKey_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void containsKey_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.containsKey("booleanKey");
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void containsKey_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void containsKey_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.containsKey("booleanKey");
     }
 
     @Test
-    public void putStringAndLong_storesStringInSharedPreferences() throws UnexpectedException {
+    public void putStringAndLong_storesStringInSharedPreferences() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
 
@@ -188,38 +188,38 @@ public class BraintreeSharedPreferencesTest {
         assertEquals(123L, sut.getLong("longKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putStringAndLong_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putStringAndLong_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void putStringAndLong_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void putStringAndLong_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
     }
 
     @Test
-    public void getLong_returnsZeroByDefault() throws UnexpectedException {
+    public void getLong_returnsZeroByDefault() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertEquals(0L, sut.getLong("longKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getLong_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getLong_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.getLong("longKey");
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void getLong_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void getLong_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.getLong("longKey");
     }
 
     @Test
-    public void clearSharedPreferences_clearsSharedPreferences() throws UnexpectedException {
+    public void clearSharedPreferences_clearsSharedPreferences() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
 
         sut.putString("stringKey", "stringValue");
@@ -233,15 +233,15 @@ public class BraintreeSharedPreferencesTest {
         assertFalse(sut.containsKey("longKey"));
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void clearSharedPreferences_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void clearSharedPreferences_whenSharedPreferencesFails_throwsError() throws BraintreeSharedPreferencesException {
         BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
         sut.clearSharedPreferences();
     }
 
-    @Test(expected = UnexpectedException.class)
-    public void clearSharedPreferences_whenSharedPreferencesNotAccessible_throwsError() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new UnexpectedException("message"));
+    @Test(expected = BraintreeSharedPreferencesException.class)
+    public void clearSharedPreferences_whenSharedPreferencesNotAccessible_throwsError() throws BraintreeSharedPreferencesException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(new BraintreeSharedPreferencesException("message"));
         sut.clearSharedPreferences();
     }
 }

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -50,7 +50,6 @@ public class BraintreeSharedPreferencesTest {
         );
 
         failingSharedPreferences = mock(SharedPreferences.class);
-
         when(failingSharedPreferences.getString(anyString(), anyString()))
                 .thenThrow(new SecurityException("get string error"));
         when(failingSharedPreferences.getBoolean(anyString(), anyBoolean()))

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -3,6 +3,11 @@ package com.braintreepayments.api;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -23,35 +28,66 @@ import java.security.GeneralSecurityException;
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class BraintreeSharedPreferencesTest {
 
-    private Context context;
-    private SharedPreferences sharedPreferences;
+    private SharedPreferences workingSharedPreferences;
+
+    private SharedPreferences failingSharedPreferences;
+    private SharedPreferences.Editor failingSharedPreferencesEditor;
 
     @Before
     public void beforeEach() throws GeneralSecurityException, IOException {
-        context = ApplicationProvider.getApplicationContext();
+        Context context = ApplicationProvider.getApplicationContext();
 
         MasterKey masterKey = new MasterKey.Builder(context)
                 .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                 .build();
 
-        sharedPreferences = EncryptedSharedPreferences.create(
+        workingSharedPreferences = EncryptedSharedPreferences.create(
                 context,
                 "testfilename",
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         );
+
+        failingSharedPreferences = mock(SharedPreferences.class);
+
+        when(failingSharedPreferences.getString(anyString(), anyString()))
+                .thenThrow(new SecurityException("get string error"));
+        when(failingSharedPreferences.getBoolean(anyString(), anyBoolean()))
+                .thenThrow(new SecurityException("get boolean error"));
+        when(failingSharedPreferences.contains(anyString()))
+                .thenThrow(new SecurityException("get contains error"));
+        when(failingSharedPreferences.getLong(anyString(), anyLong()))
+                .thenThrow(new SecurityException("get long error"));
+
+        failingSharedPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(failingSharedPreferences.edit()).thenReturn(failingSharedPreferencesEditor);
+
+        when(failingSharedPreferences.edit().putString(anyString(), anyString()))
+                .thenThrow(new SecurityException("put string error"));
+        when(failingSharedPreferences.edit().putBoolean(anyString(), anyBoolean()))
+                .thenThrow(new SecurityException("put boolean error"));
+        when(failingSharedPreferences.edit().putLong(anyString(), anyLong()))
+                .thenThrow(new SecurityException("put long error"));
+        when(failingSharedPreferences.edit().clear())
+                .thenThrow(new SecurityException("clear error"));
     }
 
     @After
     public void afterEach() {
-        sharedPreferences.edit().clear().apply();
+        workingSharedPreferences.edit().clear().apply();
     }
 
     @Test
     public void getString_returnsFallbackStringByDefault() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertEquals("fallbackValue", sut.getString("stringKey", "fallbackValue"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void getString_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.getString("stringKey", "fallbackValue");
     }
 
     @Test(expected = UnexpectedException.class)
@@ -62,10 +98,16 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void putString_storesStringInSharedPreferences() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putString("stringKey", "stringValue");
 
         assertEquals("stringValue", sut.getString("stringKey", ""));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void putString_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.putString("stringKey", "stringValue");
     }
 
     @Test(expected = UnexpectedException.class)
@@ -76,8 +118,14 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void getBoolean_returnsFalseByDefault() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertFalse(sut.getBoolean("booleanKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void getBoolean_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.getBoolean("booleanKey");
     }
 
     @Test(expected = UnexpectedException.class)
@@ -88,10 +136,16 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void putBoolean_storesBooleanInSharedPreferences() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putBoolean("booleanKey", true);
 
         assertTrue(sut.getBoolean("booleanKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void putBoolean_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.putBoolean("booleanKey", true);
     }
 
     @Test(expected = UnexpectedException.class)
@@ -102,7 +156,7 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void containsKey_whenKeyExists_returnsTrue() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putBoolean("booleanKey", true);
 
         assertTrue(sut.containsKey("booleanKey"));
@@ -110,7 +164,7 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void containsKey_whenKeyDoesNotExist_returnsTrue() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertFalse(sut.containsKey("booleanKey"));
     }
 
@@ -120,13 +174,25 @@ public class BraintreeSharedPreferencesTest {
         sut.containsKey("booleanKey");
     }
 
+    @Test(expected = UnexpectedException.class)
+    public void containsKey_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.containsKey("booleanKey");
+    }
+
     @Test
     public void putStringAndLong_storesStringInSharedPreferences() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
 
         assertEquals("stringValue", sut.getString("stringKey", null));
         assertEquals(123L, sut.getLong("longKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void putStringAndLong_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.putStringAndLong("stringKey", "stringValue", "longKey", 123L);
     }
 
     @Test(expected = UnexpectedException.class)
@@ -137,8 +203,14 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void getLong_returnsZeroByDefault() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
         assertEquals(0L, sut.getLong("longKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void getLong_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.getLong("longKey");
     }
 
     @Test(expected = UnexpectedException.class)
@@ -149,7 +221,7 @@ public class BraintreeSharedPreferencesTest {
 
     @Test
     public void clearSharedPreferences_clearsSharedPreferences() throws UnexpectedException {
-        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(sharedPreferences);
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(workingSharedPreferences);
 
         sut.putString("stringKey", "stringValue");
         sut.putBoolean("booleanKey", true);
@@ -160,6 +232,12 @@ public class BraintreeSharedPreferencesTest {
         assertFalse(sut.containsKey("booleanKey"));
         assertFalse(sut.containsKey("stringKey2"));
         assertFalse(sut.containsKey("longKey"));
+    }
+
+    @Test(expected = UnexpectedException.class)
+    public void clearSharedPreferences_whenSharedPreferencesFails_throwsError() throws UnexpectedException {
+        BraintreeSharedPreferences sut = new BraintreeSharedPreferences(failingSharedPreferences);
+        sut.clearSharedPreferences();
     }
 
     @Test(expected = UnexpectedException.class)

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/BraintreeSharedPreferencesTest.java
@@ -15,29 +15,26 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class BraintreeSharedPreferencesTest {
 
     private Context context;
 
     @Before
-    public void beforeEach() throws GeneralSecurityException, IOException {
+    public void beforeEach() throws UnexpectedException {
         context = ApplicationProvider.getApplicationContext();
         getSharedPreferences(context).edit().clear().apply();
     }
 
     @Test
-    public void getSharedPreferences_returnsEncryptedSharedPreferences() {
+    public void getSharedPreferences_returnsEncryptedSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
         SharedPreferences sharedPreferences = getSharedPreferences(ApplicationProvider.getApplicationContext());
         assertTrue(sharedPreferences instanceof EncryptedSharedPreferences);
     }
 
     @Test
-    public void getString_returnsStringFromSharedPreferences() {
+    public void getString_returnsStringFromSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         sharedPreferences.edit().putString("testKey", "testValue").apply();
@@ -46,7 +43,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void getString_withFilename_returnsStringFromSharedPreferences() {
+    public void getString_withFilename_returnsStringFromSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         sharedPreferences.edit().putString("testKey", "testValue").apply();
@@ -55,7 +52,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void putString_savesStringInSharedPreferences() {
+    public void putString_savesStringInSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
 
         sut.putString(context, "testKey2", "testValue2");
@@ -65,7 +62,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void putString_withFilename_savesStringInSharedPreferences() {
+    public void putString_withFilename_savesStringInSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
 
         sut.putString(context, "testKey2", "testValue2");
@@ -75,7 +72,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void getBoolean_returnsBooleanFromSharedPreferences() {
+    public void getBoolean_returnsBooleanFromSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         sharedPreferences.edit().putBoolean("testKeyBoolean", true).apply();
@@ -84,7 +81,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void putBoolean_savesBooleanToSharedPreferences() {
+    public void putBoolean_savesBooleanToSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
 
         sut.putBoolean(context, "testKeyBoolean2", true);
@@ -94,7 +91,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void containsKey_returnsIfKeyExistsInSharedPreferences() {
+    public void containsKey_returnsIfKeyExistsInSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
 
         SharedPreferences sharedPreferences = getSharedPreferences(context);
@@ -104,7 +101,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void getLong_returnsLongFromSharedPreferences() {
+    public void getLong_returnsLongFromSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         sharedPreferences.edit().putLong("testKeyLong", 1L).apply();
@@ -113,7 +110,7 @@ public class BraintreeSharedPreferencesTest {
     }
 
     @Test
-    public void putStringAndLong_savesToSharedPreferences() {
+    public void putStringAndLong_savesToSharedPreferences() throws UnexpectedException {
         BraintreeSharedPreferences sut = BraintreeSharedPreferences.getInstance();
 
         sut.putStringAndLong(context, "testKeyString", "testValueString", "testKeyLong", 2L);

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -6,6 +6,8 @@ import android.content.SharedPreferences;
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
 
+// TODO: consider removing Security exception ignore statements once crypto library
+// bugs are fixed by Google
 class BraintreeSharedPreferences {
 
     private static volatile BraintreeSharedPreferences INSTANCE;
@@ -24,7 +26,8 @@ class BraintreeSharedPreferences {
         return INSTANCE;
     }
 
-    private BraintreeSharedPreferences() {}
+    private BraintreeSharedPreferences() {
+    }
 
     static SharedPreferences getSharedPreferences(Context context) {
         try {
@@ -46,28 +49,41 @@ class BraintreeSharedPreferences {
         }
     }
 
-    String getString(Context context, String key, String fallback)  {
+    String getString(Context context, String key, String fallback) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            return sharedPreferences.getString(key, fallback);
+            try {
+                return sharedPreferences.getString(key, fallback);
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+                return fallback;
+            }
         }
         return fallback;
     }
 
-    void putString(Context context, String key, String value){
+    void putString(Context context, String key, String value) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            sharedPreferences
-                    .edit()
-                    .putString(key, value)
-                    .apply();
+            try {
+                sharedPreferences
+                        .edit()
+                        .putString(key, value)
+                        .apply();
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+            }
         }
     }
 
     boolean getBoolean(Context context, String key) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            return sharedPreferences.getBoolean(key, false);
+            try {
+                return sharedPreferences.getBoolean(key, false);
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+            }
         }
         return false;
     }
@@ -75,17 +91,26 @@ class BraintreeSharedPreferences {
     void putBoolean(Context context, String key, boolean value) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            sharedPreferences
-                    .edit()
-                    .putBoolean(key, value)
-                    .apply();
+            try {
+                sharedPreferences
+                        .edit()
+                        .putBoolean(key, value)
+                        .apply();
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+            }
         }
     }
 
     boolean containsKey(Context context, String key) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            return sharedPreferences.contains(key);
+            try {
+                return sharedPreferences.contains(key);
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+                return false;
+            }
         }
         return false;
     }
@@ -93,7 +118,12 @@ class BraintreeSharedPreferences {
     long getLong(Context context, String key) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            return sharedPreferences.getLong(key, 0);
+            try {
+                return sharedPreferences.getLong(key, 0);
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+                return 0;
+            }
         }
         return 0;
     }
@@ -101,22 +131,29 @@ class BraintreeSharedPreferences {
     void putStringAndLong(Context context, String stringKey, String stringValue, String longKey, long longValue) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            sharedPreferences
-                    .edit()
-                    .putString(stringKey, stringValue)
-                    .putLong(longKey, longValue)
-                    .apply();
-
+            try {
+                sharedPreferences
+                        .edit()
+                        .putString(stringKey, stringValue)
+                        .putLong(longKey, longValue)
+                        .apply();
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+            }
         }
     }
 
     void clearSharedPreferences(Context context) {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
-            sharedPreferences
-                    .edit()
-                    .clear()
-                    .apply();
+            try {
+                sharedPreferences
+                        .edit()
+                        .clear()
+                        .apply();
+            } catch (SecurityException ignored) {
+                // defensively guard against issues with shared preferences library
+            }
         }
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -19,7 +19,7 @@ class BraintreeSharedPreferences {
     private static final String BRAINTREE_SHARED_PREFS_FILENAME = "BraintreeApi";
 
     private final SharedPreferences sharedPreferences;
-    private final UnexpectedException createException;
+    private final BraintreeSharedPreferencesException createException;
 
     static BraintreeSharedPreferences getInstance(Context context) {
         if (INSTANCE == null) {
@@ -28,7 +28,7 @@ class BraintreeSharedPreferences {
                 if (INSTANCE == null) {
                     try {
                         INSTANCE = new BraintreeSharedPreferences(createSharedPreferencesInstance(context));
-                    } catch (UnexpectedException e) {
+                    } catch (BraintreeSharedPreferencesException e) {
                         INSTANCE = new BraintreeSharedPreferences(e);
                     }
                 }
@@ -37,7 +37,7 @@ class BraintreeSharedPreferences {
         return INSTANCE;
     }
 
-    private static SharedPreferences createSharedPreferencesInstance(Context context) throws UnexpectedException {
+    private static SharedPreferences createSharedPreferencesInstance(Context context) throws BraintreeSharedPreferencesException {
         try {
             MasterKey masterKey = new MasterKey.Builder(context, BRAINTREE_KEY_ALIAS)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -51,7 +51,7 @@ class BraintreeSharedPreferences {
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             );
         } catch (Exception e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
@@ -60,76 +60,76 @@ class BraintreeSharedPreferences {
         this.createException = null;
     }
 
-    BraintreeSharedPreferences(UnexpectedException createException) {
+    BraintreeSharedPreferences(BraintreeSharedPreferencesException createException) {
         this.sharedPreferences = null;
         this.createException = createException;
     }
 
     @NonNull
-    private SharedPreferences getSharedPreferences() throws UnexpectedException {
+    private SharedPreferences getSharedPreferences() throws BraintreeSharedPreferencesException {
         if (createException != null) {
             throw createException;
         } else if (sharedPreferences == null) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE);
         }
         return sharedPreferences;
     }
 
-    String getString(String key, String fallback) throws UnexpectedException {
+    String getString(String key, String fallback) throws BraintreeSharedPreferencesException {
         try {
             return getSharedPreferences().getString(key, fallback);
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    void putString(String key, String value) throws UnexpectedException {
+    void putString(String key, String value) throws BraintreeSharedPreferencesException {
         try {
             getSharedPreferences()
                     .edit()
                     .putString(key, value)
                     .apply();
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    boolean getBoolean(String key) throws UnexpectedException {
+    boolean getBoolean(String key) throws BraintreeSharedPreferencesException {
         try {
             return getSharedPreferences().getBoolean(key, false);
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    void putBoolean(String key, boolean value) throws UnexpectedException {
+    void putBoolean(String key, boolean value) throws BraintreeSharedPreferencesException {
         try {
             getSharedPreferences()
                     .edit()
                     .putBoolean(key, value)
                     .apply();
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    boolean containsKey(String key) throws UnexpectedException {
+    boolean containsKey(String key) throws BraintreeSharedPreferencesException {
         try {
             return getSharedPreferences().contains(key);
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    long getLong(String key) throws UnexpectedException {
+    long getLong(String key) throws BraintreeSharedPreferencesException {
         try {
             return getSharedPreferences().getLong(key, 0);
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException (SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    void putStringAndLong(String stringKey, String stringValue, String longKey, long longValue) throws UnexpectedException {
+    void putStringAndLong(String stringKey, String stringValue, String longKey, long longValue) throws BraintreeSharedPreferencesException {
         try {
             getSharedPreferences()
                     .edit()
@@ -137,18 +137,18 @@ class BraintreeSharedPreferences {
                     .putLong(longKey, longValue)
                     .apply();
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException (SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    void clearSharedPreferences() throws UnexpectedException {
+    void clearSharedPreferences() throws BraintreeSharedPreferencesException {
         try {
             getSharedPreferences()
                     .edit()
                     .clear()
                     .apply();
         } catch (SecurityException e) {
-            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+            throw new BraintreeSharedPreferencesException (SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -32,7 +32,7 @@ class BraintreeSharedPreferences {
     private BraintreeSharedPreferences() {
     }
 
-    private static SharedPreferences getSharedPreferences(Context context) throws UnexpectedException {
+    static SharedPreferences getSharedPreferences(Context context) throws UnexpectedException {
         try {
             MasterKey masterKey = new MasterKey.Builder(context, BRAINTREE_KEY_ALIAS)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -3,6 +3,7 @@ package com.braintreepayments.api;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.NonNull;
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
 
@@ -17,22 +18,26 @@ class BraintreeSharedPreferences {
     private static final String BRAINTREE_KEY_ALIAS = "com.braintreepayments.api.masterkey";
     private static final String BRAINTREE_SHARED_PREFS_FILENAME = "BraintreeApi";
 
-    static BraintreeSharedPreferences getInstance() {
+    private final SharedPreferences sharedPreferences;
+    private final UnexpectedException createException;
+
+    static BraintreeSharedPreferences getInstance(Context context) {
         if (INSTANCE == null) {
             synchronized (BraintreeSharedPreferences.class) {
                 // double check that instance was not created in another thread
                 if (INSTANCE == null) {
-                    INSTANCE = new BraintreeSharedPreferences();
+                    try {
+                        INSTANCE = new BraintreeSharedPreferences(createSharedPreferencesInstance(context));
+                    } catch (UnexpectedException e) {
+                        INSTANCE = new BraintreeSharedPreferences(e);
+                    }
                 }
             }
         }
         return INSTANCE;
     }
 
-    private BraintreeSharedPreferences() {
-    }
-
-    static SharedPreferences getSharedPreferences(Context context) throws UnexpectedException {
+    private static SharedPreferences createSharedPreferencesInstance(Context context) throws UnexpectedException {
         try {
             MasterKey masterKey = new MasterKey.Builder(context, BRAINTREE_KEY_ALIAS)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -50,108 +55,100 @@ class BraintreeSharedPreferences {
         }
     }
 
-    String getString(Context context, String key, String fallback) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                return sharedPreferences.getString(key, fallback);
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
-        }
-        return fallback;
+    BraintreeSharedPreferences(SharedPreferences sharedPreferences) {
+        this.sharedPreferences = sharedPreferences;
+        this.createException = null;
     }
 
-    void putString(Context context, String key, String value) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                sharedPreferences
-                        .edit()
-                        .putString(key, value)
-                        .apply();
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
-        }
+    BraintreeSharedPreferences(UnexpectedException createException) {
+        this.sharedPreferences = null;
+        this.createException = createException;
     }
 
-    boolean getBoolean(Context context, String key) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                return sharedPreferences.getBoolean(key, false);
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
+    @NonNull
+    private SharedPreferences getSharedPreferences() throws UnexpectedException {
+        if (createException != null) {
+            throw createException;
+        } else if (sharedPreferences == null) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE);
         }
-        return false;
+        return sharedPreferences;
     }
 
-    void putBoolean(Context context, String key, boolean value) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                sharedPreferences
-                        .edit()
-                        .putBoolean(key, value)
-                        .apply();
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
+    String getString(String key, String fallback) throws UnexpectedException {
+        try {
+            return getSharedPreferences().getString(key, fallback);
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    boolean containsKey(Context context, String key) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                return sharedPreferences.contains(key);
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
-        }
-        return false;
-    }
-
-    long getLong(Context context, String key) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                return sharedPreferences.getLong(key, 0);
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
-        }
-        return 0;
-    }
-
-    void putStringAndLong(Context context, String stringKey, String stringValue, String longKey, long longValue) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                sharedPreferences
-                        .edit()
-                        .putString(stringKey, stringValue)
-                        .putLong(longKey, longValue)
-                        .apply();
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
+    void putString(String key, String value) throws UnexpectedException {
+        try {
+            getSharedPreferences()
+                    .edit()
+                    .putString(key, value)
+                    .apply();
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    void clearSharedPreferences(Context context) throws UnexpectedException {
-        SharedPreferences sharedPreferences = getSharedPreferences(context);
-        if (sharedPreferences != null) {
-            try {
-                sharedPreferences
-                        .edit()
-                        .clear()
-                        .apply();
-            } catch (SecurityException e) {
-                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
-            }
+    boolean getBoolean(String key) throws UnexpectedException {
+        try {
+            return getSharedPreferences().getBoolean(key, false);
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+        }
+    }
+
+    void putBoolean(String key, boolean value) throws UnexpectedException {
+        try {
+            getSharedPreferences()
+                    .edit()
+                    .putBoolean(key, value)
+                    .apply();
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+        }
+    }
+
+    boolean containsKey(String key) throws UnexpectedException {
+        try {
+            return getSharedPreferences().contains(key);
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+        }
+    }
+
+    long getLong(String key) throws UnexpectedException {
+        try {
+            return getSharedPreferences().getLong(key, 0);
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+        }
+    }
+
+    void putStringAndLong(String stringKey, String stringValue, String longKey, long longValue) throws UnexpectedException {
+        try {
+            getSharedPreferences()
+                    .edit()
+                    .putString(stringKey, stringValue)
+                    .putLong(longKey, longValue)
+                    .apply();
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
+        }
+    }
+
+    void clearSharedPreferences() throws UnexpectedException {
+        try {
+            getSharedPreferences()
+                    .edit()
+                    .clear()
+                    .apply();
+        } catch (SecurityException e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferences.java
@@ -10,6 +10,9 @@ import androidx.security.crypto.MasterKey;
 // bugs are fixed by Google
 class BraintreeSharedPreferences {
 
+    private static final String SHARED_PREFS_ERROR_MESSAGE =
+            "Unable to obtain a reference to encrypted shared preferences.";
+
     private static volatile BraintreeSharedPreferences INSTANCE;
     private static final String BRAINTREE_KEY_ALIAS = "com.braintreepayments.api.masterkey";
     private static final String BRAINTREE_SHARED_PREFS_FILENAME = "BraintreeApi";
@@ -29,7 +32,7 @@ class BraintreeSharedPreferences {
     private BraintreeSharedPreferences() {
     }
 
-    static SharedPreferences getSharedPreferences(Context context) {
+    private static SharedPreferences getSharedPreferences(Context context) throws UnexpectedException {
         try {
             MasterKey masterKey = new MasterKey.Builder(context, BRAINTREE_KEY_ALIAS)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -42,27 +45,24 @@ class BraintreeSharedPreferences {
                     EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             );
-        } catch (Exception ignored) {
-            // In the rare case that we are unable to obtain a reference to encrypted shared
-            // preferences, all preference update and retrieval logic will no-op
-            return null;
+        } catch (Exception e) {
+            throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
         }
     }
 
-    String getString(Context context, String key, String fallback) {
+    String getString(Context context, String key, String fallback) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
                 return sharedPreferences.getString(key, fallback);
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
-                return fallback;
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
         return fallback;
     }
 
-    void putString(Context context, String key, String value) {
+    void putString(Context context, String key, String value) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
@@ -70,25 +70,25 @@ class BraintreeSharedPreferences {
                         .edit()
                         .putString(key, value)
                         .apply();
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
     }
 
-    boolean getBoolean(Context context, String key) {
+    boolean getBoolean(Context context, String key) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
                 return sharedPreferences.getBoolean(key, false);
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
         return false;
     }
 
-    void putBoolean(Context context, String key, boolean value) {
+    void putBoolean(Context context, String key, boolean value) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
@@ -96,39 +96,37 @@ class BraintreeSharedPreferences {
                         .edit()
                         .putBoolean(key, value)
                         .apply();
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
     }
 
-    boolean containsKey(Context context, String key) {
+    boolean containsKey(Context context, String key) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
                 return sharedPreferences.contains(key);
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
-                return false;
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
         return false;
     }
 
-    long getLong(Context context, String key) {
+    long getLong(Context context, String key) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
                 return sharedPreferences.getLong(key, 0);
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
-                return 0;
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
         return 0;
     }
 
-    void putStringAndLong(Context context, String stringKey, String stringValue, String longKey, long longValue) {
+    void putStringAndLong(Context context, String stringKey, String stringValue, String longKey, long longValue) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
@@ -137,13 +135,13 @@ class BraintreeSharedPreferences {
                         .putString(stringKey, stringValue)
                         .putLong(longKey, longValue)
                         .apply();
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
     }
 
-    void clearSharedPreferences(Context context) {
+    void clearSharedPreferences(Context context) throws UnexpectedException {
         SharedPreferences sharedPreferences = getSharedPreferences(context);
         if (sharedPreferences != null) {
             try {
@@ -151,8 +149,8 @@ class BraintreeSharedPreferences {
                         .edit()
                         .clear()
                         .apply();
-            } catch (SecurityException ignored) {
-                // defensively guard against issues with shared preferences library
+            } catch (SecurityException e) {
+                throw new UnexpectedException(SHARED_PREFS_ERROR_MESSAGE, e);
             }
         }
     }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferencesException.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/BraintreeSharedPreferencesException.java
@@ -1,0 +1,15 @@
+package com.braintreepayments.api;
+
+/**
+ * Exception thrown when an error occurs while interacting with Android shared preferences.
+ */
+public class BraintreeSharedPreferencesException  extends Exception {
+
+    BraintreeSharedPreferencesException(String message) {
+        super(message);
+    }
+
+    BraintreeSharedPreferencesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/SharedUtils/src/main/java/com/braintreepayments/api/UnexpectedException.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/UnexpectedException.java
@@ -9,4 +9,8 @@ public class UnexpectedException extends Exception {
     UnexpectedException(String message) {
         super(message);
     }
+
+    UnexpectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
@@ -28,7 +28,7 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
         getSharedPreferences(context).edit().clear().commit();
         try {
             BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
         }
 
         keyguardLock = ((KeyguardManager) ApplicationProvider.getApplicationContext().getSystemService(Context.KEYGUARD_SERVICE))
@@ -46,7 +46,7 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
         getSharedPreferences(context).edit().clear().commit();
         try {
             BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
         }
 
         keyguardLock.reenableKeyguard();

--- a/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
@@ -26,7 +26,7 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
     private void init() {
         getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
 
@@ -43,7 +43,7 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
 
         getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
 

--- a/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
@@ -24,9 +24,10 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
     @SuppressWarnings("MissingPermission")
     @SuppressLint({"MissingPermission", "ApplySharedPref"})
     private void init() {
-        getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
+        Context context = ApplicationProvider.getApplicationContext();
+        getSharedPreferences(context).edit().clear().commit();
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
+            BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
 
@@ -41,9 +42,10 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
     protected void afterActivityFinished() {
         super.afterActivityFinished();
 
-        getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
+        Context context = ApplicationProvider.getApplicationContext();
+        getSharedPreferences(context).edit().clear().commit();
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
+            BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
 

--- a/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/BraintreeActivityTestRule.java
@@ -25,7 +25,10 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
     @SuppressLint({"MissingPermission", "ApplySharedPref"})
     private void init() {
         getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
-        BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+        try {
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+        } catch (UnexpectedException ignored) {
+        }
 
         keyguardLock = ((KeyguardManager) ApplicationProvider.getApplicationContext().getSystemService(Context.KEYGUARD_SERVICE))
                 .newKeyguardLock("BraintreeActivityTestRule");
@@ -39,7 +42,10 @@ public class BraintreeActivityTestRule<T extends AppCompatActivity> extends Acti
         super.afterActivityFinished();
 
         getSharedPreferences(ApplicationProvider.getApplicationContext()).edit().clear().commit();
-        BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+        try {
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences(ApplicationProvider.getApplicationContext());
+        } catch (UnexpectedException ignored) {
+        }
 
         keyguardLock.reenableKeyguard();
     }

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
@@ -40,7 +40,7 @@ public class MockConfigurationLoaderBuilder {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
-                ConfigurationLoaderCallback callback = (ConfigurationLoaderCallback) invocation.getArguments()[2];
+                ConfigurationLoaderCallback callback = (ConfigurationLoaderCallback) invocation.getArguments()[1];
                 if (configuration != null) {
                     ConfigurationLoaderResult result =
                         new ConfigurationLoaderResult(configuration, loadFromCacheError, saveToCacheError);

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
@@ -13,6 +13,8 @@ public class MockConfigurationLoaderBuilder {
 
     private Configuration configuration;
     private Exception configurationError;
+    private Exception loadFromCacheError;
+    private Exception saveToCacheError;
 
     public MockConfigurationLoaderBuilder configuration(Configuration configuration) {
         this.configuration = configuration;
@@ -24,21 +26,33 @@ public class MockConfigurationLoaderBuilder {
         return this;
     }
 
+    public MockConfigurationLoaderBuilder loadFromCacheError(Exception loadFromCacheError) {
+        this.loadFromCacheError = loadFromCacheError;
+        return this;
+    }
+
+    public MockConfigurationLoaderBuilder saveToCacheError(Exception saveToCacheError) {
+        this.saveToCacheError = saveToCacheError;
+        return this;
+    }
+
     public ConfigurationLoader build() {
         ConfigurationLoader configurationLoader = mock(ConfigurationLoader.class);
 
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
-                ConfigurationCallback callback = (ConfigurationCallback) invocation.getArguments()[2];
+                ConfigurationLoaderCallback callback = (ConfigurationLoaderCallback) invocation.getArguments()[2];
                 if (configuration != null) {
-                    callback.onResult(configuration, null);
+                    ConfigurationLoaderResult result =
+                        new ConfigurationLoaderResult(configuration, loadFromCacheError, saveToCacheError);
+                    callback.onResult(result, null);
                 } else if (configurationError != null) {
                     callback.onResult(null, configurationError);
                 }
                 return null;
             }
-        }).when(configurationLoader).loadConfiguration(any(Context.class), any(Authorization.class), any(ConfigurationCallback.class));
+        }).when(configurationLoader).loadConfiguration(any(Context.class), any(Authorization.class), any(ConfigurationLoaderCallback.class));
 
         return configurationLoader;
     }

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockConfigurationLoaderBuilder.java
@@ -1,7 +1,5 @@
 package com.braintreepayments.api;
 
-import android.content.Context;
-
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -52,7 +50,7 @@ public class MockConfigurationLoaderBuilder {
                 }
                 return null;
             }
-        }).when(configurationLoader).loadConfiguration(any(Context.class), any(Authorization.class), any(ConfigurationLoaderCallback.class));
+        }).when(configurationLoader).loadConfiguration(any(Authorization.class), any(ConfigurationLoaderCallback.class));
 
         return configurationLoader;
     }

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -24,10 +24,16 @@ public class SharedPreferencesHelper {
 
         String cacheKey = Base64.encodeToString(String.format("%s%s", configUrl, authorization.getBearer()).getBytes(), 0);
         String timestampKey = String.format("%s_timestamp", cacheKey);
-        BraintreeSharedPreferences.getInstance().putStringAndLong(context, cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
+        try {
+            BraintreeSharedPreferences.getInstance().putStringAndLong(context, cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
+        } catch (UnexpectedException ignored) {
+        }
     }
 
     public static void clearConfigurationCacheOverride(Context context) {
-        BraintreeSharedPreferences.getInstance().clearSharedPreferences(context);
+        try {
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences(context);
+        } catch (UnexpectedException ignored) {
+        }
     }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -26,14 +26,14 @@ public class SharedPreferencesHelper {
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
             BraintreeSharedPreferences.getInstance(context).putStringAndLong(cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
         }
     }
 
     public static void clearConfigurationCacheOverride(Context context) {
         try {
             BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
-        } catch (UnexpectedException ignored) {
+        } catch (BraintreeSharedPreferencesException ignored) {
         }
     }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -25,14 +25,14 @@ public class SharedPreferencesHelper {
         String cacheKey = Base64.encodeToString(String.format("%s%s", configUrl, authorization.getBearer()).getBytes(), 0);
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
-            BraintreeSharedPreferences.getInstance().putStringAndLong(context, cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
+            BraintreeSharedPreferences.getInstance().putStringAndLong(cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
         } catch (UnexpectedException ignored) {
         }
     }
 
     public static void clearConfigurationCacheOverride(Context context) {
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences(context);
+            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
     }

--- a/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/SharedPreferencesHelper.java
@@ -25,14 +25,14 @@ public class SharedPreferencesHelper {
         String cacheKey = Base64.encodeToString(String.format("%s%s", configUrl, authorization.getBearer()).getBytes(), 0);
         String timestampKey = String.format("%s_timestamp", cacheKey);
         try {
-            BraintreeSharedPreferences.getInstance().putStringAndLong(cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
+            BraintreeSharedPreferences.getInstance(context).putStringAndLong(cacheKey, configuration.toJson(), timestampKey, System.currentTimeMillis());
         } catch (UnexpectedException ignored) {
         }
     }
 
     public static void clearConfigurationCacheOverride(Context context) {
         try {
-            BraintreeSharedPreferences.getInstance().clearSharedPreferences();
+            BraintreeSharedPreferences.getInstance(context).clearSharedPreferences();
         } catch (UnexpectedException ignored) {
         }
     }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -263,6 +263,7 @@ public class VenmoClient {
                                                 listener.onVenmoSuccess(nonce);
                                             }
                                         } catch (UnexpectedException unexpectedError) {
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
                                             listener.onVenmoFailure(unexpectedError);
                                         }
                                     } else {
@@ -294,6 +295,7 @@ public class VenmoClient {
                                 }
 
                             } catch (UnexpectedException unexpectedError) {
+                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
                                 listener.onVenmoFailure(unexpectedError);
                             }
                         }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -190,8 +190,8 @@ public class VenmoClient {
                                     if (authorization != null) {
                                         try {
                                             startVenmoActivityForResult(activity, request, configuration, authorization, finalVenmoProfileId, paymentContextId);
-                                        } catch (UnexpectedException unexpectedError) {
-                                            callback.onResult(unexpectedError);
+                                        } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                            callback.onResult(sharedPrefsError);
                                         }
                                     } else {
                                         callback.onResult(authError);
@@ -215,7 +215,7 @@ public class VenmoClient {
             Authorization authorization,
             final String venmoProfileId,
             @Nullable final String paymentContextId
-    ) throws UnexpectedException {
+    ) throws BraintreeSharedPreferencesException {
         boolean isClientTokenAuth = (authorization instanceof ClientToken);
         boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
         sharedPrefsWriter.persistVenmoVaultOption(activity, shouldVault);
@@ -262,9 +262,9 @@ public class VenmoClient {
                                                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
                                                 listener.onVenmoSuccess(nonce);
                                             }
-                                        } catch (UnexpectedException unexpectedError) {
+                                        } catch (BraintreeSharedPreferencesException sharedPrefsError) {
                                             braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
-                                            listener.onVenmoFailure(unexpectedError);
+                                            listener.onVenmoFailure(sharedPrefsError);
                                         }
                                     } else {
                                         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
@@ -294,9 +294,9 @@ public class VenmoClient {
                                     listener.onVenmoSuccess(venmoAccountNonce);
                                 }
 
-                            } catch (UnexpectedException unexpectedError) {
+                            } catch (BraintreeSharedPreferencesException sharedPrefsError) {
                                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
-                                listener.onVenmoFailure(unexpectedError);
+                                listener.onVenmoFailure(sharedPrefsError);
                             }
                         }
                     } else if (authError != null) {
@@ -344,8 +344,8 @@ public class VenmoClient {
                                                 callback.onResult(nonce, null);
                                             }
 
-                                        } catch (UnexpectedException unexpectedError) {
-                                            callback.onResult(null, unexpectedError);
+                                        } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                            callback.onResult(null, sharedPrefsError);
                                         }
                                     } else {
                                         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
@@ -365,8 +365,8 @@ public class VenmoClient {
                                     VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
                                     callback.onResult(venmoAccountNonce, null);
                                 }
-                            } catch (UnexpectedException unexpectedError) {
-                                callback.onResult(null, unexpectedError);
+                            } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                callback.onResult(null, sharedPrefsError);
                             }
                         }
                     } else if (authError != null) {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -191,6 +191,7 @@ public class VenmoClient {
                                         try {
                                             startVenmoActivityForResult(activity, request, configuration, authorization, finalVenmoProfileId, paymentContextId);
                                         } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
                                             callback.onResult(sharedPrefsError);
                                         }
                                     } else {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -45,7 +45,7 @@ public class VenmoClient {
     /**
      * Create a new instance of {@link VenmoClient} from within an Activity using a {@link BraintreeClient}.
      *
-     * @param activity a {@link FragmentActivity}
+     * @param activity        a {@link FragmentActivity}
      * @param braintreeClient a {@link BraintreeClient}
      */
     public VenmoClient(@NonNull FragmentActivity activity, @NonNull BraintreeClient braintreeClient) {
@@ -55,7 +55,7 @@ public class VenmoClient {
     /**
      * Create a new instance of {@link VenmoClient} from within a Fragment using a {@link BraintreeClient}.
      *
-     * @param fragment a {@link Fragment}
+     * @param fragment        a {@link Fragment}
      * @param braintreeClient a {@link BraintreeClient}
      */
     public VenmoClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
@@ -68,7 +68,7 @@ public class VenmoClient {
 
     /**
      * Create a new instance of {@link VenmoClient} using a {@link BraintreeClient}.
-     *
+     * <p>
      * Deprecated. Use {@link VenmoClient(Fragment, BraintreeClient)} or
      * {@link VenmoClient(FragmentActivity, BraintreeClient)} instead.
      *
@@ -142,7 +142,7 @@ public class VenmoClient {
      * Start the Pay With Venmo flow. This will app switch to the Venmo app.
      * <p>
      * If the Venmo app is not available, {@link AppSwitchNotAvailableException} will be sent to {@link VenmoTokenizeAccountCallback#onResult(Exception)}
-     *
+     * <p>
      * Deprecated. Use {@link VenmoClient#tokenizeVenmoAccount(FragmentActivity, VenmoRequest)}.
      *
      * @param activity Android FragmentActivity
@@ -182,9 +182,22 @@ public class VenmoClient {
                 final String finalVenmoProfileId = venmoProfileId;
                 venmoApi.createPaymentContext(request, venmoProfileId, new VenmoApiCallback() {
                     @Override
-                    public void onResult(@Nullable String paymentContextId, @Nullable Exception exception) {
+                    public void onResult(@Nullable final String paymentContextId, @Nullable Exception exception) {
                         if (exception == null) {
-                            startVenmoActivityForResult(activity, request, configuration, finalVenmoProfileId, paymentContextId);
+                            braintreeClient.getAuthorization(new AuthorizationCallback() {
+                                @Override
+                                public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception authError) {
+                                    if (authorization != null) {
+                                        try {
+                                            startVenmoActivityForResult(activity, request, configuration, authorization, finalVenmoProfileId, paymentContextId);
+                                        } catch (UnexpectedException unexpectedError) {
+                                            callback.onResult(unexpectedError);
+                                        }
+                                    } else {
+                                        callback.onResult(authError);
+                                    }
+                                }
+                            });
                         } else {
                             callback.onResult(exception);
                             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
@@ -195,25 +208,25 @@ public class VenmoClient {
         });
     }
 
-    private void startVenmoActivityForResult(final FragmentActivity activity, final VenmoRequest request, final Configuration configuration, final String venmoProfileId, @Nullable final String paymentContextId) {
-        braintreeClient.getAuthorization(new AuthorizationCallback() {
-            @Override
-            public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error) {
-                if (authorization != null) {
-                    boolean isClientTokenAuth = (authorization instanceof ClientToken);
-                    boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
-                    sharedPrefsWriter.persistVenmoVaultOption(activity, shouldVault);
-                    if (observer != null) {
-                        VenmoIntentData intentData = new VenmoIntentData(configuration, venmoProfileId, paymentContextId, braintreeClient.getSessionId(), braintreeClient.getIntegrationType());
-                        observer.launch(intentData);
-                    } else {
-                        Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
-                        activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
-                    }
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
-                }
-            }
-        });
+    private void startVenmoActivityForResult(
+            final FragmentActivity activity,
+            final VenmoRequest request,
+            final Configuration configuration,
+            Authorization authorization,
+            final String venmoProfileId,
+            @Nullable final String paymentContextId
+    ) throws UnexpectedException {
+        boolean isClientTokenAuth = (authorization instanceof ClientToken);
+        boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
+        sharedPrefsWriter.persistVenmoVaultOption(activity, shouldVault);
+        if (observer != null) {
+            VenmoIntentData intentData = new VenmoIntentData(configuration, venmoProfileId, paymentContextId, braintreeClient.getSessionId(), braintreeClient.getIntegrationType());
+            observer.launch(intentData);
+        } else {
+            Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
+            activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
+        }
+        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
     }
 
     void onVenmoResult(final VenmoResult venmoResult) {
@@ -222,7 +235,7 @@ public class VenmoClient {
 
             braintreeClient.getAuthorization(new AuthorizationCallback() {
                 @Override
-                public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception authError) {
+                public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable final Exception authError) {
                     if (authorization != null) {
                         final boolean isClientTokenAuth = (authorization instanceof ClientToken);
 
@@ -232,21 +245,25 @@ public class VenmoClient {
                                 @Override
                                 public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
                                     if (nonce != null) {
-                                        boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
-                                        if (shouldVault && isClientTokenAuth) {
-                                            vaultVenmoAccountNonce(nonce.getString(), new VenmoOnActivityResultCallback() {
-                                                @Override
-                                                public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
-                                                    if (venmoAccountNonce != null) {
-                                                        listener.onVenmoSuccess(venmoAccountNonce);
-                                                    } else if (error != null) {
-                                                        listener.onVenmoFailure(error);
+                                        try {
+                                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
+                                            if (shouldVault && isClientTokenAuth) {
+                                                vaultVenmoAccountNonce(nonce.getString(), new VenmoOnActivityResultCallback() {
+                                                    @Override
+                                                    public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
+                                                        if (venmoAccountNonce != null) {
+                                                            listener.onVenmoSuccess(venmoAccountNonce);
+                                                        } else if (error != null) {
+                                                            listener.onVenmoFailure(error);
+                                                        }
                                                     }
-                                                }
-                                            });
-                                        } else {
-                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                            listener.onVenmoSuccess(nonce);
+                                                });
+                                            } else {
+                                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
+                                                listener.onVenmoSuccess(nonce);
+                                            }
+                                        } catch (UnexpectedException unexpectedError) {
+                                            listener.onVenmoFailure(unexpectedError);
                                         }
                                     } else {
                                         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
@@ -257,22 +274,27 @@ public class VenmoClient {
                         } else {
                             String nonce = venmoResult.getVenmoAccountNonce();
 
-                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
-                            if (shouldVault && isClientTokenAuth) {
-                                vaultVenmoAccountNonce(nonce, new VenmoOnActivityResultCallback() {
-                                    @Override
-                                    public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
-                                        if (venmoAccountNonce != null) {
-                                            listener.onVenmoSuccess(venmoAccountNonce);
-                                        } else if (error != null) {
-                                            listener.onVenmoFailure(error);
+                            try {
+                                boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
+                                if (shouldVault && isClientTokenAuth) {
+                                    vaultVenmoAccountNonce(nonce, new VenmoOnActivityResultCallback() {
+                                        @Override
+                                        public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
+                                            if (venmoAccountNonce != null) {
+                                                listener.onVenmoSuccess(venmoAccountNonce);
+                                            } else if (error != null) {
+                                                listener.onVenmoFailure(error);
+                                            }
                                         }
-                                    }
-                                });
-                            } else {
-                                String venmoUsername = venmoResult.getVenmoUsername();
-                                VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
-                                listener.onVenmoSuccess(venmoAccountNonce);
+                                    });
+                                } else {
+                                    String venmoUsername = venmoResult.getVenmoUsername();
+                                    VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
+                                    listener.onVenmoSuccess(venmoAccountNonce);
+                                }
+
+                            } catch (UnexpectedException unexpectedError) {
+                                listener.onVenmoFailure(unexpectedError);
                             }
                         }
                     } else if (authError != null) {
@@ -310,7 +332,8 @@ public class VenmoClient {
                             venmoApi.createNonceFromPaymentContext(paymentContextId, new VenmoOnActivityResultCallback() {
                                 @Override
                                 public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
-                                        if (nonce != null) {
+                                    if (nonce != null) {
+                                        try {
                                             boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
                                             if (shouldVault && isClientTokenAuth) {
                                                 vaultVenmoAccountNonce(nonce.getString(), callback);
@@ -318,22 +341,30 @@ public class VenmoClient {
                                                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
                                                 callback.onResult(nonce, null);
                                             }
-                                        } else {
-                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                            callback.onResult(null, error);
+
+                                        } catch (UnexpectedException unexpectedError) {
+                                            callback.onResult(null, unexpectedError);
                                         }
+                                    } else {
+                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
+                                        callback.onResult(null, error);
+                                    }
                                 }
                             });
                         } else {
                             String nonce = data.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
 
-                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                            if (shouldVault && isClientTokenAuth) {
-                                vaultVenmoAccountNonce(nonce, callback);
-                            } else {
-                                String venmoUsername = data.getStringExtra(EXTRA_USERNAME);
-                                VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
-                                callback.onResult(venmoAccountNonce, null);
+                            try {
+                                boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
+                                if (shouldVault && isClientTokenAuth) {
+                                    vaultVenmoAccountNonce(nonce, callback);
+                                } else {
+                                    String venmoUsername = data.getStringExtra(EXTRA_USERNAME);
+                                    VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
+                                    callback.onResult(venmoAccountNonce, null);
+                                }
+                            } catch (UnexpectedException unexpectedError) {
+                                callback.onResult(null, unexpectedError);
                             }
                         }
                     } else if (authError != null) {
@@ -409,7 +440,7 @@ public class VenmoClient {
      * {@code true}, show the Venmo button. When it is called with {@code false}, display other
      * checkout options.
      *
-     * @param context Android Context
+     * @param context  Android Context
      * @param callback {@link VenmoIsReadyToPayCallback}
      */
     public void isReadyToPay(final Context context, final VenmoIsReadyToPayCallback callback) {
@@ -418,7 +449,7 @@ public class VenmoClient {
             public void onResult(@Nullable Configuration configuration, @Nullable Exception configError) {
                 if (configuration != null) {
                     boolean result =
-                        configuration.isVenmoEnabled() && isVenmoAppSwitchAvailable(context);
+                            configuration.isVenmoEnabled() && isVenmoAppSwitchAvailable(context);
                     callback.onResult(result, null);
                 } else {
                     callback.onResult(false, configError);

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -346,6 +346,7 @@ public class VenmoClient {
                                             }
 
                                         } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
                                             callback.onResult(null, sharedPrefsError);
                                         }
                                     } else {
@@ -367,6 +368,7 @@ public class VenmoClient {
                                     callback.onResult(venmoAccountNonce, null);
                                 }
                             } catch (BraintreeSharedPreferencesException sharedPrefsError) {
+                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.shared-prefs.failure");
                                 callback.onResult(null, sharedPrefsError);
                             }
                         }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -8,22 +8,21 @@ class VenmoSharedPrefsWriter {
 
     private static final String VAULT_VENMO_KEY = "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY";
 
-    private final BraintreeSharedPreferences braintreeSharedPreferences;
-
-    VenmoSharedPrefsWriter() {
-        this(BraintreeSharedPreferences.getInstance());
+    void persistVenmoVaultOption(Context context, boolean shouldVault) throws UnexpectedException {
+        persistVenmoVaultOption(BraintreeSharedPreferences.getInstance(context), shouldVault);
     }
 
     @VisibleForTesting
-    VenmoSharedPrefsWriter(BraintreeSharedPreferences braintreeSharedPreferences) {
-        this.braintreeSharedPreferences = braintreeSharedPreferences;
-    }
-
-    void persistVenmoVaultOption(Context context, boolean shouldVault) throws UnexpectedException {
+    void persistVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences, boolean shouldVault) throws UnexpectedException {
         braintreeSharedPreferences.putBoolean(VAULT_VENMO_KEY, shouldVault);
     }
 
     boolean getVenmoVaultOption(Context context) throws UnexpectedException {
+        return getVenmoVaultOption(BraintreeSharedPreferences.getInstance(context));
+    }
+
+    @VisibleForTesting
+    boolean getVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences) throws UnexpectedException {
         return braintreeSharedPreferences.getBoolean(VAULT_VENMO_KEY);
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -20,10 +20,10 @@ class VenmoSharedPrefsWriter {
     }
 
     void persistVenmoVaultOption(Context context, boolean shouldVault) throws UnexpectedException {
-        braintreeSharedPreferences.putBoolean(context, VAULT_VENMO_KEY, shouldVault);
+        braintreeSharedPreferences.putBoolean(VAULT_VENMO_KEY, shouldVault);
     }
 
     boolean getVenmoVaultOption(Context context) throws UnexpectedException {
-        return braintreeSharedPreferences.getBoolean(context, VAULT_VENMO_KEY);
+        return braintreeSharedPreferences.getBoolean(VAULT_VENMO_KEY);
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -8,21 +8,21 @@ class VenmoSharedPrefsWriter {
 
     private static final String VAULT_VENMO_KEY = "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY";
 
-    void persistVenmoVaultOption(Context context, boolean shouldVault) throws UnexpectedException {
+    void persistVenmoVaultOption(Context context, boolean shouldVault) throws BraintreeSharedPreferencesException {
         persistVenmoVaultOption(BraintreeSharedPreferences.getInstance(context), shouldVault);
     }
 
     @VisibleForTesting
-    void persistVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences, boolean shouldVault) throws UnexpectedException {
+    void persistVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences, boolean shouldVault) throws BraintreeSharedPreferencesException {
         braintreeSharedPreferences.putBoolean(VAULT_VENMO_KEY, shouldVault);
     }
 
-    boolean getVenmoVaultOption(Context context) throws UnexpectedException {
+    boolean getVenmoVaultOption(Context context) throws BraintreeSharedPreferencesException {
         return getVenmoVaultOption(BraintreeSharedPreferences.getInstance(context));
     }
 
     @VisibleForTesting
-    boolean getVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences) throws UnexpectedException {
+    boolean getVenmoVaultOption(BraintreeSharedPreferences braintreeSharedPreferences) throws BraintreeSharedPreferencesException {
         return braintreeSharedPreferences.getBoolean(VAULT_VENMO_KEY);
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoSharedPrefsWriter.java
@@ -19,11 +19,11 @@ class VenmoSharedPrefsWriter {
         this.braintreeSharedPreferences = braintreeSharedPreferences;
     }
 
-    void persistVenmoVaultOption(Context context, boolean shouldVault) {
+    void persistVenmoVaultOption(Context context, boolean shouldVault) throws UnexpectedException {
         braintreeSharedPreferences.putBoolean(context, VAULT_VENMO_KEY, shouldVault);
     }
 
-    boolean getVenmoVaultOption(Context context) {
+    boolean getVenmoVaultOption(Context context) throws UnexpectedException {
         return braintreeSharedPreferences.getBoolean(context, VAULT_VENMO_KEY);
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -157,7 +157,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() throws JSONException {
+    public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -489,7 +489,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
+    public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -512,7 +512,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsTrue_persistsVaultVenmoOption() {
+    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsTrue_persistsVaultVenmoOption() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -538,7 +538,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
+    public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -561,7 +561,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
+    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -587,7 +587,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withTokenizationKey_persistsVenmoVaultFalse() {
+    public void tokenizeVenmoAccount_withTokenizationKey_persistsVenmoVaultFalse() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -611,7 +611,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_withTokenizationKey_persistsVenmoVaultFalse() {
+    public void tokenizeVenmoAccount_withObserver_withTokenizationKey_persistsVenmoVaultFalse() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -758,7 +758,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_performsVaultRequestIfRequestPersisted() {
+    public void onActivityResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -841,7 +841,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_performsVaultRequestIfRequestPersisted() {
+    public void onActivityResult_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -870,7 +870,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() {
+    public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
                 .authorizationSuccess(tokenizationKey)
@@ -886,7 +886,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() {
+    public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -910,7 +910,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException {
+    public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -938,7 +938,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException {
+    public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -963,7 +963,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() {
+    public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -988,7 +988,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException {
+    public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1017,7 +1017,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() {
+    public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1168,7 +1168,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_performsVaultRequestIfRequestPersisted() {
+    public void onVenmoResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -1250,7 +1250,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_performsVaultRequestIfRequestPersisted() throws JSONException {
+    public void onVenmoResult_performsVaultRequestIfRequestPersisted() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -1279,7 +1279,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_doesNotPerformRequestIfTokenizationKeyUsed() {
+    public void onVenmoResult_doesNotPerformRequestIfTokenizationKeyUsed() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
                 .authorizationSuccess(tokenizationKey)
@@ -1298,7 +1298,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() {
+    public void onVenmoResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1325,7 +1325,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException {
+    public void onVenmoResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1354,7 +1354,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() {
+    public void onVenmoResult_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() throws UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1381,7 +1381,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException {
+    public void onVenmoResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -440,30 +440,11 @@ public class VenmoClientUnitTest {
         request.setShouldVault(false);
 
         VenmoClient sut = new VenmoClient(null, null, braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
+        sut.setListener(listener);
         sut.tokenizeVenmoAccount(activity, request);
 
-        InOrder inOrder = Mockito.inOrder(activity, braintreeClient);
-
-        ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
-        inOrder.verify(activity).startActivityForResult(captor.capture(), eq(BraintreeRequestCodes.VENMO));
-
-        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
-
-        Intent intent = captor.getValue();
-        assertEquals(new ComponentName("com.venmo", "com.venmo.controller.SetupMerchantActivity"), intent.getComponent());
-        assertEquals("sample-venmo-merchant", intent.getStringExtra(EXTRA_MERCHANT_ID));
-        assertEquals("access-token", intent.getStringExtra(EXTRA_ACCESS_TOKEN));
-        assertEquals("environment", intent.getStringExtra(EXTRA_ENVIRONMENT));
-        assertEquals("venmo-payment-context-id", intent.getStringExtra(EXTRA_RESOURCE_ID));
-
-        JSONObject expectedBraintreeData = new JSONObject()
-                .put("_meta", new JSONObject()
-                        .put("platform", "android")
-                        .put("sessionId", "session-id")
-                        .put("integration", "custom")
-                        .put("version", BuildConfig.VERSION_NAME)
-                );
-        JSONAssert.assertEquals(expectedBraintreeData, new JSONObject(intent.getStringExtra(EXTRA_BRAINTREE_DATA)), JSONCompareMode.STRICT);
+        verify(listener).onVenmoFailure(sharedPrefsError);
+        verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.shared-prefs.failure"));
     }
 
     @Test

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -157,7 +157,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() throws JSONException, UnexpectedException {
+    public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -489,7 +489,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() throws UnexpectedException {
+    public void tokenizeVenmoAccount_whenShouldVaultIsTrue_persistsVenmoVaultTrue() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -512,7 +512,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsTrue_persistsVaultVenmoOption() throws UnexpectedException {
+    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsTrue_persistsVaultVenmoOption() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -538,7 +538,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws UnexpectedException {
+    public void tokenizeVenmoAccount_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -561,7 +561,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws UnexpectedException {
+    public void tokenizeVenmoAccount_withObserver_whenShouldVaultIsFalse_persistsVenmoVaultFalse() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -587,7 +587,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withTokenizationKey_persistsVenmoVaultFalse() throws UnexpectedException {
+    public void tokenizeVenmoAccount_withTokenizationKey_persistsVenmoVaultFalse() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -611,7 +611,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withObserver_withTokenizationKey_persistsVenmoVaultFalse() throws UnexpectedException {
+    public void tokenizeVenmoAccount_withObserver_withTokenizationKey_persistsVenmoVaultFalse() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -758,7 +758,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
+    public void onActivityResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -841,7 +841,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
+    public void onActivityResult_performsVaultRequestIfRequestPersisted() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -870,7 +870,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() throws UnexpectedException {
+    public void onActivityResult_doesNotPerformRequestIfTokenizationKeyUsed() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
                 .authorizationSuccess(tokenizationKey)
@@ -886,7 +886,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws UnexpectedException {
+    public void onActivityResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -910,7 +910,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
+    public void onActivityResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -938,7 +938,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException, UnexpectedException {
+    public void onActivityResult_withSuccessfulVaultCall_sendsAnalyticsEvent() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -963,7 +963,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() throws UnexpectedException {
+    public void onActivityResult_withFailedVaultCall_forwardsErrorToActivityResultListener() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -988,7 +988,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
+    public void onActivityResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1017,7 +1017,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() throws UnexpectedException {
+    public void onActivityResult_withFailedVaultCall_sendsAnalyticsEvent() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1168,7 +1168,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws UnexpectedException {
+    public void onVenmoResult_withPaymentContext_performsVaultRequestIfRequestPersisted() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -1250,7 +1250,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_performsVaultRequestIfRequestPersisted() throws JSONException, UnexpectedException {
+    public void onVenmoResult_performsVaultRequestIfRequestPersisted() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -1279,7 +1279,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_doesNotPerformRequestIfTokenizationKeyUsed() throws UnexpectedException {
+    public void onVenmoResult_doesNotPerformRequestIfTokenizationKeyUsed() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
                 .authorizationSuccess(tokenizationKey)
@@ -1298,7 +1298,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() throws UnexpectedException {
+    public void onVenmoResult_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1325,7 +1325,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
+    public void onVenmoResult_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1354,7 +1354,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() throws UnexpectedException {
+    public void onVenmoResult_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() throws BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -1381,7 +1381,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void onVenmoResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, UnexpectedException {
+    public void onVenmoResult_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() throws JSONException, BraintreeSharedPreferencesException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
@@ -3,33 +3,29 @@ package com.braintreepayments.api;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import android.content.Context;
-
 import org.junit.Before;
 import org.junit.Test;
 
 public class VenmoSharedPrefsWriterUnitTest {
 
-    private Context context;
     private BraintreeSharedPreferences braintreeSharedPreferences;
 
     @Before
     public void beforeEach() {
-        context = mock(Context.class);
         braintreeSharedPreferences = mock(BraintreeSharedPreferences.class);
     }
 
     @Test
     public void persistVenmoVaultOption_persistsVaultOption() throws UnexpectedException {
-        VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
-        sut.persistVenmoVaultOption(context, true);
+        VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
+        sut.persistVenmoVaultOption(braintreeSharedPreferences, true);
         verify(braintreeSharedPreferences).putBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", true);
     }
 
     @Test
     public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() throws UnexpectedException {
-        VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
-        sut.getVenmoVaultOption(context);
+        VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
+        sut.getVenmoVaultOption(braintreeSharedPreferences);
         verify(braintreeSharedPreferences).getBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY");
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
@@ -8,9 +8,6 @@ import android.content.Context;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
 public class VenmoSharedPrefsWriterUnitTest {
 
     private Context context;
@@ -26,13 +23,13 @@ public class VenmoSharedPrefsWriterUnitTest {
     public void persistVenmoVaultOption_persistsVaultOption() throws UnexpectedException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
         sut.persistVenmoVaultOption(context, true);
-        verify(braintreeSharedPreferences).putBoolean(context, "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", true);
+        verify(braintreeSharedPreferences).putBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", true);
     }
 
     @Test
     public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() throws UnexpectedException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
         sut.getVenmoVaultOption(context);
-        verify(braintreeSharedPreferences).getBoolean(context, "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY");
+        verify(braintreeSharedPreferences).getBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY");
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
@@ -16,14 +16,14 @@ public class VenmoSharedPrefsWriterUnitTest {
     }
 
     @Test
-    public void persistVenmoVaultOption_persistsVaultOption() throws UnexpectedException {
+    public void persistVenmoVaultOption_persistsVaultOption() throws BraintreeSharedPreferencesException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
         sut.persistVenmoVaultOption(braintreeSharedPreferences, true);
         verify(braintreeSharedPreferences).putBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", true);
     }
 
     @Test
-    public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() throws UnexpectedException {
+    public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() throws BraintreeSharedPreferencesException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter();
         sut.getVenmoVaultOption(braintreeSharedPreferences);
         verify(braintreeSharedPreferences).getBoolean("com.braintreepayments.api.Venmo.VAULT_VENMO_KEY");

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoSharedPrefsWriterUnitTest.java
@@ -17,20 +17,20 @@ public class VenmoSharedPrefsWriterUnitTest {
     private BraintreeSharedPreferences braintreeSharedPreferences;
 
     @Before
-    public void beforeEach() throws GeneralSecurityException, IOException {
+    public void beforeEach() {
         context = mock(Context.class);
         braintreeSharedPreferences = mock(BraintreeSharedPreferences.class);
     }
 
     @Test
-    public void persistVenmoVaultOption_persistsVaultOption() {
+    public void persistVenmoVaultOption_persistsVaultOption() throws UnexpectedException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
         sut.persistVenmoVaultOption(context, true);
         verify(braintreeSharedPreferences).putBoolean(context, "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY", true);
     }
 
     @Test
-    public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() {
+    public void getVenmoVaultOption_retrievesVaultOptionFromSharedPrefs() throws UnexpectedException {
         VenmoSharedPrefsWriter sut = new VenmoSharedPrefsWriter(braintreeSharedPreferences);
         sut.getVenmoVaultOption(context);
         verify(braintreeSharedPreferences).getBoolean(context, "com.braintreepayments.api.Venmo.VAULT_VENMO_KEY");

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
+        jcenter()
     }
 
     ext.versions = [
@@ -96,8 +97,8 @@ allprojects {
             dirs "${rootDir}/libs"
         }
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         google()
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
             // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError
-            "room"           : "2.4.0",
+            "room"           : "2.2.6",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "19.1.0"
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ allprojects {
         }
         google()
         mavenCentral()
-        jcenter()
     }
 }
 
@@ -128,6 +127,7 @@ subprojects {
                 password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
+        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,11 +93,8 @@ ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
 
 allprojects {
     repositories {
-        flatDir {
-            dirs "${rootDir}/libs"
-        }
-        google()
         mavenCentral()
+        google()
     }
 }
 
@@ -126,6 +123,9 @@ subprojects {
                 username 'braintree_team_sdk'
                 password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
+        }
+        flatDir {
+            dirs "${rootDir}/libs"
         }
         jcenter()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
             // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError
-            "room"           : "2.2.6",
+            "room"           : "2.4.0",
             // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
             "playServices"   : "19.1.0"
     ]


### PR DESCRIPTION
### Summary of changes

 - Allow `BraintreeSharedPreferences` to gracefully degrade when `EncryptedSharedPreferences` fails (fix for #619)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
