### PR TITLE
Append Browser Switch Original Error Message on Failure

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -9,8 +9,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
-import java.util.Locale;
-
 /**
  * Core Braintree class that handles network requests.
  */
@@ -331,7 +329,7 @@ public class BraintreeClient {
         return returnUrlScheme;
     }
 
-    boolean canPerformBrowserSwitch(FragmentActivity activity, @BraintreeRequestCodes int requestCode) {
+    void assertCanPerformBrowserSwitch(FragmentActivity activity, @BraintreeRequestCodes int requestCode) throws BrowserSwitchException {
         // url used to see if the application is able to open an https url e.g. web browser
         Uri url = Uri.parse("https://braintreepayments.com");
         String returnUrlScheme = getReturnUrlScheme();
@@ -339,13 +337,7 @@ public class BraintreeClient {
                 .url(url)
                 .returnUrlScheme(returnUrlScheme)
                 .requestCode(requestCode);
-        boolean result = true;
-        try {
-            browserSwitchClient.assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
-        } catch (BrowserSwitchException e) {
-            result = false;
-        }
-        return result;
+        browserSwitchClient.assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
     }
 
     <T> boolean isUrlSchemeDeclaredInAndroidManifest(String urlScheme, Class<T> klass) {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -484,7 +484,7 @@ public class BraintreeClientUnitTest {
         BraintreeClient sut = new BraintreeClient(params);
 
         FragmentActivity activity = mock(FragmentActivity.class);
-        sut.canPerformBrowserSwitch(activity, 123);
+        sut.assertCanPerformBrowserSwitch(activity, 123);
 
         ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
         verify(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), captor.capture());
@@ -502,7 +502,7 @@ public class BraintreeClientUnitTest {
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
-        assertTrue(sut.canPerformBrowserSwitch(activity, 123));
+        assertTrue(sut.assertCanPerformBrowserSwitch(activity, 123));
     }
 
     @Test
@@ -513,8 +513,8 @@ public class BraintreeClientUnitTest {
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
-        sut.canPerformBrowserSwitch(activity, 123);
-        assertFalse(sut.canPerformBrowserSwitch(activity, 123));
+        sut.assertCanPerformBrowserSwitch(activity, 123);
+        assertFalse(sut.assertCanPerformBrowserSwitch(activity, 123));
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -480,7 +480,7 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void canPerformBrowserSwitch_assertsBrowserSwitchIsPossible() throws BrowserSwitchException {
+    public void assertCanPerformBrowserSwitch_assertsBrowserSwitchIsPossible() throws BrowserSwitchException {
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
@@ -496,7 +496,7 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void canPerformBrowserSwitch_onSuccess_returnsTrue() throws BrowserSwitchException {
+    public void assertCanPerformBrowserSwitch_onSuccess_doesNotThrow() throws BrowserSwitchException {
         FragmentActivity activity = mock(FragmentActivity.class);
         doNothing().when(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), any(BrowserSwitchOptions.class));
 
@@ -511,7 +511,7 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
-    public void canPerformBrowserSwitch_onError_returnsFalse() throws BrowserSwitchException {
+    public void assertCanPerformBrowserSwitch_onError_throws() throws BrowserSwitchException {
         FragmentActivity activity = mock(FragmentActivity.class);
         BrowserSwitchException browserSwitchException = new BrowserSwitchException("error");
         doThrow(browserSwitchException)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -116,7 +117,7 @@ public class BraintreeClientUnitTest {
 
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
         BraintreeSharedPreferencesException loadFromCacheError =
-            new BraintreeSharedPreferencesException("cache load error");
+                new BraintreeSharedPreferencesException("cache load error");
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .loadFromCacheError(loadFromCacheError)
@@ -140,7 +141,7 @@ public class BraintreeClientUnitTest {
 
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ANALYTICS);
         BraintreeSharedPreferencesException saveToCacheError =
-            new BraintreeSharedPreferencesException("cache save error");
+                new BraintreeSharedPreferencesException("cache save error");
         ConfigurationLoader configurationLoader = new MockConfigurationLoaderBuilder()
                 .configuration(configuration)
                 .saveToCacheError(saveToCacheError)
@@ -502,19 +503,29 @@ public class BraintreeClientUnitTest {
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
-        assertTrue(sut.assertCanPerformBrowserSwitch(activity, 123));
+        try {
+            sut.assertCanPerformBrowserSwitch(activity, 123);
+        } catch (BrowserSwitchException e) {
+            fail("shouldn't get here");
+        }
     }
 
     @Test
     public void canPerformBrowserSwitch_onError_returnsFalse() throws BrowserSwitchException {
         FragmentActivity activity = mock(FragmentActivity.class);
-        doThrow(new BrowserSwitchException("error")).when(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), any(BrowserSwitchOptions.class));
+        BrowserSwitchException browserSwitchException = new BrowserSwitchException("error");
+        doThrow(browserSwitchException)
+                .when(browserSwitchClient).assertCanPerformBrowserSwitch(same(activity), any(BrowserSwitchOptions.class));
 
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);
 
-        sut.assertCanPerformBrowserSwitch(activity, 123);
-        assertFalse(sut.assertCanPerformBrowserSwitch(activity, 123));
+        try {
+            sut.assertCanPerformBrowserSwitch(activity, 123);
+            fail("shouldn't get here");
+        } catch (BrowserSwitchException e) {
+            assertSame(browserSwitchException, e);
+        }
     }
 
     @Test
@@ -583,7 +594,7 @@ public class BraintreeClientUnitTest {
         ClientTokenProvider clientTokenProvider = mock(ClientTokenProvider.class);
         String sessionId = "custom-session-id";
         BraintreeClient sut =
-            new BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN);
+                new BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN);
 
         assertEquals("custom-session-id", sut.getSessionId());
     }
@@ -613,7 +624,7 @@ public class BraintreeClientUnitTest {
         ClientTokenProvider clientTokenProvider = mock(ClientTokenProvider.class);
         String sessionId = "custom-session-id";
         BraintreeClient sut =
-            new BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN);
+                new BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN);
 
         assertEquals("dropin", sut.getIntegrationType());
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.25.1
 
 * BraintreeCore
-  * Provide more error information on Browser Switch failures
+  * Provide more detailed information for Browser Switch errors for PayPal, PayPalNativeCheckout, and ThreeDSecure payment flows
 * SharedUtils
   * Revert androidx `security-crypto` dependency to `1.1.0-alpha03` (`1.1.0-alpha04` requires a compile target of 33)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.25.1
 
+* BraintreeCore
+  * Provide more error information on Browser Switch failures
 * SharedUtils
   * Revert androidx `security-crypto` dependency to `1.1.0-alpha03` (`1.1.0-alpha04` requires a compile target of 33)
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -187,7 +187,7 @@ public class PayPalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
-                .canPerformBrowserSwitch(false)
+                .browserSwitchAssertionError(new BrowserSwitchException("browser switch error"))
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
@@ -200,7 +200,7 @@ public class PayPalClientUnitTest {
         assertEquals("AndroidManifest.xml is incorrectly configured or another app " +
                 "defines the same browser switch url as this app. See " +
                 "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                "for the correct configuration", errorCaptor.getValue().getMessage());
+                "for the correct configuration: browser switch error", errorCaptor.getValue().getMessage());
     }
 
     @Test
@@ -284,7 +284,6 @@ public class PayPalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
-                .canPerformBrowserSwitch(true)
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
@@ -359,7 +358,7 @@ public class PayPalClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
-                .canPerformBrowserSwitch(false)
+                .browserSwitchAssertionError(new BrowserSwitchException("browser switch error"))
                 .build();
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
@@ -372,7 +371,7 @@ public class PayPalClientUnitTest {
         assertEquals("AndroidManifest.xml is incorrectly configured or another app " +
                 "defines the same browser switch url as this app. See " +
                 "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                "for the correct configuration", errorCaptor.getValue().getMessage());
+                "for the correct configuration: browser switch error", errorCaptor.getValue().getMessage());
     }
 
 

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.java
@@ -101,7 +101,6 @@ public class PayPalNativeCheckoutClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(payPalEnabledConfig)
-                .canPerformBrowserSwitch(true)
                 .build();
         PowerMockito.mockStatic(PayPalCheckout.class);
         PowerMockito.mockStatic(PLog.class);

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -11,6 +11,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,9 +37,7 @@ public class MockBraintreeClientBuilder {
     private String returnUrlScheme;
 
     private BrowserSwitchResult browserSwitchResult;
-
-    private boolean urlSchemeInAndroidManifest = true;
-    private boolean canPerformBrowserSwitch = true;
+    private BrowserSwitchException browserSwitchAssertionError;
 
     private ActivityInfo activityInfo;
     private boolean launchesBrowserSwitchAsNewTask;
@@ -117,13 +116,8 @@ public class MockBraintreeClientBuilder {
          return this;
     }
 
-    public MockBraintreeClientBuilder urlSchemeDeclaredInManifest(boolean urlSchemeInAndroidManifest) {
-        this.urlSchemeInAndroidManifest = urlSchemeInAndroidManifest;
-        return this;
-    }
-
-    public MockBraintreeClientBuilder canPerformBrowserSwitch(boolean canPerformBrowserSwitch) {
-        this.canPerformBrowserSwitch = canPerformBrowserSwitch;
+    public MockBraintreeClientBuilder browserSwitchAssertionError(BrowserSwitchException browserSwitchAssertionError) {
+        this.browserSwitchAssertionError = browserSwitchAssertionError;
         return this;
     }
 
@@ -156,8 +150,13 @@ public class MockBraintreeClientBuilder {
             when(braintreeClient.getReturnUrlScheme()).thenReturn(returnUrlScheme);
         }
 
-        when(braintreeClient.isUrlSchemeDeclaredInAndroidManifest(anyString(), any(Class.class))).thenReturn(urlSchemeInAndroidManifest);
-        when(braintreeClient.assertCanPerformBrowserSwitch(any(FragmentActivity.class), anyInt())).thenReturn(canPerformBrowserSwitch);
+        if (browserSwitchAssertionError != null) {
+            try {
+                doThrow(browserSwitchAssertionError)
+                        .when(braintreeClient).assertCanPerformBrowserSwitch(any(FragmentActivity.class), anyInt());
+            } catch (BrowserSwitchException ignored) {}
+        }
+
         when(braintreeClient.getManifestActivityInfo(any(Class.class))).thenReturn(activityInfo);
         when(braintreeClient.deliverBrowserSwitchResult(any(FragmentActivity.class))).thenReturn(browserSwitchResult);
         when(braintreeClient.launchesBrowserSwitchAsNewTask()).thenReturn(launchesBrowserSwitchAsNewTask);

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -157,7 +157,7 @@ public class MockBraintreeClientBuilder {
         }
 
         when(braintreeClient.isUrlSchemeDeclaredInAndroidManifest(anyString(), any(Class.class))).thenReturn(urlSchemeInAndroidManifest);
-        when(braintreeClient.canPerformBrowserSwitch(any(FragmentActivity.class), anyInt())).thenReturn(canPerformBrowserSwitch);
+        when(braintreeClient.assertCanPerformBrowserSwitch(any(FragmentActivity.class), anyInt())).thenReturn(canPerformBrowserSwitch);
         when(braintreeClient.getManifestActivityInfo(any(Class.class))).thenReturn(activityInfo);
         when(braintreeClient.deliverBrowserSwitchResult(any(FragmentActivity.class))).thenReturn(browserSwitchResult);
         when(braintreeClient.launchesBrowserSwitchAsNewTask()).thenReturn(launchesBrowserSwitchAsNewTask);

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -144,13 +144,14 @@ public class ThreeDSecureClient {
                     return;
                 }
 
-                boolean supportsBrowserSwitch = braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE);
-                if (!supportsBrowserSwitch) {
+                try {
+                    braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE);
+                } catch (BrowserSwitchException exception) {
                     braintreeClient.sendAnalyticsEvent("three-d-secure.invalid-manifest");
                     callback.onResult(null, new BraintreeException("AndroidManifest.xml is incorrectly configured or another app " +
                             "defines the same browser switch url as this app. See " +
                             "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                            "for the correct configuration"));
+                            "for the correct configuration: " + exception.getMessage()));
                     return;
                 }
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -96,7 +97,6 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.performVerification(activity, basicRequest, threeDSecureResultCallback);
@@ -113,7 +113,6 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setNonce("a-nonce");
@@ -148,7 +147,6 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setNonce("a-nonce");
@@ -189,7 +187,6 @@ public class ThreeDSecureClientUnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
@@ -214,7 +211,6 @@ public class ThreeDSecureClientUnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.setListener(listener);
@@ -230,13 +226,15 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_whenBrowserSwitchNotSetup_postsException() {
+    public void performVerification_whenBrowserSwitchNotSetup_postsException() throws BrowserSwitchException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
+
+        doThrow(new BrowserSwitchException("browser switch error"))
+                .when(braintreeClient).assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.setListener(listener);
@@ -247,17 +245,18 @@ public class ThreeDSecureClientUnitTest {
         assertEquals("AndroidManifest.xml is incorrectly configured or another app " +
                 "defines the same browser switch url as this app. See " +
                 "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                "for the correct configuration", captor.getValue().getMessage());
+                "for the correct configuration: browser switch error", captor.getValue().getMessage());
     }
 
     @Test
-    public void performVerification_whenBrowserSwitchNotSetup_sendsAnalyticEvent() {
+    public void performVerification_whenBrowserSwitchNotSetup_sendsAnalyticEvent() throws BrowserSwitchException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
+        doThrow(new BrowserSwitchException("browser switch error"))
+                .when(braintreeClient).assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.performVerification(activity, basicRequest, threeDSecureResultCallback);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -96,7 +96,7 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.performVerification(activity, basicRequest, threeDSecureResultCallback);
@@ -113,7 +113,7 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setNonce("a-nonce");
@@ -148,7 +148,7 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setNonce("a-nonce");
@@ -189,7 +189,7 @@ public class ThreeDSecureClientUnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
@@ -214,7 +214,7 @@ public class ThreeDSecureClientUnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.setListener(listener);
@@ -236,7 +236,7 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.setListener(listener);
@@ -257,7 +257,7 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.THREE_D_SECURE)).thenReturn(false);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
         sut.performVerification(activity, basicRequest, threeDSecureResultCallback);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
@@ -84,7 +84,6 @@ public class ThreeDSecureV1UnitTest {
                 .returnUrlScheme("sample-url-scheme://")
                 .build();
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -104,7 +103,6 @@ public class ThreeDSecureV1UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -128,8 +126,6 @@ public class ThreeDSecureV1UnitTest {
 
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
-
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -160,8 +156,6 @@ public class ThreeDSecureV1UnitTest {
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
-
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
         sut.continuePerformVerification(activity, threeDSecureRequest, threeDSecureResult);
@@ -191,8 +185,6 @@ public class ThreeDSecureV1UnitTest {
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
-
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
         sut.continuePerformVerification(activity, threeDSecureRequest, threeDSecureResult);
@@ -211,8 +203,6 @@ public class ThreeDSecureV1UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme(urlScheme)
                 .build();
-
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(eq(urlScheme), eq(assetsUrl), isNull(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class)))
                 .thenReturn("https://browser.switch.url.com");
@@ -240,8 +230,6 @@ public class ThreeDSecureV1UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme(urlScheme)
                 .build();
-
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(eq(urlScheme), eq(assetsUrl), eq(threeDSecureRequest), any(ThreeDSecureLookup.class)))
                 .thenReturn("https://browser.switch.url.com");

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV1UnitTest.java
@@ -84,7 +84,7 @@ public class ThreeDSecureV1UnitTest {
                 .returnUrlScheme("sample-url-scheme://")
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -104,7 +104,7 @@ public class ThreeDSecureV1UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -129,7 +129,7 @@ public class ThreeDSecureV1UnitTest {
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -160,7 +160,7 @@ public class ThreeDSecureV1UnitTest {
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -191,7 +191,7 @@ public class ThreeDSecureV1UnitTest {
         when(browserSwitchHelper.getUrl(urlScheme, assetsUrl, threeDSecureRequest, threeDSecureResult.getLookup()))
                 .thenReturn("https://browser.switch.url.com");
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -212,7 +212,7 @@ public class ThreeDSecureV1UnitTest {
                 .returnUrlScheme(urlScheme)
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(eq(urlScheme), eq(assetsUrl), isNull(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class)))
                 .thenReturn("https://browser.switch.url.com");
@@ -241,7 +241,7 @@ public class ThreeDSecureV1UnitTest {
                 .returnUrlScheme(urlScheme)
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         when(browserSwitchHelper.getUrl(eq(urlScheme), eq(assetsUrl), eq(threeDSecureRequest), any(ThreeDSecureLookup.class)))
                 .thenReturn("https://browser.switch.url.com");

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,7 +86,7 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -121,7 +120,7 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
@@ -153,7 +152,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
@@ -174,7 +173,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
@@ -199,7 +198,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -218,7 +217,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -237,7 +236,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -256,7 +255,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -280,7 +279,7 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme("sample-return-url://")
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -302,7 +301,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -323,7 +322,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -344,7 +343,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -367,7 +366,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(null, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         ThreeDSecureResult threeDSecureResult = ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
@@ -390,7 +389,7 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
-        when(braintreeClient.canPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
+        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -86,8 +86,6 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
-
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
 
@@ -120,8 +118,6 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .build();
 
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
-
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
@@ -152,7 +148,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
@@ -173,7 +168,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
 
@@ -198,7 +192,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -217,7 +210,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -236,7 +228,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -255,7 +246,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -279,7 +269,6 @@ public class ThreeDSecureV2UnitTest {
                 .configuration(threeDSecureEnabledConfig)
                 .returnUrlScheme("sample-return-url://")
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
         when(browserSwitchHelper.getUrl(anyString(), anyString(), any(ThreeDSecureRequest.class), any(ThreeDSecureLookup.class))).thenReturn("https://example.com");
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
@@ -301,7 +290,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -322,7 +310,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -343,7 +330,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);
@@ -366,7 +352,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(threeDSecureEnabledConfig)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(null, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         ThreeDSecureResult threeDSecureResult = ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
@@ -389,7 +374,6 @@ public class ThreeDSecureV2UnitTest {
                 .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .build();
-        when(braintreeClient.assertCanPerformBrowserSwitch(activity, THREE_D_SECURE)).thenReturn(true);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, new ThreeDSecureAPI(braintreeClient));
         sut.setListener(listener);


### PR DESCRIPTION
### Summary of changes

 - In rare cases, browser switch fails in production for some users. It's difficult to reproduce this issue.
 - The browser switch library provides more information that may be helpful to diagnose an issue 
 - Appending original browser switch error message to error output will help resolve issues like #630

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
