### PR TITLE
Bump Browser Switch to 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+# unreleased
+
+* BraintreeCore
+  * Bump `browser-switch` version to `2.3.2`
 
 ## 4.22.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
             // kotlin libraries. Make sure to keep this dependency in line with the kotlin version used.
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
-            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.1",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.2",
             "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-2",
             "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",


### PR DESCRIPTION
### Summary of changes

* BraintreeCore
  * Bump `browser-switch` version to `2.3.2`

 ### Checklist

 - [x] Added a changelog entry