### PR TITLE
Generate Documentation With Dokka

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,7 @@ jobs:
           ./gradlew -PversionParam=${{ github.event.inputs.version }} changeREADMEVersion
           ./gradlew -PversionParam=${{ github.event.inputs.version }} changeMigrationGuideVersion
           ./gradlew -PversionParam=${{ github.event.inputs.version }} updateCHANGELOGVersion
+          ./gradlew dokkaHtmlMultiModule
           git commit -am 'Release ${{ github.event.inputs.version }}'
           git tag ${{ github.event.inputs.version }} -a -m 'Release ${{ github.event.inputs.version }}'
 

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -49,17 +49,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -88,7 +77,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'american-express'

--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.library'
-    id 'de.marcphilipp.nexus-publish'
     id 'kotlin-android'
-    id 'signing'
     id 'org.jetbrains.dokka'
+    id 'de.marcphilipp.nexus-publish'
+    id 'signing'
 }
 
 def DEVELOPMENT_URL = System.properties['DEVELOPMENT_URL'] ?: '"http://10.0.2.2:3000/"';

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -106,22 +106,6 @@ gradle.taskGraph.whenReady { taskGraph ->
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-
-    // Used to exclude docstrings from public site
-    exclude "com/braintreepayments/api/PreferredPaymentMethods.java"
-    exclude "com/braintreepayments/api/models/PreferredPaymentMethodsResult.java"
-    exclude "com/braintreepayments/api/interfaces/PreferredPaymentMethodsListener.java"
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -150,7 +134,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'braintree-core'

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'kotlin-android'
-    id 'org.jetbrains.dokka'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 def DEVELOPMENT_URL = System.properties['DEVELOPMENT_URL'] ?: '"http://10.0.2.2:3000/"';
@@ -85,14 +85,6 @@ dependencies {
     testImplementation project(':TestUtils')
     testImplementation project(':UnionPay')
     testImplementation project(':Venmo')
-}
-
-dokkaHtml.configure {
-    dokkaSourceSets {
-        named('main') {
-            noAndroidSdkLink.set(false)
-        }
-    }
 }
 
 android.buildTypes.each { type ->

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'signing'
 }
 
@@ -84,6 +85,14 @@ dependencies {
     testImplementation project(':TestUtils')
     testImplementation project(':UnionPay')
     testImplementation project(':Venmo')
+}
+
+dokkaHtml.configure {
+    dokkaSourceSets {
+        named('main') {
+            noAndroidSdkLink.set(false)
+        }
+    }
 }
 
 android.buildTypes.each { type ->

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -63,7 +63,7 @@ import org.json.JSONObject
  */
 open class Configuration internal constructor(configurationString: String?) {
 
-    companion object {
+    internal companion object {
         private const val ANALYTICS_KEY = "analytics"
         private const val ASSETS_URL_KEY = "assetsUrl"
         private const val BRAINTREE_API_KEY = "braintreeApi"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -267,6 +267,7 @@ open class Configuration internal constructor(configurationString: String?) {
      *
      * @param feature The feature to check.
      * @return `true` if GraphQL is enabled and the feature is enabled, `false` otherwise.
+     * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun isGraphQLFeatureEnabled(feature: String) = graphQLConfiguration.isFeatureEnabled(feature)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -185,8 +185,7 @@ open class Configuration internal constructor(configurationString: String?) {
         }
 
         analyticsConfiguration = AnalyticsConfiguration(json.optJSONObject(ANALYTICS_KEY))
-        braintreeApiConfiguration =
-            BraintreeApiConfiguration(json.optJSONObject(BRAINTREE_API_KEY))
+        braintreeApiConfiguration = BraintreeApiConfiguration(json.optJSONObject(BRAINTREE_API_KEY))
         cardConfiguration = CardConfiguration(json.optJSONObject(CARD_KEY))
         cardinalAuthenticationJwt = Json.optString(json, CARDINAL_AUTHENTICATION_JWT, null)
         environment = json.getString(ENVIRONMENT_KEY)
@@ -198,12 +197,10 @@ open class Configuration internal constructor(configurationString: String?) {
         merchantAccountId = Json.optString(json, MERCHANT_ACCOUNT_ID_KEY, null)
         merchantId = json.getString(MERCHANT_ID_KEY)
         payPalConfiguration = PayPalConfiguration(json.optJSONObject(PAYPAL_KEY))
-        samsungPayConfiguration =
-            SamsungPayConfiguration(json.optJSONObject(SAMSUNG_PAY_KEY))
+        samsungPayConfiguration = SamsungPayConfiguration(json.optJSONObject(SAMSUNG_PAY_KEY))
         unionPayConfiguration = UnionPayConfiguration(json.optJSONObject(UNIONPAY_KEY))
         venmoConfiguration = VenmoConfiguration(json.optJSONObject(PAY_WITH_VENMO_KEY))
-        visaCheckoutConfiguration =
-            VisaCheckoutConfiguration(json.optJSONObject(VISA_CHECKOUT_KEY))
+        visaCheckoutConfiguration = VisaCheckoutConfiguration(json.optJSONObject(VISA_CHECKOUT_KEY))
 
         isCvvChallengePresent = challenges.contains("cvv")
         isGooglePayEnabled = googlePayConfiguration.isEnabled

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -11,55 +11,24 @@ import org.json.JSONObject
  * Contains the remote configuration for the Braintree Android SDK.
  *
  * @property assetsUrl The assets URL of the current environment.
- * @property braintreeApiAccessToken The Access Token for Braintree API.
- * @property braintreeApiUrl the base url for accessing Braintree API.
  * @property cardinalAuthenticationJwt the JWT for Cardinal
  * @property clientApiUrl The url of the Braintree client API for the current environment.
  * @property environment The current environment.
- * @property googlePayAuthorizationFingerprint the authorization fingerprint to use for Google Payment, only allows tokenizing Google Payment cards.
- * @property googlePayDisplayName the Google Pay display name to show to the user.
- * @property googlePayEnvironment the current Google Pay environment.
- * @property googlePayPayPalClientId the PayPal Client ID used by Google Pay.
- * @property googlePaySupportedNetworks a list of supported card networks for Google Pay.
- * @property graphQLUrl the GraphQL url.
- * @property isAnalyticsEnabled `true` if analytics are enabled, `false` otherwise.
- * @property isBraintreeApiEnabled a boolean indicating whether Braintree API is enabled for this merchant.
  * @property isCvvChallengePresent `true` if cvv is required for card transactions, `false` otherwise.
- * @property isFraudDataCollectionEnabled `true` if fraud device data collection should occur; `false` otherwise.
  * @property isGooglePayEnabled `true` if Google Payment is enabled and supported in the current environment; `false` otherwise.
- * @property isGraphQLEnabled  `true` if GraphQL is enabled for the merchant account; `false` otherwise.
- * @property isKountEnabled `true` if Kount is enabled for the merchant account; `false` otherwise.
  * @property isLocalPaymentEnabled `true` if Local Payment is enabled for the merchant account; `false` otherwise.
  * @property isPayPalEnabled `true` if PayPal is enabled and supported in the current environment, `false` otherwise.
- * @property isPayPalTouchDisabled `true` if PayPal touch is currently disabled, `false` otherwise.
  * @property isPostalCodeChallengePresent `true` if postal code is required for card transactions, `false` otherwise.
  * @property isSamsungPayEnabled `true` if Samsung Pay is enabled; `false` otherwise.
  * @property isThreeDSecureEnabled `true` if 3D Secure is enabled and supported for the current merchant account, * `false` otherwise.
  * @property isUnionPayEnabled `true` if UnionPay is enabled for the merchant account; `false` otherwise.
  * @property isVenmoEnabled `true` if Venmo is enabled for the merchant account; `false` otherwise.
  * @property isVisaCheckoutEnabled `true` if Visa Checkout is enabled for the merchant account; `false` otherwise.
- * @property kountMerchantId the Kount merchant id set in the Gateway.
  * @property merchantAccountId the current Braintree merchant account id.
  * @property merchantId the current Braintree merchant id.
- * @property payPalClientId the PayPal app client id.
- * @property payPalCurrencyIsoCode the PayPal currency code.
  * @property payPalDirectBaseUrl the url for custom PayPal environments.
- * @property payPalDisplayName the PayPal app display name.
- * @property payPalEnvironment the current environment for PayPal.
  * @property payPalPrivacyUrl the PayPal app privacy url.
  * @property payPalUserAgreementUrl the PayPal app user agreement url.
- * @property samsungPayAuthorization the authorization to use with Samsung Pay.
- * @property samsungPayEnvironment the Braintree environment Samsung Pay should interact with.
- * @property samsungPayMerchantDisplayName the merchant display name for Samsung Pay.
- * @property samsungPayServiceId the Samsung Pay service id associated with the merchant.
- * @property samsungPaySupportedCardBrands a list of card brands supported by Samsung Pay.
- * @property supportedCardTypes a list of card types supported by the merchant.
- * @property venmoAccessToken the Access Token used by the Venmo app to tokenize on behalf of the merchant.
- * @property venmoEnvironment the Venmo environment used to handle this payment.
- * @property venmoMerchantId the Venmo merchant id used by the Venmo app to authorize payment.
- * @property visaCheckoutApiKey the Visa Checkout API key configured in the Braintree Control Panel.
- * @property visaCheckoutExternalClientId the Visa Checkout External Client ID configured in the Braintree Control Panel.
- * @property visaCheckoutSupportedNetworks the Visa Checkout supported networks enabled for the merchant account.
  */
 open class Configuration internal constructor(configurationString: String?) {
 
@@ -122,36 +91,191 @@ open class Configuration internal constructor(configurationString: String?) {
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val analyticsUrl: String?
+
+    /**
+     * @return The Access Token for Braintree API.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val braintreeApiAccessToken: String
+
+    /**
+     * @return the base url for accessing Braintree API.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val braintreeApiUrl: String
+
+    /**
+     * @return the authorization fingerprint to use for Google Payment, only allows tokenizing Google Payment cards.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val googlePayAuthorizationFingerprint: String?
+
+    /**
+     * @return the Google Pay display name to show to the user.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val googlePayDisplayName: String
+
+    /**
+     * @return the current Google Pay environment.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val googlePayEnvironment: String?
+
+    /**
+     * @return the PayPal Client ID used by Google Pay.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val googlePayPayPalClientId: String
+
+    /**
+     * @return a list of supported card networks for Google Pay.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val googlePaySupportedNetworks: List<String>
+
+    /**
+     * @return the GraphQL url.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val graphQLUrl: String
+
+    /**
+     * @return `true` if analytics are enabled, `false` otherwise.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isAnalyticsEnabled: Boolean
+
+    /**
+     * @return a boolean indicating whether Braintree API is enabled for this merchant.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isBraintreeApiEnabled: Boolean
+
+    /**
+     * @return `true` if fraud device data collection should occur; `false` otherwise.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isFraudDataCollectionEnabled: Boolean
+
+    /**
+     * @return `true` if GraphQL is enabled for the merchant account; `false` otherwise.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isGraphQLEnabled: Boolean
+
+    /**
+     * @return `true` if Kount is enabled for the merchant account; `false` otherwise.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isKountEnabled: Boolean
+
+    /**
+     * @return `true` if PayPal touch is currently disabled, `false` otherwise.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val isPayPalTouchDisabled: Boolean
+
+    /**
+     * @return the Kount merchant id set in the Gateway.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val kountMerchantId: String
+
+    /**
+     * @return the PayPal app client id.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val payPalClientId: String?
+
+    /**
+     * @return the PayPal currency code.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val payPalCurrencyIsoCode: String?
+
+    /**
+     * @return the PayPal app display name.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val payPalDisplayName: String?
+
+    /**
+     * @return the current environment for PayPal.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val payPalEnvironment: String?
+
+    /**
+     * @return the authorization to use with Samsung Pay.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val samsungPayAuthorization: String
+
+    /**
+     * @return the Braintree environment Samsung Pay should interact with.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val samsungPayEnvironment: String
+
+    /**
+     * @return the merchant display name for Samsung Pay.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val samsungPayMerchantDisplayName: String
+
+    /**
+     * @return the Samsung Pay service id associated with the merchant.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val samsungPayServiceId: String
+
+    /**
+     * @return a list of card brands supported by Samsung Pay.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val samsungPaySupportedCardBrands: List<String>
+
+    /**
+     * @return a list of card types supported by the merchant.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val supportedCardTypes: List<String>
+
+    /**
+     * @return the Access Token used by the Venmo app to tokenize on behalf of the merchant.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val venmoAccessToken: String
+
+    /**
+     * @return the Venmo environment used to handle this payment.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val venmoEnvironment: String
+
+    /**
+     * @return the Venmo merchant id used by the Venmo app to authorize payment.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val venmoMerchantId: String
+
+    /**
+     * @return the Visa Checkout API key configured in the Braintree Control Panel.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val visaCheckoutApiKey: String
+
+    /**
+     * @return the Visa Checkout External Client ID configured in the Braintree Control Panel.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val visaCheckoutExternalClientId: String
+
+    /**
+     * @return the Visa Checkout supported networks enabled for the merchant account.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val visaCheckoutSupportedNetworks: List<String>
 
     private val analyticsConfiguration: AnalyticsConfiguration

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -32,7 +32,10 @@ import org.json.JSONObject
  */
 open class Configuration internal constructor(configurationString: String?) {
 
-    internal companion object {
+    /**
+     * @suppress
+     */
+    companion object {
         private const val ANALYTICS_KEY = "analytics"
         private const val ASSETS_URL_KEY = "assetsUrl"
         private const val BRAINTREE_API_KEY = "braintreeApi"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/Configuration.kt
@@ -10,7 +10,6 @@ import org.json.JSONObject
 /**
  * Contains the remote configuration for the Braintree Android SDK.
  *
- * @property analyticsUrl [String] url of the Braintree analytics service.
  * @property assetsUrl The assets URL of the current environment.
  * @property braintreeApiAccessToken The Access Token for Braintree API.
  * @property braintreeApiUrl the base url for accessing Braintree API.
@@ -117,6 +116,11 @@ open class Configuration internal constructor(configurationString: String?) {
     // endregion
 
     // region Internal Properties
+
+    /**
+     * @return [String] url of the Braintree analytics service.
+     * @suppress
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val analyticsUrl: String?
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val braintreeApiAccessToken: String
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val braintreeApiUrl: String

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -66,17 +66,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -105,7 +94,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'data-collector'

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/BraintreeDataCollector/build.gradle
+++ b/BraintreeDataCollector/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
     id 'kotlin-android'
+    id 'org.jetbrains.dokka'
 }
 
 android {
@@ -53,6 +54,14 @@ dependencies {
     androidTestImplementation deps.androidxTestRules
     androidTestImplementation deps.androidxTestRunner
     androidTestImplementation deps.junitTest
+}
+
+dokkaHtml.configure {
+    dokkaSourceSets {
+        named('main') {
+            noAndroidSdkLink.set(false)
+        }
+    }
 }
 
 // region signing and publishing

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.library'
-    id 'de.marcphilipp.nexus-publish'
-    id 'signing'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
+    id 'de.marcphilipp.nexus-publish'
+    id 'signing'
 }
 
 android {

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -56,14 +56,6 @@ dependencies {
     androidTestImplementation deps.junitTest
 }
 
-dokkaHtml.configure {
-    dokkaSourceSets {
-        named('main') {
-            noAndroidSdkLink.set(false)
-        }
-    }
-}
-
 // region signing and publishing
 
 task javadocs(type: Javadoc) {

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -58,17 +58,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -97,7 +86,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'card'

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'de.marcphilipp.nexus-publish'
     id 'kotlin-android'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.library'
-    id 'de.marcphilipp.nexus-publish'
     id 'kotlin-android'
-    id 'signing'
     id 'org.jetbrains.dokka'
+    id 'de.marcphilipp.nexus-publish'
+    id 'signing'
 }
 
 android {

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -66,17 +66,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -105,7 +94,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'google-pay'

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -55,17 +55,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -94,7 +83,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'local-payment'

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -51,17 +51,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -90,7 +79,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'paypal'

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPalDataCollector/build.gradle
+++ b/PayPalDataCollector/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPalDataCollector/build.gradle
+++ b/PayPalDataCollector/build.gradle
@@ -65,17 +65,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -104,7 +93,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'paypal-data-collector'

--- a/PayPalDataCollector/build.gradle
+++ b/PayPalDataCollector/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -55,17 +55,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -94,7 +83,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'paypal-native-checkout'

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/SEPADirectDebit/build.gradle
+++ b/SEPADirectDebit/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/SEPADirectDebit/build.gradle
+++ b/SEPADirectDebit/build.gradle
@@ -54,17 +54,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -93,7 +82,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'sepa-direct-debit'

--- a/SEPADirectDebit/build.gradle
+++ b/SEPADirectDebit/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -57,17 +57,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -96,7 +85,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'samsung-pay'

--- a/SamsungPay/build.gradle
+++ b/SamsungPay/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -56,17 +56,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -95,7 +84,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'shared-utils'

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -1,8 +1,9 @@
- plugins {
+plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -2,6 +2,7 @@
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -60,17 +60,6 @@ dependencies {
 
 // region signing and publishing
 
- task javadocs(type: Javadoc) {
-     source = android.sourceSets.main.java.srcDirs
-     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-     failOnError false
- }
-
- task javadocsJar(type: Jar, dependsOn: javadocs) {
-     archiveClassifier.set('javadoc')
-     from javadocs.destinationDir
- }
-
  task sourcesJar(type: Jar) {
      archiveClassifier.set('sources')
      from android.sourceSets.main.java.srcDirs
@@ -99,7 +88,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'three-d-secure'

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -57,17 +57,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -96,7 +85,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'union-pay'

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.library'
-    id 'de.marcphilipp.nexus-publish'
-    id 'signing'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
+    id 'de.marcphilipp.nexus-publish'
+    id 'signing'
 }
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/UnionPay/build.gradle
+++ b/UnionPay/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
     id 'kotlin-android'
+    id 'org.jetbrains.dokka'
 }
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -53,17 +53,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
@@ -92,7 +81,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'venmo'

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
-    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'de.marcphilipp.nexus-publish'
     id 'signing'
+    id 'org.jetbrains.dokka'
 }
 
 android {

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -58,16 +58,6 @@ dependencies {
 }
 
 /* maven deploy + signing */
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
 
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
@@ -97,7 +87,6 @@ afterEvaluate {
                 from components.release
 
                 artifact sourcesJar
-                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'visa-checkout'

--- a/build.gradle
+++ b/build.gradle
@@ -89,10 +89,12 @@ buildscript {
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.10'
     }
 }
 
 plugins {
+    id 'org.jetbrains.dokka' version '1.7.10'
     id 'io.codearte.nexus-staging' version '0.21.2'
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,10 @@ subprojects {
     }
 }
 
+dokkaHtmlMultiModule.configure {
+    outputDirectory.set(project.file("docs"))
+}
+
 task changeGradleReleaseVersion {
     doLast {
         def gradleFile = new File('build.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ subprojects {
 }
 
 dokkaHtmlMultiModule.configure {
+    // redirect dokka output to GitHub pages root directory
     outputDirectory.set(project.file("docs"))
 }
 


### PR DESCRIPTION
### Summary of changes

 - Replace Javadoc with [Dokka](https://kotlin.github.io/dokka) to generate docs for both Java and Kotlin
 - Add `./gradlew dokkaHtmlMultiModule` to the GitHub actions release workflow
 - Output docs in the `./docs` folder so we can host docs via GitHub Pages  

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 