### PR TITLE
Catch All Cardinal Runtime Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ThreeDSecure
+  * Guard `ThreeDSecureClient` against potential Cardinal SDK runtime exceptions
+
 ## 4.27.1
 
 * ThreeDSecure

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -159,7 +159,7 @@ public class ThreeDSecureClient {
                     }
                     braintreeClient.sendAnalyticsEvent("three-d-secure.initialized");
 
-                    cardinalClient.initialize(activity, configuration, request, new CardinalInitializeCallback() {
+                    CardinalInitializeCallback cardinalInitializeCallback = new CardinalInitializeCallback() {
                         @Override
                         public void onResult(String consumerSessionId, Exception error) {
                             if (consumerSessionId != null) {
@@ -170,7 +170,13 @@ public class ThreeDSecureClient {
                                 braintreeClient.sendAnalyticsEvent("three-d-secure.cardinal-sdk.init.setup-failed");
                             }
                         }
-                    });
+                    };
+
+                    try {
+                        cardinalClient.initialize(activity, configuration, request, cardinalInitializeCallback);
+                    } catch (BraintreeException initializeException) {
+                        callback.onResult(null, initializeException);
+                    }
                 }
             }
         });
@@ -215,7 +221,7 @@ public class ThreeDSecureClient {
                                 return;
                             }
 
