### PR TITLE
Allow Uppercase Characters in Return URL Scheme

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -36,13 +36,11 @@ public class BraintreeClient {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
-                .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
 
         String braintreeReturnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
-                .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree.deeplinkhandler";
         return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, null, IntegrationType.CUSTOM, braintreeReturnUrlScheme);
     }
@@ -55,13 +53,11 @@ public class BraintreeClient {
         String returnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
-                .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree";
 
         String braintreeReturnUrlScheme = context
                 .getApplicationContext()
                 .getPackageName()
-                .toLowerCase(Locale.ROOT)
                 .replace("_", "") + ".braintree.deeplinkhandler";
 
         return createDefaultParams(context, authString, clientTokenProvider, returnUrlScheme, sessionId, integrationType, braintreeReturnUrlScheme);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Allow uppercase characters in default return url scheme
+
 ## 4.23.1
 
 * ThreeDSecure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Allow uppercase characters in default return url scheme
+* BraintreeCore
+  * Allow uppercase characters in default return url scheme
 
 ## 4.23.1
 
@@ -25,7 +26,7 @@
   * Update exception documentation links to point to valid PayPal Braintree documentation URL
 * ThreeDSecure
   * Update exception documentation links to point to valid PayPal Braintree documentation URL
-* Braintree Core
+* BraintreeCore
   * Update pinned certificates used by `BraintreeGraphQLClient` and `BraintreeHttpClient`
 
 ## 4.21.0


### PR DESCRIPTION
### Summary of changes

 - `BraintreeClient` forces `applicationId` to lowercase when creating a `returnUrlScheme` for browser switching
 - Uppercase characters are [valid URL scheme characters](https://stackoverflow.com/a/3641782)
 - We should remove this restriction (See [braintree-android-drop-in #379](https://github.com/braintree/braintree-android-drop-in/issues/379))
 
 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
