### PR TITLE
Catch Cardinal Null Pointer Exception and General Cleanup

### DIFF
--- a/BraintreeCore/src/androidTest/AndroidManifest.xml
+++ b/BraintreeCore/src/androidTest/AndroidManifest.xml
@@ -3,8 +3,7 @@
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 
-    <application
-        android:usesCleartextTraffic="true">
+    <application>
 
         <!--suppress AndroidDomInspection -->
         <activity android:name=".TestActivity" />

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AuthorizationCallback.kt
@@ -6,6 +6,6 @@ import androidx.annotation.RestrictTo
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface AuthorizationCallback {
+fun interface AuthorizationCallback {
     fun onAuthorizationResult(authorization: Authorization?, error: Exception?)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -169,24 +169,19 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param callback [ConfigurationCallback]
      */
     open fun getConfiguration(callback: ConfigurationCallback) {
-        getAuthorization(object : AuthorizationCallback {
-            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
-                if (authorization != null) {
-                    configurationLoader.loadConfiguration(authorization,
-                        object : ConfigurationLoaderCallback {
-                            override fun onResult(configuration: Configuration?, configError: Exception?) {
-                                if (configuration != null) {
-                                    callback.onResult(configuration, null)
-                                } else {
-                                    callback.onResult(null, configError)
-                                }
-                            }
-                        })
-                } else {
-                    callback.onResult(null, authError)
+        getAuthorization { authorization, authError ->
+            if (authorization != null) {
+                configurationLoader.loadConfiguration(authorization) { configuration, configError ->
+                    if (configuration != null) {
+                        callback.onResult(configuration, null)
+                    } else {
+                        callback.onResult(null, configError)
+                    }
                 }
+            } else {
+                callback.onResult(null, authError)
             }
-        })
+        }
     }
 
     /**
@@ -202,15 +197,13 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendAnalyticsEvent(eventName: String) {
-        getAuthorization(object : AuthorizationCallback {
-            override fun onAuthorizationResult(authorization: Authorization?, error: Exception?) {
-                if (authorization != null) {
-                    getConfiguration { configuration, _ ->
-                        sendAnalyticsEvent(eventName, configuration, authorization)
-                    }
+        getAuthorization { authorization, _ ->
+            if (authorization != null) {
+                getConfiguration { configuration, _ ->
+                    sendAnalyticsEvent(eventName, configuration, authorization)
                 }
             }
-        })
+        }
     }
 
     private fun sendAnalyticsEvent(
@@ -234,21 +227,19 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendGET(url: String, responseCallback: HttpResponseCallback) {
-        getAuthorization(object : AuthorizationCallback {
-            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
-                if (authorization != null) {
-                    getConfiguration { configuration, configError ->
-                        if (configuration != null) {
-                            httpClient.get(url, configuration, authorization, responseCallback)
-                        } else {
-                            responseCallback.onResult(null, configError)
-                        }
+        getAuthorization { authorization, authError ->
+            if (authorization != null) {
+                getConfiguration { configuration, configError ->
+                    if (configuration != null) {
+                        httpClient.get(url, configuration, authorization, responseCallback)
+                    } else {
+                        responseCallback.onResult(null, configError)
                     }
-                } else {
-                    responseCallback.onResult(null, authError)
                 }
+            } else {
+                responseCallback.onResult(null, authError)
             }
-        })
+        }
     }
 
     /**
@@ -256,27 +247,25 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendPOST(url: String, data: String, responseCallback: HttpResponseCallback) {
-        getAuthorization(object : AuthorizationCallback {
-            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
-                if (authorization != null) {
-                    getConfiguration { configuration, configError ->
-                        if (configuration != null) {
-                            httpClient.post(
-                                url,
-                                data,
-                                configuration,
-                                authorization,
-                                responseCallback
-                            )
-                        } else {
-                            responseCallback.onResult(null, configError)
-                        }
+        getAuthorization { authorization, authError ->
+            if (authorization != null) {
+                getConfiguration { configuration, configError ->
+                    if (configuration != null) {
+                        httpClient.post(
+                            url,
+                            data,
+                            configuration,
+                            authorization,
+                            responseCallback
+                        )
+                    } else {
+                        responseCallback.onResult(null, configError)
                     }
-                } else {
-                    responseCallback.onResult(null, authError)
                 }
+            } else {
+                responseCallback.onResult(null, authError)
             }
-        })
+        }
     }
 
     /**
@@ -284,26 +273,24 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun sendGraphQLPOST(payload: String?, responseCallback: HttpResponseCallback) {
-        getAuthorization(object : AuthorizationCallback {
-            override fun onAuthorizationResult(authorization: Authorization?, authError: Exception?) {
-                if (authorization != null) {
-                    getConfiguration { configuration, configError ->
-                        if (configuration != null) {
-                            graphQLClient.post(
-                                payload,
-                                configuration,
-                                authorization,
-                                responseCallback
-                            )
-                        } else {
-                            responseCallback.onResult(null, configError)
-                        }
+        getAuthorization { authorization, authError ->
+            if (authorization != null) {
+                getConfiguration { configuration, configError ->
+                    if (configuration != null) {
+                        graphQLClient.post(
+                            payload,
+                            configuration,
+                            authorization,
+                            responseCallback
+                        )
+                    } else {
+                        responseCallback.onResult(null, configError)
                     }
-                } else {
-                    responseCallback.onResult(null, authError)
                 }
+            } else {
+                responseCallback.onResult(null, authError)
             }
-        })
+        }
     }
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/CardConfiguration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/CardConfiguration.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api
 
 import org.json.JSONArray
 import org.json.JSONObject
-import kotlin.collections.ArrayList
 
 /**
  * Contains the remote card configuration for the Braintree SDK.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ConfigurationLoaderCallback.kt
@@ -1,5 +1,5 @@
 package com.braintreepayments.api
 
-internal interface ConfigurationLoaderCallback {
+internal fun interface ConfigurationLoaderCallback {
     fun onResult(result: Configuration?, error: Exception?)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/KountConfiguration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/KountConfiguration.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
  * @property kountMerchantId the Kount Merchant Id.
  * @property isEnabled `true` if Kount is enabled, `false` otherwise.
  */
-internal data class KountConfiguration private constructor(val kountMerchantId: String) {
+internal data class KountConfiguration internal constructor(val kountMerchantId: String) {
 
     constructor(json: JSONObject?) : this(Json.optString(json, KOUNT_MERCHANT_ID_KEY, ""))
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/PaymentMethod.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/PaymentMethod.kt
@@ -31,7 +31,11 @@ abstract class PaymentMethod {
 
     abstract val apiPath: String?
 
-    internal constructor()
+    /**
+     * @suppress
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor()
 
     /**
      * Sets the integration method associated with the tokenization call for analytics use.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/SamsungPayConfiguration.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/SamsungPayConfiguration.kt
@@ -3,7 +3,6 @@ package com.braintreepayments.api
 import android.text.TextUtils
 import org.json.JSONArray
 import org.json.JSONObject
-import kotlin.collections.ArrayList
 
 /**
  * Contains the remote Samsung Pay configuration for the Braintree SDK.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/UUIDHelper.kt
@@ -3,8 +3,6 @@ package com.braintreepayments.api
 import android.content.Context
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
-import com.braintreepayments.api.BraintreeSharedPreferences
-import com.braintreepayments.api.UUIDHelper
 import java.util.*
 
 /**

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/DeviceInspectorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/DeviceInspectorUnitTest.kt
@@ -1,25 +1,24 @@
 package com.braintreepayments.api
 
-import org.robolectric.RobolectricTestRunner
-import android.net.ConnectivityManager
-import android.content.pm.PackageManager
-import org.robolectric.util.ReflectionHelpers
-import android.os.Build.VERSION
-import android.content.pm.ApplicationInfo
-import android.net.NetworkInfo
-import android.content.Intent
 import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
 import android.os.Build
+import android.os.Build.VERSION
 import io.mockk.*
 import org.json.JSONException
-import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
 import java.io.File
 
 @RunWith(RobolectricTestRunner::class)

--- a/BraintreeDataCollector/src/androidTest/AndroidManifest.xml
+++ b/BraintreeDataCollector/src/androidTest/AndroidManifest.xml
@@ -3,8 +3,7 @@
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 
-    <application
-        android:usesCleartextTraffic="true">
+    <application>
 
         <!--suppress AndroidDomInspection -->
         <activity android:name=".TestActivity" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ThreeDSecure
+  * Catch Null Pointer Exception in `ThreeDSecureActivity` to prevent crash (fixes #715)
+
 ## 4.27.0
 
 * DataCollector

--- a/Card/src/androidTest/AndroidManifest.xml
+++ b/Card/src/androidTest/AndroidManifest.xml
@@ -3,8 +3,7 @@
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 
-    <application
-        android:usesCleartextTraffic="true">
+    <application>
 
         <!--suppress AndroidDomInspection -->
         <activity android:name=".TestActivity" />

--- a/Demo/src/debug/AndroidManifest.xml
+++ b/Demo/src/debug/AndroidManifest.xml
@@ -10,7 +10,6 @@
         android:label="@string/app_name"
         android:theme="@style/DemoAppTheme"
         android:name=".DemoApplication"
-        android:usesCleartextTraffic="true"
         tools:replace="android:allowBackup">
 
         <meta-data android:name="com.google.android.gms.wallet.api.enabled" android:value="true" />

--- a/LocalPayment/src/androidTest/AndroidManifest.xml
+++ b/LocalPayment/src/androidTest/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 
-    <application android:usesCleartextTraffic="true">
+    <application>
 
         <!--suppress AndroidDomInspection -->
         <activity android:name=".TestActivity" />

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
@@ -44,7 +44,7 @@ class CardinalClient {
         try {
             Cardinal.getInstance().cca_continue(transactionId, paReq, activity, validateReceiver);
         } catch (NullPointerException e) {
-            throw new BraintreeException("Cardinal SDK Error");
+            throw new BraintreeException("Cardinal SDK Error.", e);
         }
     }
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
@@ -18,7 +18,7 @@ class CardinalClient {
     CardinalClient () {}
 
     void initialize(Context context, Configuration configuration, final ThreeDSecureRequest request, final CardinalInitializeCallback callback) {
-        configurationCardinal(context, configuration, request);
+        configureCardinal(context, configuration, request);
         Cardinal.getInstance().init(configuration.getCardinalAuthenticationJwt(), new CardinalInitService() {
             @Override
             public void onSetupCompleted(String sessionId) {
@@ -37,14 +37,18 @@ class CardinalClient {
         });
     }
 
-    void continueLookup(FragmentActivity activity, ThreeDSecureResult threeDSecureResult, CardinalValidateReceiver validateReceiver) {
+    void continueLookup(FragmentActivity activity, ThreeDSecureResult threeDSecureResult, CardinalValidateReceiver validateReceiver) throws BraintreeException {
         ThreeDSecureLookup lookup = threeDSecureResult.getLookup();
         String transactionId = lookup.getTransactionId();
         String paReq = lookup.getPareq();
-        Cardinal.getInstance().cca_continue(transactionId, paReq, activity, validateReceiver);
+        try {
+            Cardinal.getInstance().cca_continue(transactionId, paReq, activity, validateReceiver);
+        } catch (NullPointerException e) {
+            throw new BraintreeException("Cardinal SDK Error");
+        }
     }
 
-    private void configurationCardinal(Context context, Configuration configuration, ThreeDSecureRequest request) {
+    private void configureCardinal(Context context, Configuration configuration, ThreeDSecureRequest request) {
         CardinalEnvironment cardinalEnvironment = CardinalEnvironment.STAGING;
         if ("production".equalsIgnoreCase(configuration.getEnvironment())) {
             cardinalEnvironment = CardinalEnvironment.PRODUCTION;

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
@@ -40,13 +40,21 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
 
         ThreeDSecureResult threeDSecureResult = extras.getParcelable(EXTRA_THREE_D_SECURE_RESULT);
         if (threeDSecureResult != null) {
-            cardinalClient.continueLookup(this, threeDSecureResult, this);
+            try {
+                cardinalClient.continueLookup(this, threeDSecureResult, this);
+            } catch (BraintreeException e) {
+                finishWithError(e.getMessage());
+            }
         } else {
-            Intent result = new Intent();
-            result.putExtra(EXTRA_ERROR_MESSAGE, "Unable to launch 3DS authentication.");
-            setResult(RESULT_COULD_NOT_START_CARDINAL, result);
-            finish();
+            finishWithError("Unable to launch 3DS authentication.");
         }
+    }
+
+    private void finishWithError(String errorMessage) {
+        Intent result = new Intent();
+        result.putExtra(EXTRA_ERROR_MESSAGE, errorMessage);
+        setResult(RESULT_COULD_NOT_START_CARDINAL, result);
+        finish();
     }
 
     @Override

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
@@ -144,7 +144,7 @@ public class CardinalClientUnitTest {
     }
 
     @Test
-    public void continueLookup_continuesCardinalLookup() {
+    public void continueLookup_continuesCardinalLookup() throws BraintreeException {
         when(Cardinal.getInstance()).thenReturn(cardinalInstance);
         CardinalClient sut = new CardinalClient();
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
@@ -1,15 +1,21 @@
 package com.braintreepayments.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+import android.app.Activity;
 import android.content.Context;
 
 import androidx.fragment.app.FragmentActivity;
@@ -163,5 +169,29 @@ public class CardinalClientUnitTest {
                 activity,
                 cardinalValidateReceiver
         );
+    }
+
+    @Test
+    public void continueLookup_onCardinalNullPointerException_throwsError() {
+        when(Cardinal.getInstance()).thenReturn(cardinalInstance);
+        NullPointerException nullPointerException = new NullPointerException("fake message");
+        doThrow(nullPointerException)
+                .when(cardinalInstance).cca_continue(anyString(), anyString(), any(Activity.class), any(CardinalValidateReceiver.class));
+        CardinalClient sut = new CardinalClient();
+
+        ThreeDSecureLookup threeDSecureLookup = mock(ThreeDSecureLookup.class);
+        when(threeDSecureLookup.getTransactionId()).thenReturn("sample-transaction-id");
+        when(threeDSecureLookup.getPareq()).thenReturn("sample-payer-authentication-request");
+
+        ThreeDSecureResult threeDSecureResult = mock(ThreeDSecureResult.class);
+        when(threeDSecureResult.getLookup()).thenReturn(threeDSecureLookup);
+
+        try {
+            sut.continueLookup(activity, threeDSecureResult, cardinalValidateReceiver);
+            fail("should not get here");
+        } catch (BraintreeException e) {
+            assertEquals("Cardinal SDK Error.", e.getMessage());
+            assertSame(nullPointerException, e.getCause());
+        }
     }
 }

--- a/UnionPay/src/androidTest/AndroidManifest.xml
+++ b/UnionPay/src/androidTest/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
 
-    <application android:usesCleartextTraffic="true">
+    <application>
 
         <!--suppress AndroidDomInspection -->
         <activity android:name=".TestActivity" />

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
 
     ext.versions = [
-            "kotlin"         : "1.5.32",
+            "kotlin"         : "1.7.20",
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
-        jcenter()
     }
 
     def sdkTargetJavaVersion = JavaVersion.VERSION_1_8
@@ -141,7 +140,6 @@ subprojects {
         flatDir {
             dirs "${rootDir}/libs"
         }
-        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
 
     ext.versions = [
-            "kotlin"         : "1.7.20",
+            "kotlin"         : "1.5.32",
             "androidxTest"   : "1.4.0",
             "powermock"      : '2.0.9',
             "powermockLegacy": "1.7.4",


### PR DESCRIPTION
### Summary of changes

 - Catch Null Pointer Exception that can be thrown by `Cardinal.cca_continue()`
 - Remove `android:usesCleartextTraffic` from `AndroidManifest.xml` files
 - Make `AuthorizationCallback` and `ConfigurationLoaderCallback` functional interfaces
 - Remove unnecessary imports and address linting errors

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