-                            cardinalClient.initialize(context, configuration, request, new CardinalInitializeCallback() {
+                            CardinalInitializeCallback cardinalInitializeCallback = new CardinalInitializeCallback() {
                                 @Override
                                 public void onResult(String consumerSessionId, Exception error) {
                                     if (consumerSessionId != null) {
@@ -226,7 +232,13 @@ public class ThreeDSecureClient {
                                     }
                                     callback.onResult(request, lookupJSON.toString(), null);
                                 }
-                            });
+                            };
+
+                            try {
+                                cardinalClient.initialize(context, configuration, request, cardinalInitializeCallback);
+                            } catch (BraintreeException initializeException) {
+                                callback.onResult(null, null, initializeException);
+                            }
                         }
                     });
                 } else {

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.java
@@ -173,7 +173,23 @@ public class CardinalClientUnitTest {
 
     @Test
     public void initialize_onCardinalInitRuntimeException_throwsError() {
+        when(Cardinal.getInstance()).thenReturn(cardinalInstance);
+        when(configuration.getCardinalAuthenticationJwt()).thenReturn("token");
+        CardinalClient sut = new CardinalClient();
 
+        RuntimeException runtimeException = new RuntimeException("fake message");
+        doThrow(runtimeException)
+                .when(cardinalInstance)
+                .init(anyString(), any(CardinalInitService.class));
+
+        ThreeDSecureRequest request = new ThreeDSecureRequest();
+        try {
+            sut.initialize(context, configuration, request, cardinalInitializeCallback);
+            fail("should not get here");
+        } catch (BraintreeException e) {
+            assertEquals("Cardinal SDK init Error.", e.getMessage());
+            assertSame(runtimeException, e.getCause());
+        }
     }
 
     @Test

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/MockCardinalClientBuilder.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/MockCardinalClientBuilder.java
@@ -25,7 +25,7 @@ public class MockCardinalClientBuilder {
         return this;
     }
 
-    public CardinalClient build() {
+    public CardinalClient build() throws BraintreeException {
         CardinalClient cardinalClient = mock(CardinalClient.class);
         when(cardinalClient.getConsumerSessionId()).thenReturn(successReferenceId);
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -86,7 +86,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_sendsAnalyticEvent() {
+    public void performVerification_sendsAnalyticEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("sample-session-id")
                 .build();
@@ -102,7 +102,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_sendsParamsInLookupRequest() throws JSONException {
+    public void performVerification_sendsParamsInLookupRequest() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -136,7 +136,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_performsLookup_WhenCardinalSDKInitFails() throws JSONException {
+    public void performVerification_performsLookup_WhenCardinalSDKInitFails() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("error"))
                 .build();
@@ -175,7 +175,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_callsLookupListener() {
+    public void performVerification_callsLookupListener() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("sample-session-id")
                 .build();
@@ -202,7 +202,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_withInvalidRequest_postsException() {
+    public void performVerification_withInvalidRequest_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -221,7 +221,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_whenV1_throwsAnError() {
+    public void performVerification_whenV1_throwsAnError() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(threeDSecureEnabledConfig)
@@ -241,7 +241,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onActivityResult_whenResultNotOk_postsExceptionToCallback() {
+    public void onActivityResult_whenResultNotOk_postsExceptionToCallback() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -261,7 +261,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenSuccessful_postsPayment() {
+    public void onBrowserSwitchResult_whenSuccessful_postsPayment() throws BraintreeException {
         Uri uri = Uri.parse("http://demo-app.com")
                 .buildUpon()
                 .appendQueryParameter("auth_response", Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
@@ -290,7 +290,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenSuccessful_sendAnalyticsEvents() {
+    public void onBrowserSwitchResult_whenSuccessful_sendAnalyticsEvents() throws BraintreeException {
         Uri uri = Uri.parse("http://demo-app.com")
                 .buildUpon()
                 .appendQueryParameter("auth_response", Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
@@ -340,7 +340,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenBrowserSwitchStatusCanceled_returnsExceptionToCallback() {
+    public void onBrowserSwitchResult_whenBrowserSwitchStatusCanceled_returnsExceptionToCallback() throws BraintreeException {
         BrowserSwitchResult browserSwitchResult =
                 new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, null, null);
 
@@ -362,7 +362,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onBrowserSwitchResult_whenListenerNull_setsPendingBrowserSwitchResult_andDoesNotDeliver() {
+    public void onBrowserSwitchResult_whenListenerNull_setsPendingBrowserSwitchResult_andDoesNotDeliver() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
@@ -377,7 +377,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenErrorExists_forwardsErrorToListener_andSendsAnalytics() {
+    public void onCardinalResult_whenErrorExists_forwardsErrorToListener_andSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -393,7 +393,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_onSuccess_sendsAnalyticsEvent() {
+    public void onCardinalResult_onSuccess_sendsAnalyticsEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -411,7 +411,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseTimeout_returnsErrorAndSendsAnalytics() {
+    public void onCardinalResult_whenValidateResponseTimeout_returnsErrorAndSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -435,7 +435,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseCancel_returnsUserCanceledErrorAndSendsAnalytics() {
+    public void onCardinalResult_whenValidateResponseCancel_returnsUserCanceledErrorAndSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -460,7 +460,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResult_returnsResultAndSendsAnalytics() {
+    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResult_returnsResultAndSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -491,7 +491,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResultWithError_returnsResultAndSendsAnalytics() {
+    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResultWithError_returnsResultAndSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -523,7 +523,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTError_returnsErrorAndSendsAnalytics() {
+    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTError_returnsErrorAndSendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -554,7 +554,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void constructor_setsLifecycleObserver() {
+    public void constructor_setsLifecycleObserver() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -611,7 +611,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void setListener_whenPendingBrowserSwitchResultExists_deliversResultToListener_andSetsPendingResultNull() {
+    public void setListener_whenPendingBrowserSwitchResultExists_deliversResultToListener_andSetsPendingResultNull() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         Uri uri = Uri.parse("http://demo-app.com")
@@ -634,7 +634,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void setListener_whenPendingBrowserSwitchResultDoesNotExist_doesNotInvokeListener() {
+    public void setListener_whenPendingBrowserSwitchResultDoesNotExist_doesNotInvokeListener() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -649,7 +649,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void getBrowserSwitchResult_forwardsInvocationToBraintreeClient() {
+    public void getBrowserSwitchResult_forwardsInvocationToBraintreeClient() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 
@@ -663,7 +663,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void deliverBrowserSwitchResult_forwardsInvocationToBraintreeClient() {
+    public void deliverBrowserSwitchResult_forwardsInvocationToBraintreeClient() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 
@@ -677,7 +677,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void getBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() {
+    public void getBrowserSwitchResultFromCache_forwardsInvocationToBraintreeClient() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 
@@ -691,7 +691,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBraintreeClient() {
+    public void deliverBrowserSwitchResultFromNewTask_forwardsInvocationToBraintreeClient() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -159,6 +159,26 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
+    public void prepareLookup_whenCardinalClientInitializeFails_forwardsError() throws BraintreeException {
+        BraintreeException initializeRuntimeError = new BraintreeException("initialize error");
+        CardinalClient cardinalClient = new MockCardinalClientBuilder()
+                .initializeRuntimeError(initializeRuntimeError)
+                .build();
+
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
+                .configuration(threeDSecureEnabledConfig)
+                .build();
+
+        ThreeDSecureClient sut = new ThreeDSecureClient(activity, lifecycle, braintreeClient, cardinalClient, new ThreeDSecureAPI(braintreeClient));
+
+        ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
+        sut.prepareLookup(activity, basicRequest, callback);
+
+        verify(callback).onResult(null, null, initializeRuntimeError);
+    }
+
+    @Test
     public void prepareLookup_withoutCardinalJWT_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         Configuration configuration = new TestConfigurationBuilder()

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureV2UnitTest.java
@@ -78,7 +78,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_returnsValidLookupJSONString() throws JSONException {
+    public void prepareLookup_returnsValidLookupJSONString() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("fake-df")
                 .build();
@@ -110,7 +110,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_returnsValidLookupJSONString_whenCardinalSetupFails() throws JSONException {
+    public void prepareLookup_returnsValidLookupJSONString_whenCardinalSetupFails() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("cardinal error"))
                 .build();
@@ -141,7 +141,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_initializesCardinal() {
+    public void prepareLookup_initializesCardinal() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("fake-df")
                 .build();
@@ -160,7 +160,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void prepareLookup_withoutCardinalJWT_postsException() {
+    public void prepareLookup_withoutCardinalJWT_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         Configuration configuration = new TestConfigurationBuilder()
                 .threeDSecureEnabled(true)
@@ -185,7 +185,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_initializesCardinal() {
+    public void performVerification_initializesCardinal() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -203,7 +203,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_whenCardinalSetupCompleted_sendsAnalyticEvent() {
+    public void performVerification_whenCardinalSetupCompleted_sendsAnalyticEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -221,7 +221,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_whenCardinalSetupFailed_sendsAnalyticEvent() {
+    public void performVerification_whenCardinalSetupFailed_sendsAnalyticEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("cardinal error"))
                 .build();
@@ -239,7 +239,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenAuthenticatingWithCardinal_sendsAnalyticsEvent() throws JSONException {
+    public void continuePerformVerification_whenAuthenticatingWithCardinal_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -261,7 +261,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsPresented_sendsAnalyticsEvent() throws JSONException {
+    public void continuePerformVerification_whenChallengeIsPresented_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -282,7 +282,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsNotPresented_sendsAnalyticsEvent() throws JSONException {
+    public void continuePerformVerification_whenChallengeIsNotPresented_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -302,7 +302,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsNotPresented_returnsResult() throws JSONException {
+    public void continuePerformVerification_whenChallengeIsNotPresented_returnsResult() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -322,7 +322,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_when3DSVersionIsVersion2_sendsAnalyticsEvent() throws JSONException {
+    public void continuePerformVerification_when3DSVersionIsVersion2_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -344,7 +344,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenObserverIsNull_startsActivity() throws JSONException {
+    public void continuePerformVerification_whenObserverIsNull_startsActivity() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -363,7 +363,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenObserverIsNullAndTransactionIsTooLarge_callsBackAnException() throws JSONException {
+    public void continuePerformVerification_whenObserverIsNullAndTransactionIsTooLarge_callsBackAnException() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -397,7 +397,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_whenObserverIsNullAndRuntimeExceptionThrown_rethrowsException() throws JSONException {
+    public void continuePerformVerification_whenObserverIsNullAndRuntimeExceptionThrown_rethrowsException() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -424,7 +424,7 @@ public class ThreeDSecureV2UnitTest {
         }
     }
     @Test
-    public void continuePerformVerification_withObserverAndTransactionIsTooLarge_callsBackAnException() throws JSONException {
+    public void continuePerformVerification_withObserverAndTransactionIsTooLarge_callsBackAnException() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -457,7 +457,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void continuePerformVerification_withObserverAndRuntimeExceptionThrown_rethrowsException() throws JSONException {
+    public void continuePerformVerification_withObserverAndRuntimeExceptionThrown_rethrowsException() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
                 .build();
@@ -485,7 +485,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void performVerification_withoutCardinalJWT_postsException() {
+    public void performVerification_withoutCardinalJWT_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         Configuration configuration = new TestConfigurationBuilder()
@@ -511,7 +511,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_sendsAnalyticsEvent() throws JSONException {
+    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         ThreeDSecureAPI threeDSecureAPI = mock(ThreeDSecureAPI.class);
 
@@ -544,7 +544,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_whenResultWithError_sendsAnalytics() {
+    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_whenResultWithError_sendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         ThreeDSecureAPI threeDSecureAPI = mock(ThreeDSecureAPI.class);
 
@@ -576,7 +576,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_whenAuthenticateJWTReturnsError_sendsAnalytics() {
+    public void onActivityResult_whenCardinalCardVerificationReportsSuccess_whenAuthenticateJWTReturnsError_sendsAnalytics() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         ThreeDSecureAPI threeDSecureAPI = mock(ThreeDSecureAPI.class);
 
@@ -609,7 +609,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationReportsNoAction_sendsAnalyticsEvent() throws JSONException {
+    public void onActivityResult_whenCardinalCardVerificationReportsNoAction_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -631,7 +631,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationReportsFailure_sendsAnalyticsEvent() throws JSONException {
+    public void onActivityResult_whenCardinalCardVerificationReportsFailure_sendsAnalyticsEvent() throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -653,7 +653,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationIsCanceled_sendsAnalyticsEventAndReturnsExceptionToCallback() {
+    public void onActivityResult_whenCardinalCardVerificationIsCanceled_sendsAnalyticsEventAndReturnsExceptionToCallback() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -679,7 +679,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationErrors_sendsAnalyticsEvent() {
+    public void onActivityResult_whenCardinalCardVerificationErrors_sendsAnalyticsEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -697,7 +697,7 @@ public class ThreeDSecureV2UnitTest {
     }
 
     @Test
-    public void onActivityResult_whenCardinalCardVerificationTimeout_sendsAnalyticsEvent() {
+    public void onActivityResult_whenCardinalCardVerificationTimeout_sendsAnalyticsEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();


### PR DESCRIPTION
### Summary of changes

 - Guard `ThreeDSecureClient` against potential Cardinal SDK runtime exceptions

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
