### PR TITLE
Add `BraintreeClient#deliverBrowserSwitchResultFromNewTask()` method

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.java
@@ -301,15 +301,30 @@ public class BraintreeClient {
         return browserSwitchClient.getResult(activity);
     }
 
+    /**
+     * Deliver a browser switch result from an Activity's pending deep link intent url.
+     * If {@link BraintreeClient#launchesBrowserSwitchAsNewTask(boolean)} is set to true,
+     * use {@link BraintreeClient#deliverBrowserSwitchResultFromNewTask(Context)} instead.
+     *
+     * @param activity
+     * @return {@link BrowserSwitchResult}
+     */
     public BrowserSwitchResult deliverBrowserSwitchResult(@NonNull FragmentActivity activity) {
         return browserSwitchClient.deliverResult(activity);
     }
 
-    BrowserSwitchResult getBrowserSwitchResultFromCache(@NonNull Context context) {
+    BrowserSwitchResult getBrowserSwitchResultFromNewTask(@NonNull Context context) {
         return browserSwitchClient.getResultFromCache(context);
     }
 
-    BrowserSwitchResult deliverBrowserSwitchResultFromCache(@NonNull Context context) {
+    /**
+     * Deliver pending browser switch result received by {@link BraintreeDeepLinkActivity} when
+     * {@link BraintreeClient#launchesBrowserSwitchAsNewTask(boolean)} is set to true.
+     *
+     * @param context
+     * @return {@link BrowserSwitchResult}
+     */
+    public BrowserSwitchResult deliverBrowserSwitchResultFromNewTask(@NonNull Context context) {
         return browserSwitchClient.deliverResultFromCache(context);
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.java
@@ -432,6 +432,17 @@ public class BraintreeClientUnitTest {
     }
 
     @Test
+    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBrowserSwitchClient() {
+        Context context = mock(Context.class);
+
+        BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
+        BraintreeClient sut = new BraintreeClient(params);
+
+        sut.deliverBrowserSwitchResultFromNewTask(context);
+        verify(browserSwitchClient).deliverResultFromCache(context);
+    }
+
+    @Test
     public void assertCanPerformBrowserSwitch_assertsBrowserSwitchIsPossible() throws BrowserSwitchException {
         BraintreeClientParams params = createDefaultParams(configurationLoader, authorizationLoader);
         BraintreeClient sut = new BraintreeClient(params);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* BraintreeCore
+  * Add `BraintreeClient#deliverBrowserSwitchResultFromNewTask()` method to allow browser switch results to be captured manually when `BraintreeClient#launchesBrowserSwitchAsNewTask()` is set to true.
 * SharedUtils
   * Replace EncryptedSharedPreferences with SharedPreferences for internal persistent data storage for all payment flows
   * Deprecate `BraintreeSharedPreferencesException`

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -230,12 +230,12 @@ public class LocalPaymentClient {
         return braintreeClient.deliverBrowserSwitchResult(activity);
     }
 
-    BrowserSwitchResult getBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.getBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult getBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.getBrowserSwitchResultFromNewTask(activity);
     }
 
-    BrowserSwitchResult deliverBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.deliverBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult deliverBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.deliverBrowserSwitchResultFromNewTask(activity);
     }
 
     /**

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentLifecycleObserver.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentLifecycleObserver.java
@@ -64,10 +64,10 @@ class LocalPaymentLifecycleObserver implements LifecycleEventObserver {
                         }
 
                         BrowserSwitchResult pendingResultFromCache =
-                                localPaymentClient.getBrowserSwitchResultFromCache(finalActivity);
+                                localPaymentClient.getBrowserSwitchResultFromNewTask(finalActivity);
                         if (pendingResultFromCache != null && pendingResultFromCache.getRequestCode() == LOCAL_PAYMENT) {
                             resultToDeliver =
-                                    localPaymentClient.deliverBrowserSwitchResultFromCache(finalActivity);
+                                    localPaymentClient.deliverBrowserSwitchResultFromNewTask(finalActivity);
                         }
 
                         if (resultToDeliver != null) {

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -682,19 +682,19 @@ public class LocalPaymentClientUnitTest {
     @Test
     public void getBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() {
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
-        when(braintreeClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
-        assertSame(browserSwitchResult, sut.getBrowserSwitchResultFromCache(activity));
+        assertSame(browserSwitchResult, sut.getBrowserSwitchResultFromNewTask(activity));
     }
 
     @Test
-    public void deliverBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() {
+    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBraintreeClient() {
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
-        when(braintreeClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
-        assertSame(browserSwitchResult, sut.deliverBrowserSwitchResultFromCache(activity));
+        assertSame(browserSwitchResult, sut.deliverBrowserSwitchResultFromNewTask(activity));
     }
 
     private LocalPaymentRequest getIdealLocalPaymentRequest() {

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentLifecycleObserverUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentLifecycleObserverUnitTest.java
@@ -68,8 +68,8 @@ public class LocalPaymentLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(LOCAL_PAYMENT);
 
         LocalPaymentClient localPaymentClient = mock(LocalPaymentClient.class);
-        when(localPaymentClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(localPaymentClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(localPaymentClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(localPaymentClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         LocalPaymentLifecycleObserver sut = new LocalPaymentLifecycleObserver(localPaymentClient);
 
@@ -86,8 +86,8 @@ public class LocalPaymentLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(LOCAL_PAYMENT);
 
         LocalPaymentClient localPaymentClient = mock(LocalPaymentClient.class);
-        when(localPaymentClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(localPaymentClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(localPaymentClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(localPaymentClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         LocalPaymentLifecycleObserver sut = new LocalPaymentLifecycleObserver(localPaymentClient);
 
@@ -121,7 +121,7 @@ public class LocalPaymentLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
 
         LocalPaymentClient localPaymentClient = mock(LocalPaymentClient.class);
-        when(localPaymentClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(localPaymentClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         LocalPaymentLifecycleObserver sut = new LocalPaymentLifecycleObserver(localPaymentClient);
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -307,12 +307,12 @@ public class PayPalClient {
         return braintreeClient.deliverBrowserSwitchResult(activity);
     }
 
-    BrowserSwitchResult getBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.getBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult getBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.getBrowserSwitchResultFromNewTask(activity);
     }
 
-    BrowserSwitchResult deliverBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.deliverBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult deliverBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.deliverBrowserSwitchResultFromNewTask(activity);
     }
 
     /**

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLifeCycleObserver.java
@@ -65,10 +65,10 @@ class PayPalLifecycleObserver implements LifecycleEventObserver {
                         }
 
                         BrowserSwitchResult pendingResultFromCache =
-                                payPalClient.getBrowserSwitchResultFromCache(finalActivity);
+                                payPalClient.getBrowserSwitchResultFromNewTask(finalActivity);
                         if (pendingResultFromCache != null && pendingResultFromCache.getRequestCode() == PAYPAL) {
                             resultToDeliver =
-                                    payPalClient.deliverBrowserSwitchResultFromCache(finalActivity);
+                                    payPalClient.deliverBrowserSwitchResultFromNewTask(finalActivity);
                         }
 
                         if (resultToDeliver != null) {

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -778,25 +778,25 @@ public class PayPalClientUnitTest {
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
 
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
-        when(braintreeClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
 
-        BrowserSwitchResult result = sut.getBrowserSwitchResultFromCache(activity);
+        BrowserSwitchResult result = sut.getBrowserSwitchResultFromNewTask(activity);
         assertSame(browserSwitchResult, result);
     }
 
     @Test
-    public void deliverBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() {
+    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBraintreeClient() {
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
 
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
-        when(braintreeClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
 
-        BrowserSwitchResult result = sut.deliverBrowserSwitchResultFromCache(activity);
+        BrowserSwitchResult result = sut.deliverBrowserSwitchResultFromNewTask(activity);
         assertSame(browserSwitchResult, result);
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalLifecycleObserverUnitTest.java
@@ -68,8 +68,8 @@ public class PayPalLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
 
         PayPalClient payPalClient = mock(PayPalClient.class);
-        when(payPalClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(payPalClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(payPalClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(payPalClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
 
@@ -86,8 +86,8 @@ public class PayPalLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
 
         PayPalClient payPalClient = mock(PayPalClient.class);
-        when(payPalClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(payPalClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(payPalClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(payPalClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
 
@@ -122,7 +122,7 @@ public class PayPalLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(THREE_D_SECURE);
 
         PayPalClient payPalClient = mock(PayPalClient.class);
-        when(payPalClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(payPalClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         PayPalLifecycleObserver sut = new PayPalLifecycleObserver(payPalClient);
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -620,12 +620,12 @@ public class ThreeDSecureClient {
         return braintreeClient.deliverBrowserSwitchResult(activity);
     }
 
-    BrowserSwitchResult getBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.getBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult getBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.getBrowserSwitchResultFromNewTask(activity);
     }
 
-    BrowserSwitchResult deliverBrowserSwitchResultFromCache(FragmentActivity activity) {
-        return braintreeClient.deliverBrowserSwitchResultFromCache(activity);
+    BrowserSwitchResult deliverBrowserSwitchResultFromNewTask(FragmentActivity activity) {
+        return braintreeClient.deliverBrowserSwitchResultFromNewTask(activity);
     }
 
     // endregion

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLifecycleObserver.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLifecycleObserver.java
@@ -88,10 +88,10 @@ class ThreeDSecureLifecycleObserver implements LifecycleEventObserver {
                             }
 
                             BrowserSwitchResult pendingResultFromCache =
-                                    threeDSecureClient.getBrowserSwitchResultFromCache(finalActivity);
+                                    threeDSecureClient.getBrowserSwitchResultFromNewTask(finalActivity);
                             if (pendingResultFromCache != null && pendingResultFromCache.getRequestCode() == THREE_D_SECURE) {
                                 resultToDeliver =
-                                        threeDSecureClient.deliverBrowserSwitchResultFromCache(finalActivity);
+                                        threeDSecureClient.deliverBrowserSwitchResultFromNewTask(finalActivity);
                             }
 
                             if (resultToDeliver != null) {

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -706,25 +706,25 @@ public class ThreeDSecureClientUnitTest {
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
-        when(braintreeClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
 
-        BrowserSwitchResult result = sut.getBrowserSwitchResultFromCache(activity);
+        BrowserSwitchResult result = sut.getBrowserSwitchResultFromNewTask(activity);
         assertSame(browserSwitchResult, result);
     }
 
     @Test
-    public void deliverBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() {
+    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBraintreeClient() {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
-        when(braintreeClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(braintreeClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, browserSwitchHelper, threeDSecureAPI);
 
-        BrowserSwitchResult result = sut.deliverBrowserSwitchResultFromCache(activity);
+        BrowserSwitchResult result = sut.deliverBrowserSwitchResultFromNewTask(activity);
         assertSame(browserSwitchResult, result);
     }
 }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLifecycleObserverUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLifecycleObserverUnitTest.java
@@ -132,8 +132,8 @@ public class ThreeDSecureLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(THREE_D_SECURE);
 
         ThreeDSecureClient threeDSecureClient = mock(ThreeDSecureClient.class);
-        when(threeDSecureClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(threeDSecureClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(threeDSecureClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(threeDSecureClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         ThreeDSecureLifecycleObserver sut = new ThreeDSecureLifecycleObserver(activityResultRegistry, threeDSecureClient);
 
@@ -151,8 +151,8 @@ public class ThreeDSecureLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(THREE_D_SECURE);
 
         ThreeDSecureClient threeDSecureClient = mock(ThreeDSecureClient.class);
-        when(threeDSecureClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
-        when(threeDSecureClient.deliverBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(threeDSecureClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
+        when(threeDSecureClient.deliverBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         ThreeDSecureLifecycleObserver sut = new ThreeDSecureLifecycleObserver(activityResultRegistry, threeDSecureClient);
 
@@ -189,7 +189,7 @@ public class ThreeDSecureLifecycleObserverUnitTest {
         when(browserSwitchResult.getRequestCode()).thenReturn(PAYPAL);
 
         ThreeDSecureClient threeDSecureClient = mock(ThreeDSecureClient.class);
-        when(threeDSecureClient.getBrowserSwitchResultFromCache(activity)).thenReturn(browserSwitchResult);
+        when(threeDSecureClient.getBrowserSwitchResultFromNewTask(activity)).thenReturn(browserSwitchResult);
 
         ThreeDSecureLifecycleObserver sut = new ThreeDSecureLifecycleObserver(activityResultRegistry, threeDSecureClient);
 


### PR DESCRIPTION
### Summary of changes

 - Add `BraintreeClient#deliverBrowserSwitchResultFromNewTask()` method to allow browser switch results to be captured manually when `BraintreeClient#launchesBrowserSwitchAsNewTask()` is set to true.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
