### PR TITLE
Make `DeviceInspector` Library Restricted

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/DeviceInspector.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/DeviceInspector.kt
@@ -7,10 +7,15 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.os.Build
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import java.io.File
 
-internal class DeviceInspector @VisibleForTesting constructor(
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DeviceInspector @VisibleForTesting internal constructor(
     private val appHelper: AppHelper,
     private val uuidHelper: UUIDHelper,
     private val signatureVerifier: SignatureVerifier,
@@ -26,7 +31,7 @@ internal class DeviceInspector @VisibleForTesting constructor(
     )
 
     @VisibleForTesting
-    fun getDeviceMetadata(
+    internal fun getDeviceMetadata(
         context: Context?,
         sessionId: String?,
         integration: String?,


### PR DESCRIPTION
### Summary of changes

 - `DeviceInspector` needs to be visible across module boundaries so `VenmoClient` can use it
 - Make `DeviceInspector` library-restricted to prevent merchant use

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
