### PR TITLE
Bumping native version for cardinal fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Braintree Android SDK Release Notes
 
+
+## unreleased
+
+* PayPalNativeCheckout (BETA)
+  * Updating the native version to bump the cardinal version to `2.2.7-2` for native checkout
+
 ## 4.21.1
 
 * PayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## unreleased
 
 * PayPalNativeCheckout (BETA)
-  * Updating the native version to bump the cardinal version to `2.2.7-2` for native checkout
+  * Bump native-checkout version to `0.8.7`
 
 ## 4.21.1
 

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation deps.appCompat
     implementation project(':PayPalDataCollector')
 
-    implementation('com.paypal.checkout:android-sdk:0.8.6') {
+    implementation('com.paypal.checkout:android-sdk:0.8.7') {
         exclude group: 'com.paypal.android.sdk', module: 'data-collector'
     }
 


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
 - We need to bump the native version cause its pointing to the old cardinal dependency that is notifying google of an outdated version
 
 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
