### PR TITLE
ThreeDSecureActivity Null Pointer Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ThreeDSecure
+  * Defensively guard against `ThreeDSecureActivity` launch without extras (fixes #641)
+
 ## 4.23.0
 
 * BraintreeCore

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
@@ -36,7 +36,9 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
         }
 
         ThreeDSecureResult threeDSecureResult = extras.getParcelable(EXTRA_THREE_D_SECURE_RESULT);
-        cardinalClient.continueLookup(this, threeDSecureResult, this);
+        if (threeDSecureResult != null) {
+            cardinalClient.continueLookup(this, threeDSecureResult, this);
+        }
     }
 
     @Override

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
@@ -38,6 +38,9 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
         ThreeDSecureResult threeDSecureResult = extras.getParcelable(EXTRA_THREE_D_SECURE_RESULT);
         if (threeDSecureResult != null) {
             cardinalClient.continueLookup(this, threeDSecureResult, this);
+        } else {
+            setResult(RESULT_CANCELED);
+            finish();
         }
     }
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
@@ -15,9 +15,11 @@ import org.robolectric.RobolectricTestRunner;
 import static android.app.Activity.RESULT_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,7 +28,7 @@ import static org.mockito.Mockito.when;
 public class ThreeDSecureActivityUnitTest {
 
     @Test
-    public void onCreate_invokesCardinalWithLookupData() throws JSONException {
+    public void onCreate_withExtras_invokesCardinalWithLookupData() throws JSONException {
         ThreeDSecureResult threeDSecureResult =
             ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE);
 
@@ -49,6 +51,18 @@ public class ThreeDSecureActivityUnitTest {
         ThreeDSecureLookup actualLookup = actualResult.getLookup();
         assertEquals("sample-transaction-id", actualLookup.getTransactionId());
         assertEquals("sample-pareq", actualLookup.getPareq());
+    }
+
+    @Test
+    public void onCreate_withoutExtras_doesNothing() {
+        Intent intent = new Intent();
+        ThreeDSecureActivity sut = new ThreeDSecureActivity();
+        sut.setIntent(intent);
+
+        CardinalClient cardinalClient = mock(CardinalClient.class);
+        sut.onCreateInternal(cardinalClient);
+
+        verify(cardinalClient, never()).continueLookup(any(), any(), any());
     }
 
     @Test

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 
+import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -54,15 +55,17 @@ public class ThreeDSecureActivityUnitTest {
     }
 
     @Test
-    public void onCreate_withoutExtras_doesNothing() {
+    public void onCreate_withoutExtras_finishesWithError() {
         Intent intent = new Intent();
-        ThreeDSecureActivity sut = new ThreeDSecureActivity();
+        ThreeDSecureActivity sut = spy(new ThreeDSecureActivity());
         sut.setIntent(intent);
 
         CardinalClient cardinalClient = mock(CardinalClient.class);
         sut.onCreateInternal(cardinalClient);
 
         verify(cardinalClient, never()).continueLookup(any(), any(), any());
+        verify(sut).finish();
+        verify(sut).setResult(RESULT_CANCELED);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

- Defensively guard against `ThreeDSecureActivity` launch without extras (fixes #641)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
