### PR TITLE
Paypal Client Add Listener `null` Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Fix issue that causes a null pointer exception when `PayPalClient` attempts to notify success or failure when the listener is `null`
+
 ## 4.26.0
+
 * PayPalNativeCheckout (BETA)
 
   * Fixes a bug where an error was not thrown inside `PayPalNativeCheckoutClient` when no PayPal response was received from the API

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -118,7 +118,7 @@ public class PayPalClient {
         tokenizePayPalAccount(activity, payPalRequest, new PayPalFlowStartedCallback() {
             @Override
             public void onResult(@Nullable Exception error) {
-                if (error != null) {
+                if (error != null && listener != null) {
                     listener.onPayPalFailure(error);
                 }
             }
@@ -287,9 +287,9 @@ public class PayPalClient {
         onBrowserSwitchResult(browserSwitchResult, new PayPalBrowserSwitchResultCallback() {
             @Override
             public void onResult(@Nullable PayPalAccountNonce payPalAccountNonce, @Nullable Exception error) {
-                if (payPalAccountNonce != null) {
+                if (payPalAccountNonce != null && listener != null) {
                     listener.onPayPalSuccess(payPalAccountNonce);
-                } else if (error != null) {
+                } else if (error != null && listener != null) {
                     listener.onPayPalFailure(error);
                 }
             }


### PR DESCRIPTION
### Summary of changes

 - Fix issue that causes a null pointer exception when `PayPalClient` attempts to notify success or failure when the listener is `null`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
