### PR TITLE
Apply `Theme.AppCompat` to ThreeDSecureActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * Fix an issue where address override was not being honored in `PayPalNativeCheckoutRequest`
   * Breaking changes
     *`PayPalNativeRequest` requires a `returnUrl` to redirect correctly after authentication
+* ThreeDSecure
+  * Apply `Theme.AppCompat` to `ThreeDSecureActivity`
 
 ## 4.24.0
 

--- a/ThreeDSecure/src/main/AndroidManifest.xml
+++ b/ThreeDSecure/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.braintreepayments.api.threedsecure" >
+    package="com.braintreepayments.api.threedsecure">
+
     <application>
-        <activity android:name="com.braintreepayments.api.ThreeDSecureActivity"/>
+        <activity
+            android:name="com.braintreepayments.api.ThreeDSecureActivity"
+            android:theme="@style/Theme.AppCompat" />
     </application>
 </manifest>


### PR DESCRIPTION
### Summary of changes

 - Apply `Theme.AppCompat` to `ThreeDSecureActivity`
 - Possible fix for [braintree-android-drop-in #326](https://github.com/braintree/braintree-android-drop-in/issues/326)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
