### PR TITLE
Make InvalidArgumentException Constructor Visible to LIBRARY_GROUP

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api
 
 import androidx.annotation.RestrictTo
 
+// NEXT MAJOR VERSION: remove open modifier
 /**
  * Error thrown when arguments provided to a method are invalid.
  */

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
@@ -1,7 +1,6 @@
 package com.braintreepayments.api
 
 import androidx.annotation.RestrictTo
-import java.lang.Exception
 
 /**
  * Error thrown when arguments provided to a method are invalid.
@@ -13,5 +12,6 @@ open class InvalidArgumentException : Exception {
      * @param message the error message
      * @suppress
      */
+    @Suppress("ConvertSecondaryConstructorToPrimary")
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(message: String?) : super(message)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidArgumentException.kt
@@ -1,9 +1,17 @@
 package com.braintreepayments.api
 
+import androidx.annotation.RestrictTo
 import java.lang.Exception
 
 /**
  * Error thrown when arguments provided to a method are invalid.
- * @param message the error message
  */
-class InvalidArgumentException internal constructor(message: String?) : Exception(message)
+open class InvalidArgumentException : Exception {
+
+    /**
+     * Ref: https://github.com/Kotlin/dokka/issues/1953
+     * @param message the error message
+     * @suppress
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(message: String?) : super(message)
+}


### PR DESCRIPTION
### Summary of changes

 - The `InvalidArgumentException` constructor is used in the `three-d-secure` module

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
