### PR TITLE
Support SamsungPay Single Use Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     *`PayPalNativeRequest` requires a `returnUrl` to redirect correctly after authentication
 * ThreeDSecure
   * Apply `Theme.AppCompat` to `ThreeDSecureActivity`
+* SamsungPay
+  * Support legacy `singleUseToken` property when parsing Samsung Pay response (fixes #668)
 
 ## 4.24.0
 

--- a/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayNonce.java
+++ b/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayNonce.java
@@ -26,10 +26,10 @@ public class SamsungPayNonce extends PaymentMethodNonce {
         JSONObject tokenizeSamsungPayResponse =
             braintreeData.getJSONObject("tokenizeSamsungPayCard");
 
-        JSONObject paymentMethod = tokenizeSamsungPayResponse.optJSONObject("singleUseToken");
+        JSONObject paymentMethod = tokenizeSamsungPayResponse.optJSONObject("paymentMethod");
         if (paymentMethod == null) {
-            // fallback to payment method key
-            paymentMethod = tokenizeSamsungPayResponse.getJSONObject("paymentMethod");
+            // fallback to single use token key; throws when fallback not present
+            paymentMethod = tokenizeSamsungPayResponse.getJSONObject("singleUseToken");
         }
 
         String nonce = paymentMethod.getString("id");

--- a/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayNonce.java
+++ b/SamsungPay/src/main/java/com/braintreepayments/api/SamsungPayNonce.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 
 /**
  * {@link PaymentMethodNonce} representing a Samsung Pay card.
+ *
  * @see PaymentMethodNonce
  */
 public class SamsungPayNonce extends PaymentMethodNonce {
@@ -22,9 +23,14 @@ public class SamsungPayNonce extends PaymentMethodNonce {
         JSONObject data = new JSONObject(inputJson.getString("data"));
         JSONObject braintreeData = new JSONObject(data.getString("data"));
 
-        JSONObject paymentMethod = braintreeData
-                .getJSONObject("tokenizeSamsungPayCard")
-                .getJSONObject("paymentMethod");
+        JSONObject tokenizeSamsungPayResponse =
+            braintreeData.getJSONObject("tokenizeSamsungPayCard");
+
+        JSONObject paymentMethod = tokenizeSamsungPayResponse.optJSONObject("singleUseToken");
+        if (paymentMethod == null) {
+            // fallback to payment method key
+            paymentMethod = tokenizeSamsungPayResponse.getJSONObject("paymentMethod");
+        }
 
         String nonce = paymentMethod.getString("id");
 

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayInternalClientUnitTest.java
@@ -271,7 +271,7 @@ public class SamsungPayInternalClientUnitTest {
     public void startSamsungPay_onSuccess_notifiesListenerOfNonceCreation() {
         CustomSheetPaymentInfo customSheetPaymentInfo = mock(CustomSheetPaymentInfo.class);
         PaymentManager paymentManager = new MockPaymentManagerBuilder()
-                .startInAppPayWithCustomSheetSuccess(customSheetPaymentInfo, Fixtures.SAMSUNG_PAY_RESPONSE)
+                .startInAppPayWithCustomSheetSuccess(customSheetPaymentInfo, Fixtures.SAMSUNG_PAY_RESPONSE_V2)
                 .build();
 
         SamsungPay samsungPay = mock(SamsungPay.class);

--- a/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayNonceUnitTest.java
+++ b/SamsungPay/src/test/java/com/braintreepayments/api/SamsungPayNonceUnitTest.java
@@ -1,16 +1,39 @@
 package com.braintreepayments.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class SamsungPayNonceUnitTest {
 
     @Test
-    public void fromJSON_parsesNonce() throws JSONException {
-        SamsungPayNonce sut = SamsungPayNonce.fromJSON(new JSONObject(Fixtures.SAMSUNG_PAY_RESPONSE));
+    public void fromJSON_parsesNonce_v2() throws JSONException {
+        SamsungPayNonce sut = SamsungPayNonce.fromJSON(new JSONObject(Fixtures.SAMSUNG_PAY_RESPONSE_V2));
+
+        assertEquals("tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty", sut.getString());
+        assertFalse(sut.isDefault());
+
+        assertEquals("Mastercard", sut.getCardType());
+        assertEquals("1798", sut.getLastFour());
+
+        BinData binData = sut.getBinData();
+        assertEquals("Unknown", binData.getPrepaid());
+        assertEquals("Yes", binData.getHealthcare());
+        assertEquals("No", binData.getDebit());
+        assertEquals("Unknown", binData.getDurbinRegulated());
+        assertEquals("Unknown", binData.getCommercial());
+        assertEquals("Unknown", binData.getPayroll());
+        assertEquals("Unknown", binData.getIssuingBank());
+        assertEquals("US", binData.getCountryOfIssuance());
+        assertEquals("123", binData.getProductId());
+    }
+
+    @Test
+    public void fromJSON_parsesNonce_v1() throws JSONException {
+        SamsungPayNonce sut = SamsungPayNonce.fromJSON(new JSONObject(Fixtures.SAMSUNG_PAY_RESPONSE_V1));
 
         assertEquals("tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty", sut.getString());
         assertFalse(sut.isDefault());

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -2474,9 +2474,30 @@ object Fixtures {
     //endregion
 
     // language=JSON
-    const val SAMSUNG_PAY_RESPONSE = """
+    const val SAMSUNG_PAY_RESPONSE_V2 = """
         {
           "data": "{\n  \"data\": {\n    \"tokenizeSamsungPayCard\": {\n      \"paymentMethod\": {\n        \"id\": \"tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty\",\n        \"details\": {\n          \"brand\": \"Mastercard\",\n          \"brandCode\": \"MASTERCARD\",\n          \"last4\": \"1798\",\n          \"expirationYear\": \"2020\",\n          \"expirationMonth\": \"12\",\n          \"binData\": {\n            \"commercial\": \"UNKNOWN\",\n            \"countryOfIssuance\": \"US\",\n            \"debit\": \"NO\",\n            \"durbinRegulated\": \"UNKNOWN\",\n            \"healthcare\": \"YES\",\n            \"issuingBank\": null,\n            \"payroll\": \"UNKNOWN\",\n            \"prepaid\": \"UNKNOWN\",\n            \"productId\": \"123\"\n          },\n          \"origin\": {\n            \"type\": \"SAMSUNG_PAY\",\n            \"details\": {\n              \"bin\": \"411111\"\n            }\n          }\n        }\n      }\n    }\n  },\n  \"extensions\": {\n    \"requestId\": \"9eaf90d9-4e8a-4883-96c4-01c02bb0a4e5\"\n  }\n}",
+          "reference":"tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty",
+          "status":"AUTHORIZED",
+          "payment_last4_dpan":"1798",
+          "payment_last4_fpan":"1470",
+          "payment_card_brand":"MC",
+          "payment_currency_type":"USD",
+          "payment_shipping_address":{
+            "shipping":{
+
+            },
+            "email":""
+          },
+          "payment_shipping_method":""
+        }
+    """
+
+    // NOTE: SamsungPay response sometimes has `singleUseToken` as an alias for the top level `paymentMethod` field
+    // language=JSON
+    const val SAMSUNG_PAY_RESPONSE_V1 = """
+        {
+          "data": "{\n  \"data\": {\n    \"tokenizeSamsungPayCard\": {\n      \"singleUseToken\": {\n        \"id\": \"tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty\",\n        \"details\": {\n          \"brand\": \"Mastercard\",\n          \"brandCode\": \"MASTERCARD\",\n          \"last4\": \"1798\",\n          \"expirationYear\": \"2020\",\n          \"expirationMonth\": \"12\",\n          \"binData\": {\n            \"commercial\": \"UNKNOWN\",\n            \"countryOfIssuance\": \"US\",\n            \"debit\": \"NO\",\n            \"durbinRegulated\": \"UNKNOWN\",\n            \"healthcare\": \"YES\",\n            \"issuingBank\": null,\n            \"payroll\": \"UNKNOWN\",\n            \"prepaid\": \"UNKNOWN\",\n            \"productId\": \"123\"\n          },\n          \"origin\": {\n            \"type\": \"SAMSUNG_PAY\",\n            \"details\": {\n              \"bin\": \"411111\"\n            }\n          }\n        }\n      }\n    }\n  },\n  \"extensions\": {\n    \"requestId\": \"9eaf90d9-4e8a-4883-96c4-01c02bb0a4e5\"\n  }\n}",
           "reference":"tokensam_bf_v8s9hv_2htw4m_nh4f45_y3hsft_wty",
           "status":"AUTHORIZED",
           "payment_last4_dpan":"1798",


### PR DESCRIPTION
### Summary of changes

 - Support legacy `singleUseToken` property when parsing Samsung Pay response (fixes #668)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
