### PR TITLE
Changing nxo intent to use the one from the PayPalNativeCheckoutRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * Fix an issue where address override was not being honored in `PayPalNativeCheckoutRequest`
   * Breaking changes
     *`PayPalNativeRequest` requires a `returnUrl` to redirect correctly after authentication
-  * Setting the `PayPalNativeCheckoutAccountNonce` intent as the one provided in the `PayPalNativeCheckoutRequest`
+  * Fixes bug in `PayPalNativeCheckoutAccountNonce` where the `intent` was not being set correctly from the `PayPalNativeCheckoutRequest`
 * ThreeDSecure
   * Apply `Theme.AppCompat` to `ThreeDSecureActivity`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Fix an issue where address override was not being honored in `PayPalNativeCheckoutRequest`
   * Breaking changes
     *`PayPalNativeRequest` requires a `returnUrl` to redirect correctly after authentication
+  * Setting the `PayPalNativeCheckoutAccountNonce` intent as the one provided in the `PayPalNativeCheckoutRequest`
 * ThreeDSecure
   * Apply `Theme.AppCompat` to `ThreeDSecureActivity`
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -258,8 +258,8 @@ public class PayPalNativeCheckoutClient {
         payPalAccount.setClientMetadataId(riskId);
         payPalAccount.setSource("paypal-browser");
         payPalAccount.setPaymentType(paymentType);
-        if (approvalData.getCart() != null) {
-            payPalAccount.setIntent(approvalData.getCart().getIntent());
+        if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
+            payPalAccount.setIntent(((PayPalNativeCheckoutRequest) payPalRequest).getIntent());
         }
 
         try {


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Changing the intent from native to use the one from the request

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
