### PR TITLE
Bump Down `androidx.core:core-ktx` to Version 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext.deps = [
             "appCompat"                  : "androidx.appcompat:appcompat:1.3.1",
             "annotation"                 : "androidx.annotation:annotation:1.2.0",
-            "coreKtx"                    : "androidx.core:core-ktx:1.7.0",
+            "coreKtx"                    : "androidx.core:core-ktx:1.1.0",
 
             // NEXT_MAJOR_VERSION: upgrade to 2.4.0 (or latest) when Java 7 support is explicitly dropped
             "lifecycleRuntime"           : "androidx.lifecycle:lifecycle-runtime:2.3.0",


### PR DESCRIPTION
### Summary of changes

 - Lowering `androidx.core:core-ktx` dependency version to `1.1.0` since newer versions [require Java 8](https://developer.android.com/jetpack/androidx/releases/core#1.2.0-alpha02).

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
