### PR TITLE
Fix for 3DS TransactionTooLargeException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Use `applicationContext` in `DataCollector#collectDeviceData()` callback to prevent potential `Activity` leaks
 * GooglePay
   * Fix issue that causes `GooglePayNonce#isNetworkTokenized` to always return `false` after being parceled
+* ThreeDSecure
+  * Catch `TransactionTooLargeException' to prevent crash on large data (fixes #642)
 
 ## 4.26.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * GooglePay
   * Fix issue that causes `GooglePayNonce#isNetworkTokenized` to always return `false` after being parceled
 * ThreeDSecure
-  * Catch `TransactionTooLargeException' to prevent crash on large data (fixes #642)
+  * Catch `TransactionTooLargeException` to prevent crash on large data (fixes #642)
 
 ## 4.26.1
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -421,7 +421,6 @@ public class ThreeDSecureClient {
         braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.started");
 
         try {
-
             if (observer != null) {
                 observer.launch(result);
             } else {
@@ -436,7 +435,12 @@ public class ThreeDSecureClient {
         } catch (RuntimeException runtimeException) {
             Throwable exceptionCause = runtimeException.getCause();
             if (exceptionCause instanceof TransactionTooLargeException) {
-                callback.onResult(null, (TransactionTooLargeException)exceptionCause);
+                String errorMessage = "The 3D Secure response returned is too large to continue.";
+                BraintreeException threeDSecureResponseTooLargeError =
+                    new BraintreeException(errorMessage, runtimeException);
+                callback.onResult(null, threeDSecureResponseTooLargeError);
+            } else {
+                throw runtimeException;
             }
         }
     }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.TransactionTooLargeException;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -418,16 +419,25 @@ public class ThreeDSecureClient {
 
         // perform cardinal authentication
         braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.started");
-        if (observer != null) {
-             observer.launch(result);
-        } else {
-            Bundle extras = new Bundle();
-            extras.putParcelable(ThreeDSecureActivity.EXTRA_THREE_D_SECURE_RESULT, result);
 
-            Intent intent = new Intent(activity, ThreeDSecureActivity.class);
-            intent.putExtras(extras);
+        try {
 
-            activity.startActivityForResult(intent, THREE_D_SECURE);
+            if (observer != null) {
+                observer.launch(result);
+            } else {
+                Bundle extras = new Bundle();
+                extras.putParcelable(ThreeDSecureActivity.EXTRA_THREE_D_SECURE_RESULT, result);
+
+                Intent intent = new Intent(activity, ThreeDSecureActivity.class);
+                intent.putExtras(extras);
+
+                activity.startActivityForResult(intent, THREE_D_SECURE);
+            }
+        } catch (RuntimeException runtimeException) {
+            Throwable exceptionCause = runtimeException.getCause();
+            if (exceptionCause instanceof TransactionTooLargeException) {
+                callback.onResult(null, (TransactionTooLargeException)exceptionCause);
+            }
         }
     }
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -435,7 +435,8 @@ public class ThreeDSecureClient {
         } catch (RuntimeException runtimeException) {
             Throwable exceptionCause = runtimeException.getCause();
             if (exceptionCause instanceof TransactionTooLargeException) {
-                String errorMessage = "The 3D Secure response returned is too large to continue.";
+                String errorMessage = "The 3D Secure response returned is too large to continue. "
+                        + "Please contact Braintree Support for assistance.";
                 BraintreeException threeDSecureResponseTooLargeError =
                     new BraintreeException(errorMessage, runtimeException);
                 callback.onResult(null, threeDSecureResponseTooLargeError);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -398,7 +398,9 @@ public class ThreeDSecureV2UnitTest {
         verify(callback).onResult((ThreeDSecureResult) isNull(), captor.capture());
 
         BraintreeException braintreeException = captor.getValue();
-        assertEquals("The 3D Secure response returned is too large to continue.", braintreeException.getMessage());
+        String expectedMessage = "The 3D Secure response returned is too large to continue. "
+                + "Please contact Braintree Support for assistance.";
+        assertEquals(expectedMessage, braintreeException.getMessage());
     }
 
     @Test
@@ -456,7 +458,9 @@ public class ThreeDSecureV2UnitTest {
         verify(listener).onThreeDSecureFailure(captor.capture());
 
         BraintreeException braintreeException = captor.getValue();
-        assertEquals("The 3D Secure response returned is too large to continue.", braintreeException.getMessage());
+        String expectedMessage = "The 3D Secure response returned is too large to continue. "
+                + "Please contact Braintree Support for assistance.";
+        assertEquals(expectedMessage, braintreeException.getMessage());
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript {
 
             "junit"                      : "junit:junit:4.13",
             "junitTest"                  : "androidx.test.ext:junit:1.1.3",
-            "robolectric"                : "org.robolectric:robolectric:4.1",
+            "robolectric"                : "org.robolectric:robolectric:4.9.2",
             "dexmakerMockito"            : "com.google.dexmaker:dexmaker-mockito:1.2",
             "mockitoCore"                : "org.mockito:mockito-core:3.6.0",
             "jsonAssert"                 : "org.skyscreamer:jsonassert:1.5.0",

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript {
 
             "junit"                      : "junit:junit:4.13",
             "junitTest"                  : "androidx.test.ext:junit:1.1.3",
-            "robolectric"                : "org.robolectric:robolectric:4.9.2",
+            "robolectric"                : "org.robolectric:robolectric:4.1",
             "dexmakerMockito"            : "com.google.dexmaker:dexmaker-mockito:1.2",
             "mockitoCore"                : "org.mockito:mockito-core:3.6.0",
             "jsonAssert"                 : "org.skyscreamer:jsonassert:1.5.0",


### PR DESCRIPTION
### Summary of changes
  
 - fix for #642 
 - In `ThreeDSecureClient`, before launching `ThreeDSecureActivity`, we add check for `TransactionTooLargeException`

 ### Checklist

 - [x] Added a changelog entry

### Authors
@sshropshire @KunJeongPark 
