### PR TITLE
M1 Mac Build Script Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError
     def m1MacSafeRoomVersion = "2.4.0"
 
-    // The 'CI' build variable will equal 'true' when build script is executed via GitHub Actions
+    // The 'CI' build variable will evaluate to 'true' when build script is executed via GitHub Actions
     // Ref: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
     def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         jcenter()
     }
 
-    // We are restricted to version 2.2.6 since we still offer Java 7 support. Upgrading to newer
-    // versions of room that require Java 8 will introduce a breaking change to our SDK
+    // We are restricted to room version 2.2.6 since we still offer Java 7 support. Upgrading to
+    // newer versions of room that require Java 8 will introduce a breaking change to our SDK
     def java7SafeRoomVersion = "2.2.6"
 
     // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,24 @@ buildscript {
         jcenter()
     }
 
+    // We are restricted to version 2.2.6 since we still offer Java 7 support. Upgrading to newer
+    // versions of room that require Java 8 will introduce a breaking change to our SDK
+    def java7SafeRoomVersion = "2.2.6"
+
+    // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError
+    def m1MacSafeRoomVersion = "2.4.0"
+
+    // The 'CI' build variable will equal 'true' when build script is executed via GitHub Actions
+    // Ref: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+    def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
+
     ext.versions = [
             "kotlin"         : "1.5.32",
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",
-            // On M1 Macs, switch room version to 2.4.0 to fix java.lang.ExceptionInInitializerError
-            "room"           : "2.2.6",
-            // Version 19.0.0 of play-services-wallet has been released but should not be used per Google documentation
+            // NEXT MAJOR VERSION: Use a single up-to-date room version once we remove Java 7 support in favor of Java 11
+            "room"           : roomVersion,
             "playServices"   : "19.1.0"
     ]
 


### PR DESCRIPTION
### Summary of changes

 - Update build script to update Jetpack Room dependency to an M1 Mac friendly variant
 - Fallback to Java 7 friendly Room version during CI build

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
