### PR TITLE
Update androidx security-crypto to 1.1.0-alpha04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree Android SDK Release Notes
 
-## unrelease
+## unreleased
 
 * SharedUtils
   * Bump androidx `security-crypto` dependency to `1.1.0-alpha04`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unrelease
+
+* SharedUtils
+  * Bump androidx `security-crypto` dependency to `1.1.0-alpha04`
+
 ## 4.24.0
 
 * BraintreeCore

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
             // 1.1.0-alpha or higher is required for API 21 support
-            "securityCrypto"             : "androidx.security:security-crypto:1.1.0-alpha03",
+            "securityCrypto"             : "androidx.security:security-crypto:1.1.0-alpha04",
 
             // NEXT_MAJOR_VERSION: upgrade to 2.7.1 (or latest) when Java 7 support is explicitly dropped
             "work"                       : "androidx.work:work-runtime:2.7.0-alpha05",


### PR DESCRIPTION
### Summary of changes

 - Bump androidx `security-crypto` library to latest version

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
