### PR TITLE
Make UUIDHelper Library Restricted

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.kt
@@ -1,12 +1,18 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.braintreepayments.api.BraintreeSharedPreferences
 import com.braintreepayments.api.UUIDHelper
 import java.util.*
 
-internal class UUIDHelper {
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class UUIDHelper {
+
     /**
      * @param context Android Context
      * @return A persistent UUID for this application install.
@@ -16,7 +22,7 @@ internal class UUIDHelper {
     }
 
     @VisibleForTesting
-    fun getPersistentUUID(braintreeSharedPreferences: BraintreeSharedPreferences): String? {
+    internal fun getPersistentUUID(braintreeSharedPreferences: BraintreeSharedPreferences): String? {
         var uuid = braintreeSharedPreferences.getString(BRAINTREE_UUID_KEY, null)
         if (uuid == null) {
             uuid = formattedUUID
@@ -33,7 +39,7 @@ internal class UUIDHelper {
     }
 
     @VisibleForTesting
-    fun getInstallationGUID(braintreeSharedPreferences: BraintreeSharedPreferences): String {
+    internal fun getInstallationGUID(braintreeSharedPreferences: BraintreeSharedPreferences): String {
         var installationGUID = braintreeSharedPreferences.getString(INSTALL_GUID, null)
         if (installationGUID == null) {
             installationGUID = UUID.randomUUID().toString()


### PR DESCRIPTION
### Summary of changes

 - `UUIDHelper` is used accross module boundaries and needs to be library-restricted

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
