### PR TITLE
Make `Authorization` Subclasses Library-Restricted 

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ClientToken.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ClientToken.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.util.Base64
+import androidx.annotation.RestrictTo
 import org.json.JSONException
 import org.json.JSONObject
 import java.lang.NullPointerException
@@ -15,8 +16,10 @@ import kotlin.jvm.Throws
  * @property customerId The customer ID in the authorizationFingerprint if it is present
  * @constructor Create a new [ClientToken] instance from a client token
  * @throws InvalidArgumentException when client token is invalid
+ * @suppress
  */
-internal class ClientToken @Throws(InvalidArgumentException::class) constructor(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class ClientToken @Throws(InvalidArgumentException::class) constructor(
     clientTokenString: String
 ) : Authorization(clientTokenString) {
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidAuthorization.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/InvalidAuthorization.kt
@@ -1,6 +1,12 @@
 package com.braintreepayments.api
 
-internal class InvalidAuthorization(rawValue: String, val errorMessage: String) :
+import androidx.annotation.RestrictTo
+
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class InvalidAuthorization(rawValue: String, val errorMessage: String) :
     Authorization(rawValue) {
 
     override val configUrl: String? = null

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/TokenizationKey.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/TokenizationKey.kt
@@ -1,7 +1,12 @@
 package com.braintreepayments.api
 
+import androidx.annotation.RestrictTo
 
-internal class TokenizationKey(tokenizationKey: String) : Authorization(tokenizationKey) {
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class TokenizationKey(tokenizationKey: String) : Authorization(tokenizationKey) {
 
     override val configUrl: String
     override val bearer: String = toString()


### PR DESCRIPTION
### Summary of changes

 - Fixes for DropIn issue [#396](https://github.com/braintree/braintree-android-drop-in/issues/396)
 - DropIn requires visibility of these classes to change behavior

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
