### PR TITLE
Remove `fun` Interfaces

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.kt
@@ -6,6 +6,6 @@ import androidx.annotation.RestrictTo
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun interface AuthorizationCallback {
+interface AuthorizationCallback {
     fun onAuthorizationResult(authorization: Authorization?, error: Exception?)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -169,19 +169,24 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param callback [ConfigurationCallback]
      */
     open fun getConfiguration(callback: ConfigurationCallback) {
-        getAuthorization { authorization, authError ->
-            if (authorization != null) {
-                configurationLoader.loadConfiguration(authorization) { configuration, configError ->
-                    if (configuration != null) {
-                        callback.onResult(configuration, null)
-                    } else {
-                        callback.onResult(null, configError)
-                    }
+        getAuthorization(object : AuthorizationCallback {
+            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
+                if (authorization != null) {
+                    configurationLoader.loadConfiguration(authorization,
+                        object : ConfigurationLoaderCallback {
+                            override fun onResult(configuration: Configuration?, configError: Exception?) {
+                                if (configuration != null) {
+                                    callback.onResult(configuration, null)
+                                } else {
+                                    callback.onResult(null, configError)
+                                }
+                            }
+                        })
+                } else {
+                    callback.onResult(null, authError)
                 }
-            } else {
-                callback.onResult(null, authError)
             }
-        }
+        })
     }
 
     /**
@@ -197,13 +202,15 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendAnalyticsEvent(eventName: String) {
-        getAuthorization { authorization, _ ->
-            if (authorization != null) {
-                getConfiguration { configuration, _ ->
-                    sendAnalyticsEvent(eventName, configuration, authorization)
+        getAuthorization(object : AuthorizationCallback {
+            override fun onAuthorizationResult(authorization: Authorization?, error: Exception?) {
+                if (authorization != null) {
+                    getConfiguration { configuration, _ ->
+                        sendAnalyticsEvent(eventName, configuration, authorization)
+                    }
                 }
             }
-        }
+        })
     }
 
     private fun sendAnalyticsEvent(
@@ -227,19 +234,21 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendGET(url: String, responseCallback: HttpResponseCallback) {
-        getAuthorization { authorization, authError ->
-            if (authorization != null) {
-                getConfiguration { configuration, configError ->
-                    if (configuration != null) {
-                        httpClient.get(url, configuration, authorization, responseCallback)
-                    } else {
-                        responseCallback.onResult(null, configError)
+        getAuthorization(object : AuthorizationCallback {
+            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
+                if (authorization != null) {
+                    getConfiguration { configuration, configError ->
+                        if (configuration != null) {
+                            httpClient.get(url, configuration, authorization, responseCallback)
+                        } else {
+                            responseCallback.onResult(null, configError)
+                        }
                     }
+                } else {
+                    responseCallback.onResult(null, authError)
                 }
-            } else {
-                responseCallback.onResult(null, authError)
             }
-        }
+        })
     }
 
     /**
@@ -247,19 +256,27 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendPOST(url: String, data: String, responseCallback: HttpResponseCallback) {
-        getAuthorization { authorization, authError ->
-            if (authorization != null) {
-                getConfiguration { configuration, configError ->
-                    if (configuration != null) {
-                        httpClient.post(url, data, configuration, authorization, responseCallback)
-                    } else {
-                        responseCallback.onResult(null, configError)
+        getAuthorization(object : AuthorizationCallback {
+            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
+                if (authorization != null) {
+                    getConfiguration { configuration, configError ->
+                        if (configuration != null) {
+                            httpClient.post(
+                                url,
+                                data,
+                                configuration,
+                                authorization,
+                                responseCallback
+                            )
+                        } else {
+                            responseCallback.onResult(null, configError)
+                        }
                     }
+                } else {
+                    responseCallback.onResult(null, authError)
                 }
-            } else {
-                responseCallback.onResult(null, authError)
             }
-        }
+        })
     }
 
     /**
@@ -267,19 +284,26 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendGraphQLPOST(payload: String?, responseCallback: HttpResponseCallback) {
-        getAuthorization { authorization, authError ->
-            if (authorization != null) {
-                getConfiguration { configuration, configError ->
-                    if (configuration != null) {
-                        graphQLClient.post(payload, configuration, authorization, responseCallback)
-                    } else {
-                        responseCallback.onResult(null, configError)
+        getAuthorization(object : AuthorizationCallback {
+            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
+                if (authorization != null) {
+                    getConfiguration { configuration, configError ->
+                        if (configuration != null) {
+                            graphQLClient.post(
+                                payload,
+                                configuration,
+                                authorization,
+                                responseCallback
+                            )
+                        } else {
+                            responseCallback.onResult(null, configError)
+                        }
                     }
+                } else {
+                    responseCallback.onResult(null, authError)
                 }
-            } else {
-                responseCallback.onResult(null, authError)
             }
-        }
+        })
     }
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.kt
@@ -1,5 +1,5 @@
 package com.braintreepayments.api
 
-internal fun interface ConfigurationLoaderCallback {
+internal interface ConfigurationLoaderCallback {
     fun onResult(result: Configuration?, error: Exception?)
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/HttpResponseCallback.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/HttpResponseCallback.kt
@@ -7,7 +7,7 @@ import androidx.annotation.RestrictTo
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun interface HttpResponseCallback {
+interface HttpResponseCallback {
 
     @MainThread
     fun onResult(responseBody: String?, httpError: Exception?)


### PR DESCRIPTION
### Summary of changes

 - `fun interface` types in Kotlin rely on Java 8
 - By removing these functional interfaces, we can keep Java 7 support
 - All of the `fun interface` types in this PR are marked `library-private` or are `internal`
 - To prevent a breaking change, we should avoid refactoring Java callback types to adhere to [SAM](https://kotlinlang.org/docs/fun-interfaces.html)

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
