### PR TITLE
Make Browser Switch Methods on BraintreeClient Nullable to Fix Crash

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -300,7 +300,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun getBrowserSwitchResult(activity: FragmentActivity): BrowserSwitchResult =
+    fun getBrowserSwitchResult(activity: FragmentActivity): BrowserSwitchResult? =
         browserSwitchClient.getResult(activity)
 
     /**
@@ -311,7 +311,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param activity
      * @return [BrowserSwitchResult]
      */
-    fun deliverBrowserSwitchResult(activity: FragmentActivity): BrowserSwitchResult {
+    fun deliverBrowserSwitchResult(activity: FragmentActivity): BrowserSwitchResult? {
         return browserSwitchClient.deliverResult(activity)
     }
 
@@ -319,7 +319,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun getBrowserSwitchResultFromNewTask(context: Context): BrowserSwitchResult {
+    fun getBrowserSwitchResultFromNewTask(context: Context): BrowserSwitchResult? {
         return browserSwitchClient.getResultFromCache(context)
     }
 
@@ -330,7 +330,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param context
      * @return [BrowserSwitchResult]
      */
-    fun deliverBrowserSwitchResultFromNewTask(context: Context): BrowserSwitchResult {
+    fun deliverBrowserSwitchResultFromNewTask(context: Context): BrowserSwitchResult? {
         return browserSwitchClient.deliverResultFromCache(context)
     }
 


### PR DESCRIPTION
### Summary of changes

 - A few methods in `BraintreeClient` need to be nullable to prevent a crash caused by Java/Kotlin interop.
 - Integration tests are failing because Kotlin asserts non-null return values by default

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
- @KunJeongPark
