### PR TITLE
Fix `GooglePayNonce#isNetworkTokenized` Parcelable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* GooglePay
+  * Fix issue that causes `GooglePayNonce#isNetworkTokenized` to always return `false` after being parceled
+
 ## 4.26.1
 
 * BraintreeDataCollector

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -211,6 +211,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         dest.writeParcelable(billingAddress, flags);
         dest.writeParcelable(shippingAddress, flags);
         dest.writeParcelable(binData, flags);
+        dest.writeByte(isNetworkTokenized ? (byte) 1 : (byte) 0);
     }
 
     private GooglePayCardNonce(Parcel in) {
@@ -222,6 +223,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         billingAddress = in.readParcelable(PostalAddress.class.getClassLoader());
         shippingAddress = in.readParcelable(PostalAddress.class.getClassLoader());
         binData = in.readParcelable(BinData.class.getClassLoader());
+        isNetworkTokenized = in.readByte() > 0;
     }
 
     public static final Creator<GooglePayCardNonce> CREATOR = new Creator<GooglePayCardNonce>() {

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
@@ -105,6 +105,7 @@ public class GooglePayCardNonceUnitTest {
         assertEquals("11", parceled.getLastTwo());
         assertEquals("1234", parceled.getLastFour());
         assertEquals("android-user@example.com", parceled.getEmail());
+        assertTrue(parceled.isNetworkTokenized());
         assertPostalAddress(billingPostalAddress, parceled.getBillingAddress());
         assertPostalAddress(shippingPostalAddress, parceled.getShippingAddress());
 


### PR DESCRIPTION
### Summary of changes

 - Fix for https://github.com/braintree/braintree-android-drop-in/issues/405
 - Add `isNetworkTokenized` to `Parcelable` implementation for `GooglePayNonce`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
