### PR TITLE
Adding risk correlation id from NXO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+
+## unreleased
+* PayPalNativeCheckout (BETA)
+  * Adding in risk correlation id from the checkout sdk if it is not provided in the initial request
+  
 ## 4.20.0
 
 * SharedUtils

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation deps.appCompat
     implementation project(':PayPalDataCollector')
 
-    implementation('com.paypal.checkout:android-sdk:0.8.2') {
+    implementation('com.paypal.checkout:android-sdk:0.8.6') {
         exclude group: 'com.paypal.android.sdk', module: 'data-collector'
     }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccount.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccount.java
@@ -23,6 +23,7 @@ class PayPalNativeCheckoutAccount extends PaymentMethod {
     private JSONObject client;
     private String merchantAccountId;
     private String paymentType;
+    private String intent;
 
     PayPalNativeCheckoutAccount() {
         super();
@@ -34,6 +35,7 @@ class PayPalNativeCheckoutAccount extends PaymentMethod {
 
         JSONObject paymentMethodNonceJson = new JSONObject();
         paymentMethodNonceJson.put(CORRELATION_ID_KEY, clientMetadataId);
+        paymentMethodNonceJson.put(INTENT_KEY, intent);
         paymentMethodNonceJson.put(CLIENT_KEY, client);
 
         if ("single-payment".equalsIgnoreCase(paymentType)) {
@@ -105,6 +107,16 @@ class PayPalNativeCheckoutAccount extends PaymentMethod {
     void setPaymentType(String paymentType) {
         this.paymentType = paymentType;
     }
+
+    /**
+     * Used by PayPal wrappers to construct a request to create a PayPal account.
+     *
+     * @param intent The intent provided by the checkout session
+     */
+    void setIntent(String intent) {
+        this.intent = intent;
+    }
+
 
     @Override
     String getApiPath() {

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -214,7 +214,7 @@ public class PayPalNativeCheckoutClient {
         PayPalCheckout.registerCallbacks(
                 approval -> {
                     braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.started");
-                    PayPalNativeCheckoutAccount payPalAccount = setupAccount(configuration, payPalRequest, payPalResponse, approval.getData());
+                    PayPalNativeCheckoutAccount payPalAccount = setupAccount(payPalRequest, approval.getData());
                     internalPayPalClient.tokenize(payPalAccount, (payPalAccountNonce, error) -> {
                         if (payPalAccountNonce != null) {
                             braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.succeeded");
@@ -238,18 +238,25 @@ public class PayPalNativeCheckoutClient {
     }
 
     private PayPalNativeCheckoutAccount setupAccount(
-            final Configuration configuration,
-            final PayPalNativeRequest payPalRequest,
-            final PayPalNativeCheckoutResponse payPalResponse,
-            final ApprovalData approvalData
+        final PayPalNativeRequest payPalRequest,
+        final ApprovalData approvalData
     ) {
         PayPalNativeCheckoutAccount payPalAccount = new PayPalNativeCheckoutAccount();
 
         String merchantAccountId = payPalRequest.getMerchantAccountId();
         String paymentType = payPalRequest instanceof PayPalNativeCheckoutVaultRequest ? "billing-agreement" : "single-payment";
-        payPalAccount.setClientMetadataId(configuration.getPayPalClientId());
+        String riskId;
+        if (payPalRequest.getRiskCorrelationId() != null) {
+            riskId = payPalRequest.getRiskCorrelationId();
+        } else {
+            riskId = approvalData.getCorrelationIds().getRiskCorrelationId().getId;
+        }
+        payPalAccount.setClientMetadataId(riskId);
         payPalAccount.setSource("paypal-browser");
         payPalAccount.setPaymentType(paymentType);
+        if (approvalData.getCart() != null) {
+            payPalAccount.setIntent(approvalData.getCart().getIntent());
+        }
 
         try {
             JSONObject client = new JSONObject();


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Adding in the risk correlation id from the nxo payload if a supplied correlation is not supplied through the initial request
 - Bumping native version that adds the correlation id to the payload

<img width="969" alt="Screen Shot 2022-11-03 at 10 42 56 AM" src="https://user-images.githubusercontent.com/109249624/200956260-24c1aad1-030f-4132-af7d-7c7cd177e364.png">


 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
