### PR TITLE
Allow Manual Browser Switch Handling

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -364,8 +364,8 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun clearPendingBrowserSwitchRequest(context: Context) =
-        browserSwitchClient.clearActiveRequest(context)
+    fun clearPendingBrowserSwitchRequests(context: Context) =
+        browserSwitchClient.clearActiveRequests(context)
 
     /**
      * @suppress

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
 import androidx.annotation.RestrictTo
@@ -344,6 +345,27 @@ open class BraintreeClient @VisibleForTesting internal constructor(
     open fun deliverBrowserSwitchResultFromNewTask(context: Context): BrowserSwitchResult? {
         return browserSwitchClient.deliverResultFromCache(context)
     }
+
+    /**
+     * @suppress
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun getPendingBrowserSwitchRequest(context: Context) =
+        browserSwitchClient.getPendingRequest(context)
+
+    /**
+     * @suppress
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun parseBrowserSwitchResult(request: BrowserSwitchRequest, requestCode: Int, intent: Intent) =
+        browserSwitchClient.parseResult(request, requestCode, intent)
+
+    /**
+     * @suppress
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun clearPendingBrowserSwitchRequest(context: Context) =
+        browserSwitchClient.clearActiveRequest(context)
 
     /**
      * @suppress

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -350,21 +350,14 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun getPendingBrowserSwitchRequest(context: Context) =
-        browserSwitchClient.getPendingRequest(context)
+    fun parseBrowserSwitchResult(context: Context, requestCode: Int, intent: Intent?) =
+        browserSwitchClient.parseResult(context, requestCode, intent)
 
     /**
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun parseBrowserSwitchResult(request: BrowserSwitchRequest, requestCode: Int, intent: Intent) =
-        browserSwitchClient.parseResult(request, requestCode, intent)
-
-    /**
-     * @suppress
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun clearPendingBrowserSwitchRequests(context: Context) =
+    fun clearActiveBrowserSwitchRequests(context: Context) =
         browserSwitchClient.clearActiveRequests(context)
 
     /**

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
@@ -13,6 +14,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -445,6 +447,31 @@ class BraintreeClientUnitTest {
         sut.deliverBrowserSwitchResultFromNewTask(context)
 
         verify { browserSwitchClient.deliverResultFromCache(context) }
+    }
+
+    @Test
+    fun parseBrowserSwitchResult_forwardsInvocationToBrowserSwitchClient() {
+        val context = mockk<Context>(relaxed = true)
+        val params = createDefaultParams(configurationLoader, authorizationLoader)
+
+        val expected = mock<BrowserSwitchResult>()
+        val intent = Intent()
+        every { browserSwitchClient.parseResult(context, 123, intent) } returns expected
+
+        val sut = BraintreeClient(params)
+        val actual = sut.parseBrowserSwitchResult(context, 123, intent)
+        assertSame(expected, actual)
+    }
+
+    @Test
+    fun clearActiveBrowserSwitchRequests_forwardsInvocationToBrowserSwitchClient() {
+        val context = mockk<Context>(relaxed = true)
+        val params = createDefaultParams(configurationLoader, authorizationLoader)
+
+        val sut = BraintreeClient(params)
+        sut.clearActiveBrowserSwitchRequests(context)
+
+        verify { browserSwitchClient.clearActiveRequests(context) }
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Add `PayPalClient#parseBrowserSwitchResult(Context, Intent)` method
   * Add `PayPalClient#clearActiveBrowserSwitchRequests(Context)` method
 * LocalPayment
-  * Undeprecate `LocalPaymentClient(BraintreeClient)` constrcutor
+  * Undeprecate `LocalPaymentClient(BraintreeClient)` constructor
   * Undeprecate `LocalPaymentClient#onBrowserSwitchResult(Context, BrowserSwitchResult, LocalPaymentBrowserSwitchResultCallback)`
   * Add `LocalPaymentClient#parseBrowserSwitchResult(Context, Intent)` method
   * Add `LocalPaymentClient#clearActiveBrowserSwitchRequests(Context)` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Bump target Kotlin version to `1.8.0`
 * PayPal
   * Undeprecate `PayPalClient(BraintreeClient)` constructor
   * Undeprecate `PayPalClient#onBrowserSwitchResult(BrowserSwitchResult, PayPalBrowserSwitchResultCallback)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * PayPal
-  * Undeprecate `PayPalClient(BraintreeClient)` constrcutor
+  * Undeprecate `PayPalClient(BraintreeClient)` constructor
   * Undeprecate `PayPalClient#onBrowserSwitchResult(BrowserSwitchResult, PayPalBrowserSwitchResultCallback)`
   * Add `PayPalClient#parseBrowserSwitchResult(Context, Intent)` method
   * Add `PayPalClient#clearActiveBrowserSwitchRequests(Context)` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## unreleased
 
+* PayPal
+  * Undeprecate `PayPalClient(BraintreeClient)` constrcutor
+  * Undeprecate `PayPalClient#onBrowserSwitchResult(BrowserSwitchResult, PayPalBrowserSwitchResultCallback)`
+  * Add `PayPalClient#parseBrowserSwitchResult(Context, Intent)` method
+  * Add `PayPalClient#clearActiveBrowserSwitchRequests(Context)` method
+* LocalPayment
+  * Undeprecate `LocalPaymentClient(BraintreeClient)` constrcutor
+  * Undeprecate `LocalPaymentClient#onBrowserSwitchResult(Context, BrowserSwitchResult, LocalPaymentBrowserSwitchResultCallback)`
+  * Add `LocalPaymentClient#parseBrowserSwitchResult(Context, Intent)` method
+  * Add `LocalPaymentClient#clearActiveBrowserSwitchRequests(Context)` method
 * Venmo
   * Fix issue caused by `VenmoActivityResultContract` where a user cancelation is being misinterpreted as an unknown exception because the intent data is `null` (fixes #734)
   * Add the following properties to `VenmoRequest`:

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/PayPalManualBrowserSwitchTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/PayPalManualBrowserSwitchTest.java
@@ -1,0 +1,59 @@
+package com.braintreepayments.demo.test;
+
+import static com.braintreepayments.AutomatorAction.click;
+import static com.braintreepayments.AutomatorAssertion.text;
+import static com.braintreepayments.DeviceAutomator.onDevice;
+import static com.braintreepayments.UiObjectMatcher.withText;
+import static com.braintreepayments.UiObjectMatcher.withTextStartingWith;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+import com.braintreepayments.demo.test.utilities.TestHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class PayPalManualBrowserSwitchTest extends TestHelper {
+
+    @Before
+    public void setup() {
+        super.setup();
+        launchApp("Mock PayPal");
+        onDevice(withText("PayPal")).waitForEnabled().perform(click());
+
+        PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+                .edit()
+                .putBoolean("enable_manual_browser_switching", true)
+                .commit();
+    }
+
+    @Test(timeout = 60000)
+    public void browserSwitch_makesASinglePayment() {
+        onDevice(withText("Single Payment")).waitForEnabled().perform(click());
+        onDevice(withText("Proceed with Sandbox Purchase")).waitForExists();
+        onDevice(withText("Proceed with Sandbox Purchase")).perform(click());
+
+        getNonceDetails().check(text(containsString("Email: bt_buyer_us@paypal.com")));
+
+        onDevice(withText("Create a Transaction")).perform(click());
+        onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
+    }
+
+    @Test(timeout = 60000)
+    public void browserSwitch_makesABillingAgreement() {
+        onDevice(withText("Billing Agreement")).waitForEnabled().perform(click());
+        onDevice(withText("Proceed with Sandbox Purchase")).waitForExists();
+        onDevice(withText("Proceed with Sandbox Purchase")).perform(click());
+
+        getNonceDetails().check(text(containsString("Email: bt_buyer_us@paypal.com")));
+
+        onDevice(withText("Create a Transaction")).perform(click());
+        onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
+    }
+}

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -66,24 +66,23 @@ public class PayPalFragment extends BaseFragment implements PayPalListener {
         super.onResume();
         if (useManualBrowserSwitch) {
             Activity activity = requireActivity();
-            BrowserSwitchRequest request = payPalClient.getPendingBrowserSwitchRequest(activity);
-            if (request != null) {
-                completeBrowserSwitchIfNecessary(request, activity.getIntent());
+            BrowserSwitchResult browserSwitchResult =
+                payPalClient.parseBrowserSwitchResult(activity, activity.getIntent());
+            if (browserSwitchResult != null) {
+                handleBrowserSwitchResult(browserSwitchResult);
             }
         }
     }
-    private void completeBrowserSwitchIfNecessary(BrowserSwitchRequest request, Intent intent) {
-        BrowserSwitchResult browserSwitchResult = payPalClient.parseBrowserSwitchResult(request, intent);
-        if (browserSwitchResult != null) {
-            payPalClient.onBrowserSwitchResult(browserSwitchResult, ((payPalAccountNonce, error) -> {
-                if (payPalAccountNonce != null) {
-                    handlePayPalResult(payPalAccountNonce);
-                } else if (error != null) {
-                    handleError(error);
-                }
-            }));
-            payPalClient.clearPendingBrowserSwitchRequest(requireContext());
-        }
+
+    private void handleBrowserSwitchResult(BrowserSwitchResult browserSwitchResult) {
+        payPalClient.onBrowserSwitchResult(browserSwitchResult, ((payPalAccountNonce, error) -> {
+            if (payPalAccountNonce != null) {
+                handlePayPalResult(payPalAccountNonce);
+            } else if (error != null) {
+                handleError(error);
+            }
+        }));
+        payPalClient.clearPendingBrowserSwitchRequests(requireContext());
     }
 
     public void launchSinglePayment(View v) {

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -4,7 +4,6 @@ import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalChecko
 import static com.braintreepayments.demo.PayPalRequestFactory.createPayPalVaultRequest;
 
 import android.app.Activity;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -17,7 +16,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.braintreepayments.api.BraintreeClient;
-import com.braintreepayments.api.BrowserSwitchRequest;
 import com.braintreepayments.api.BrowserSwitchResult;
 import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.PayPalAccountNonce;
@@ -82,7 +80,7 @@ public class PayPalFragment extends BaseFragment implements PayPalListener {
                 handleError(error);
             }
         }));
-        payPalClient.clearPendingBrowserSwitchRequests(requireContext());
+        payPalClient.clearActiveBrowserSwitchRequests(requireContext());
     }
 
     public void launchSinglePayment(View v) {

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -213,4 +213,8 @@ public class Settings {
     public static boolean isAmexRewardsBalanceEnabled(Context context) {
         return getPreferences(context).getBoolean("amex_rewards_balance", false);
     }
+
+    public static boolean isManualBrowserSwitchingEnabled(Context context) {
+        return getPreferences(context).getBoolean("enable_manual_browser_switching", false);
+    }
 }

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -76,8 +76,11 @@
     <string name="paypal_request_address_scope">Request Address Scope</string>
     <string name="paypal_request_address_scope_summary">Request address scope from the user</string>
     <string name="three_d_secure">3D Secure</string>
+    <string name="browser_switch">Browser Switch</string>
     <string name="enable_three_d_secure">Enable 3D Secure</string>
     <string name="enable_three_d_secure_summary">3D Secure will automatically be run on all Card payment methods</string>
+    <string name="enable_manual_browser_switching">Enable Manual Browser Switching</string>
+    <string name="enable_manual_browser_switching_summary">Use alternate integration pattern to give the Demo app more control over browser switching</string>
     <string name="require_three_d_secure">Require 3D Secure</string>
     <string name="require_three_d_secure_summary">Requires a successful authentication for 3D Secure transactions</string>
     <string name="paypal_disable_signature_verification">Disable app switch signature verification</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -187,4 +187,15 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/browser_switch">
+
+        <CheckBoxPreference
+            android:key="enable_manual_browser_switching"
+            android:title="@string/enable_manual_browser_switching"
+            android:summary="@string/enable_manual_browser_switching_summary"
+            android:defaultValue="false" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
@@ -32,7 +33,7 @@ public class LocalPaymentClient {
     /**
      * Create a new instance of {@link LocalPaymentClient} from within an Activity using a {@link BraintreeClient}.
      *
-     * @param activity a {@link FragmentActivity}
+     * @param activity        a {@link FragmentActivity}
      * @param braintreeClient a {@link BraintreeClient}
      */
     public LocalPaymentClient(@NonNull FragmentActivity activity, @NonNull BraintreeClient braintreeClient) {
@@ -42,7 +43,7 @@ public class LocalPaymentClient {
     /**
      * Create a new instance of {@link LocalPaymentClient} from within a Fragment using a {@link BraintreeClient}.
      *
-     * @param fragment a {@link Fragment
+     * @param fragment        a {@link Fragment
      * @param braintreeClient a {@link BraintreeClient}
      */
     public LocalPaymentClient(@NonNull Fragment fragment, @NonNull BraintreeClient braintreeClient) {
@@ -51,13 +52,12 @@ public class LocalPaymentClient {
 
     /**
      * Create a new instance of {@link LocalPaymentClient} using a {@link BraintreeClient}.
-     *
+     * <p>
      * Deprecated. Use {@link LocalPaymentClient(Fragment, BraintreeClient)} or
      * {@link LocalPaymentClient(FragmentActivity, BraintreeClient)}.
      *
      * @param braintreeClient a {@link BraintreeClient}
      */
-    @Deprecated
     public LocalPaymentClient(@NonNull BraintreeClient braintreeClient) {
         this(null, null, braintreeClient, new PayPalDataCollector(braintreeClient), new LocalPaymentApi(braintreeClient));
     }
@@ -144,7 +144,7 @@ public class LocalPaymentClient {
 
     /**
      * Initiates the browser switch for a payment flow by opening a browser where the customer can authenticate with their bank.
-     *
+     * <p>
      * Errors encountered during the approval will be returned to the {@link LocalPaymentListener}.
      *
      * @param activity           Android FragmentActivity
@@ -161,7 +161,7 @@ public class LocalPaymentClient {
 
     /**
      * Initiates the browser switch for a payment flow by opening a browser where the customer can authenticate with their bank.
-     *
+     * <p>
      * Deprecated. Use {@link LocalPaymentClient#approveLocalPayment(FragmentActivity, LocalPaymentResult)}.
      *
      * @param activity           Android FragmentActivity
@@ -220,6 +220,39 @@ public class LocalPaymentClient {
         this.pendingBrowserSwitchResult = null;
     }
 
+    /**
+     * After calling {@link LocalPaymentClient#startPayment(LocalPaymentRequest, LocalPaymentStartCallback)},
+     * call this method in your Activity or Fragment's onResume() method to see if a response
+     * was provided through deep linking.
+     * <p>
+     * If a BrowserSwitchResult exists, call {@link LocalPaymentClient#onBrowserSwitchResult(Context, BrowserSwitchResult, LocalPaymentBrowserSwitchResultCallback)},
+     * to allow the SDK to continue tokenization of the PayPalAccount.
+     * <p>
+     * Make sure to call {@link LocalPaymentClient#clearActiveBrowserSwitchRequests(Context)} after
+     * successfully parsing a BrowserSwitchResult to guard against multiple invocations of browser
+     * switch event handling.
+     *
+     * @param context The context used to check for pending browser switch requests
+     * @param intent  The intent containing a potential deep link response. May be null.
+     * @return {@link BrowserSwitchResult} when a result has been parsed successfully from a deep link; null when an input Intent is null
+     */
+    @Nullable
+    public BrowserSwitchResult parseBrowserSwitchResult(@NonNull Context context, @Nullable Intent intent) {
+        int requestCode = BraintreeRequestCodes.LOCAL_PAYMENT;
+        return braintreeClient.parseBrowserSwitchResult(context, requestCode, intent);
+    }
+
+    /**
+     * Make sure to call this method after {@link LocalPaymentClient#parseBrowserSwitchResult(Context, Intent)}
+     * parses a {@link BrowserSwitchResult} successfully to prevent multiple invocations of browser
+     * switch event handling logic.
+     *
+     * @param context The context used to clear pending browser switch requests
+     */
+    public void clearActiveBrowserSwitchRequests(@NonNull Context context) {
+        braintreeClient.clearActiveBrowserSwitchRequests(context);
+    }
+
     // NEXT_MAJOR_VERSION: duplication here could be a sign that we need to decouple browser switching
     // logic into another component that also gives merchants more flexibility when using view models
     BrowserSwitchResult getBrowserSwitchResult(FragmentActivity activity) {
@@ -245,7 +278,6 @@ public class LocalPaymentClient {
      * @param browserSwitchResult a {@link BrowserSwitchResult} with a {@link BrowserSwitchStatus}
      * @param callback            {@link LocalPaymentBrowserSwitchResultCallback}
      */
-    @Deprecated
     public void onBrowserSwitchResult(@NonNull final Context context, @NonNull BrowserSwitchResult browserSwitchResult, @NonNull final LocalPaymentBrowserSwitchResultCallback callback) {
         //noinspection ConstantConditions
         if (browserSwitchResult == null) {

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -53,8 +53,7 @@ public class LocalPaymentClient {
     /**
      * Create a new instance of {@link LocalPaymentClient} using a {@link BraintreeClient}.
      * <p>
-     * Deprecated. Use {@link LocalPaymentClient(Fragment, BraintreeClient)} or
-     * {@link LocalPaymentClient(FragmentActivity, BraintreeClient)}.
+     * Use this constructor with the manual browser switch integration pattern.
      *
      * @param braintreeClient a {@link BraintreeClient}
      */
@@ -272,7 +271,7 @@ public class LocalPaymentClient {
     }
 
     /**
-     * Deprecated. Use {@link LocalPaymentListener} to handle results.
+     * Use this method with the manual browser switch integration pattern.
      *
      * @param context             Android Context
      * @param browserSwitchResult a {@link BrowserSwitchResult} with a {@link BrowserSwitchStatus}

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.fragment.app.Fragment;
@@ -695,6 +696,31 @@ public class LocalPaymentClientUnitTest {
 
         LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
         assertSame(browserSwitchResult, sut.deliverBrowserSwitchResultFromNewTask(activity));
+    }
+
+    @Test
+    public void parseBrowserSwitchResult_forwardsInvocationToBraintreeClient() {
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+
+        BraintreeClient braintreeClient = mock(BraintreeClient.class);
+        Intent intent = new Intent();
+        when(
+                braintreeClient.parseBrowserSwitchResult(activity, BraintreeRequestCodes.LOCAL_PAYMENT, intent)
+        ).thenReturn(browserSwitchResult);
+
+        LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
+
+        BrowserSwitchResult result = sut.parseBrowserSwitchResult(activity, intent);
+        assertSame(browserSwitchResult, result);
+    }
+
+    @Test
+    public void clearActiveBrowserSwitchRequests_forwardsInvocationToBraintreeClient() {
+        BraintreeClient braintreeClient = mock(BraintreeClient.class);
+        LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
+
+        sut.clearActiveBrowserSwitchRequests(activity);
+        verify(braintreeClient).clearActiveBrowserSwitchRequests(activity);
     }
 
     private LocalPaymentRequest getIdealLocalPaymentRequest() {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -97,7 +97,7 @@ public class PayPalClient {
      * If a BrowserSwitchResult exists, call {@link PayPalClient#onBrowserSwitchResult(BrowserSwitchResult, PayPalBrowserSwitchResultCallback)}
      * to allow the SDK to continue tokenization of the PayPalAccount.
      *
-     * Make sure to call {@link PayPalClient#clearPendingBrowserSwitchRequests(Context)} after
+     * Make sure to call {@link PayPalClient#clearActiveBrowserSwitchRequests(Context)} after
      * successfully parsing a BrowserSwitchResult to guard against multiple invocations of browser
      * switch event handling.
      *
@@ -107,15 +107,8 @@ public class PayPalClient {
      */
     @Nullable
     public BrowserSwitchResult parseBrowserSwitchResult(@NonNull Context context, @Nullable Intent intent) {
-        BrowserSwitchResult result = null;
-        if (intent != null) {
-            BrowserSwitchRequest request = braintreeClient.getPendingBrowserSwitchRequest(context);
-            if (request != null) {
-                int requestCode = BraintreeRequestCodes.PAYPAL;
-                result = braintreeClient.parseBrowserSwitchResult(request, requestCode, intent);
-            }
-        }
-        return result;
+        int requestCode = BraintreeRequestCodes.PAYPAL;
+        return braintreeClient.parseBrowserSwitchResult(context, requestCode, intent);
     }
 
     /**
@@ -125,8 +118,8 @@ public class PayPalClient {
      *
      * @param context The context used to clear pending browser switch requests
      */
-    public void clearPendingBrowserSwitchRequests(@NonNull Context context) {
-        braintreeClient.clearPendingBrowserSwitchRequests(context);
+    public void clearActiveBrowserSwitchRequests(@NonNull Context context) {
+        braintreeClient.clearActiveBrowserSwitchRequests(context);
     }
 
     private void assertCanPerformBrowserSwitch(FragmentActivity activity) throws BrowserSwitchException {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -90,6 +90,18 @@ public class PayPalClient {
     }
 
     @Nullable
+    public BrowserSwitchResult parseBrowserSwitchResult(@NonNull Context context, @Nullable Intent intent) {
+        BrowserSwitchResult result = null;
+        if (intent != null) {
+            BrowserSwitchRequest pendingRequest = getPendingBrowserSwitchRequest(context);
+            if (pendingRequest != null) {
+                result = parseBrowserSwitchResult(pendingRequest, intent);
+            }
+        }
+        return result;
+    }
+
+    @Nullable
     public BrowserSwitchRequest getPendingBrowserSwitchRequest(@NonNull Context context) {
         return braintreeClient.getPendingBrowserSwitchRequest(context);
     }
@@ -99,7 +111,7 @@ public class PayPalClient {
         return braintreeClient.parseBrowserSwitchResult(request, BraintreeRequestCodes.PAYPAL, intent);
     }
 
-    public void clearPendingBrowserSwitchRequest(@NonNull Context context) {
+    public void clearPendingBrowserSwitchRequests(@NonNull Context context) {
         braintreeClient.clearPendingBrowserSwitchRequest(context);
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -93,22 +93,13 @@ public class PayPalClient {
     public BrowserSwitchResult parseBrowserSwitchResult(@NonNull Context context, @Nullable Intent intent) {
         BrowserSwitchResult result = null;
         if (intent != null) {
-            BrowserSwitchRequest pendingRequest = getPendingBrowserSwitchRequest(context);
-            if (pendingRequest != null) {
-                result = parseBrowserSwitchResult(pendingRequest, intent);
+            BrowserSwitchRequest request = braintreeClient.getPendingBrowserSwitchRequest(context);
+            if (request != null) {
+                int requestCode = BraintreeRequestCodes.PAYPAL;
+                result = braintreeClient.parseBrowserSwitchResult(request, requestCode, intent);
             }
         }
         return result;
-    }
-
-    @Nullable
-    public BrowserSwitchRequest getPendingBrowserSwitchRequest(@NonNull Context context) {
-        return braintreeClient.getPendingBrowserSwitchRequest(context);
-    }
-
-    @Nullable
-    public BrowserSwitchResult parseBrowserSwitchResult(@NonNull BrowserSwitchRequest request, @NonNull Intent intent) {
-        return braintreeClient.parseBrowserSwitchResult(request, BraintreeRequestCodes.PAYPAL, intent);
     }
 
     public void clearPendingBrowserSwitchRequests(@NonNull Context context) {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -89,6 +89,22 @@ public class PayPalClient {
         return (configuration == null || !configuration.isPayPalEnabled());
     }
 
+    /**
+     * After calling {@link PayPalClient#tokenizePayPalAccount(FragmentActivity, PayPalRequest)},
+     * call this method in your Activity or Fragment's onResume() method to see if a response
+     * was provided through deep linking.
+     *
+     * If a BrowserSwitchResult exists, call {@link PayPalClient#onBrowserSwitchResult(BrowserSwitchResult, PayPalBrowserSwitchResultCallback)}
+     * to allow the SDK to continue tokenization of the PayPalAccount.
+     *
+     * Make sure to call {@link PayPalClient#clearPendingBrowserSwitchRequests(Context)} after
+     * successfully parsing a BrowserSwitchResult to guard against multiple invocations of browser
+     * switch event handling.
+     *
+     * @param context The context used to check for pending browser switch requests
+     * @param intent The intent containing a potential deep link response. May be null.
+     * @return {@link BrowserSwitchResult} when a result has been parsed successfully from a deep link; null when an input Intent is null
+     */
     @Nullable
     public BrowserSwitchResult parseBrowserSwitchResult(@NonNull Context context, @Nullable Intent intent) {
         BrowserSwitchResult result = null;

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api;
 
+import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
@@ -55,7 +56,6 @@ public class PayPalClient {
      *
      * @param braintreeClient a {@link BraintreeClient}
      */
-    @Deprecated
     public PayPalClient(@NonNull BraintreeClient braintreeClient) {
         this(null, null, braintreeClient, new PayPalInternalClient(braintreeClient));
     }
@@ -86,6 +86,24 @@ public class PayPalClient {
 
     private static boolean payPalConfigInvalid(Configuration configuration) {
         return (configuration == null || !configuration.isPayPalEnabled());
+    }
+
+    /**
+     * Retrieve browser switch result from persistent storage for PayPal flow if one exists.
+     * Browser switch results can only be fetched once.
+     * @param activity Browser switch host activity.
+     * @return {@link BrowserSwitchResult}
+     */
+    @Nullable
+    public BrowserSwitchResult fetchBrowserSwitchResultIfOneExists(@NonNull FragmentActivity activity) {
+        BrowserSwitchResult result = null;
+        BrowserSwitchResult browserSwitchResult = braintreeClient.getBrowserSwitchResult(activity);
+        if (browserSwitchResult != null) {
+            if (browserSwitchResult.getRequestCode() == BraintreeRequestCodes.PAYPAL) {
+                result = braintreeClient.deliverBrowserSwitchResult(activity);
+            }
+        }
+        return result;
     }
 
     private void assertCanPerformBrowserSwitch(FragmentActivity activity) throws BrowserSwitchException {
@@ -187,7 +205,7 @@ public class PayPalClient {
                 } catch (BrowserSwitchException browserSwitchException) {
                     braintreeClient.sendAnalyticsEvent("paypal.invalid-manifest");
                     Exception manifestInvalidError =
-                        createBrowserSwitchError(browserSwitchException);
+                            createBrowserSwitchError(browserSwitchException);
                     callback.onResult(manifestInvalidError);
                     return;
                 }
@@ -217,7 +235,7 @@ public class PayPalClient {
                 } catch (BrowserSwitchException browserSwitchException) {
                     braintreeClient.sendAnalyticsEvent("paypal.invalid-manifest");
                     Exception manifestInvalidError =
-                        createBrowserSwitchError(browserSwitchException);
+                            createBrowserSwitchError(browserSwitchException);
                     callback.onResult(manifestInvalidError);
                     return;
                 }
@@ -321,7 +339,6 @@ public class PayPalClient {
      * @param browserSwitchResult a {@link BrowserSwitchResult} with a {@link BrowserSwitchStatus}
      * @param callback            {@link PayPalBrowserSwitchResultCallback}
      */
-    @Deprecated
     public void onBrowserSwitchResult(@NonNull BrowserSwitchResult browserSwitchResult, @NonNull final PayPalBrowserSwitchResultCallback callback) {
         //noinspection ConstantConditions
         if (browserSwitchResult == null) {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -52,8 +52,7 @@ public class PayPalClient {
     /**
      * Create a new instance of {@link PayPalClient} using a {@link BraintreeClient}.
      * <p>
-     * Deprecated. Use {@link PayPalClient(Fragment, BraintreeClient)} or
-     * {@link PayPalClient(FragmentActivity, BraintreeClient)}.
+     * Use this constructor with the manual browser switch integration pattern.
      *
      * @param braintreeClient a {@link BraintreeClient}
      */
@@ -350,7 +349,7 @@ public class PayPalClient {
     }
 
     /**
-     * Deprecated. Use {@link PayPalListener} to handle results.
+     * Use this method with the manual browser switch integration pattern.
      *
      * @param browserSwitchResult a {@link BrowserSwitchResult} with a {@link BrowserSwitchStatus}
      * @param callback            {@link PayPalBrowserSwitchResultCallback}

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -126,7 +126,7 @@ public class PayPalClient {
      * @param context The context used to clear pending browser switch requests
      */
     public void clearPendingBrowserSwitchRequests(@NonNull Context context) {
-        braintreeClient.clearPendingBrowserSwitchRequest(context);
+        braintreeClient.clearPendingBrowserSwitchRequests(context);
     }
 
     private void assertCanPerformBrowserSwitch(FragmentActivity activity) throws BrowserSwitchException {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
 
@@ -88,22 +89,18 @@ public class PayPalClient {
         return (configuration == null || !configuration.isPayPalEnabled());
     }
 
-    /**
-     * Retrieve browser switch result from persistent storage for PayPal flow if one exists.
-     * Browser switch results can only be fetched once.
-     * @param activity Browser switch host activity.
-     * @return {@link BrowserSwitchResult}
-     */
     @Nullable
-    public BrowserSwitchResult fetchBrowserSwitchResultIfOneExists(@NonNull FragmentActivity activity) {
-        BrowserSwitchResult result = null;
-        BrowserSwitchResult browserSwitchResult = braintreeClient.getBrowserSwitchResult(activity);
-        if (browserSwitchResult != null) {
-            if (browserSwitchResult.getRequestCode() == BraintreeRequestCodes.PAYPAL) {
-                result = braintreeClient.deliverBrowserSwitchResult(activity);
-            }
-        }
-        return result;
+    public BrowserSwitchRequest getPendingBrowserSwitchRequest(@NonNull Context context) {
+        return braintreeClient.getPendingBrowserSwitchRequest(context);
+    }
+
+    @Nullable
+    public BrowserSwitchResult parseBrowserSwitchResult(@NonNull BrowserSwitchRequest request, @NonNull Intent intent) {
+        return braintreeClient.parseBrowserSwitchResult(request, BraintreeRequestCodes.PAYPAL, intent);
+    }
+
+    public void clearPendingBrowserSwitchRequest(@NonNull Context context) {
+        braintreeClient.clearPendingBrowserSwitchRequest(context);
     }
 
     private void assertCanPerformBrowserSwitch(FragmentActivity activity) throws BrowserSwitchException {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -118,6 +118,13 @@ public class PayPalClient {
         return result;
     }
 
+    /**
+     * Make sure to call this method after {@link PayPalClient#parseBrowserSwitchResult(Context, Intent)}
+     * parses a {@link BrowserSwitchResult} successfully to prevent multiple invocations of browser
+     * switch event handling logic.
+     *
+     * @param context The context used to clear pending browser switch requests
+     */
     public void clearPendingBrowserSwitchRequests(@NonNull Context context) {
         braintreeClient.clearPendingBrowserSwitchRequest(context);
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.fragment.app.Fragment;
@@ -797,5 +798,32 @@ public class PayPalClientUnitTest {
 
         BrowserSwitchResult result = sut.deliverBrowserSwitchResultFromNewTask(activity);
         assertSame(browserSwitchResult, result);
+    }
+
+    @Test
+    public void parseBrowserSwitchResult_forwardsInvocationToBraintreeClient() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+
+        BraintreeClient braintreeClient = mock(BraintreeClient.class);
+        Intent intent = new Intent();
+        when(
+                braintreeClient.parseBrowserSwitchResult(activity, BraintreeRequestCodes.PAYPAL, intent)
+        ).thenReturn(browserSwitchResult);
+
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+
+        BrowserSwitchResult result = sut.parseBrowserSwitchResult(activity, intent);
+        assertSame(browserSwitchResult, result);
+    }
+
+    @Test
+    public void clearActiveBrowserSwitchRequests_forwardsInvocationToBraintreeClient() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+        BraintreeClient braintreeClient = mock(BraintreeClient.class);
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+
+        sut.clearActiveBrowserSwitchRequests(activity);
+        verify(braintreeClient).clearActiveBrowserSwitchRequests(activity);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,8 @@ buildscript {
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
             "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.3-SNAPSHOT",
-            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-3",            "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
+            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-3",
+            "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
             // NEXT_MAJOR_VERSION: upgrade to 2.7.1 (or latest) when Java 7 support is explicitly dropped
@@ -93,6 +94,9 @@ allprojects {
     repositories {
         mavenCentral()
         google()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ buildscript {
             // kotlin libraries. Make sure to keep this dependency in line with the kotlin version used.
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
-            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.3-SNAPSHOT",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.4.0",
             "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-3",
             "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
@@ -94,9 +94,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
 
     ext.versions = [
-            "kotlin"         : "1.7.0",
+            "kotlin"         : "1.8.0",
             "androidxTest"   : "1.4.0",
             // NEXT MAJOR VERSION: Use a single up-to-date room version once we remove Java 7 support in favor of Java 11
             "room"           : roomVersion,
@@ -38,15 +38,14 @@ buildscript {
             // NEXT_MAJOR_VERSION: upgrade to 2.4.0 (or latest) when Java 7 support is explicitly dropped
             "lifecycleRuntime"           : "androidx.lifecycle:lifecycle-runtime:2.3.0",
 
-            "kotlinStdLib"               : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+            "kotlinStdLib"               : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
             "kotlinTest"                 : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
             // This library doesn't seem to follow the versioning pattern of the other jetbrains
             // kotlin libraries. Make sure to keep this dependency in line with the kotlin version used.
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
-            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.2",
-            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-3",
-            "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.3.3-SNAPSHOT",
+            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-3",            "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
 
             // NEXT_MAJOR_VERSION: upgrade to 2.7.1 (or latest) when Java 7 support is explicitly dropped

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1074,6 +1074,3 @@ class MainActivity : AppCompatActivity() {
 }
 ```
 
-### Android 9 Known Issues
-
-TODO: explain Android 9 issues that have been encountered by merchants in the past and provide a workaround

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1066,7 +1066,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // clear pending request to guard against additional browser switch result invocations
-    payPalClient.clearPendingBrowserSwitchRequest(this)
+    payPalClient.clearActiveBrowserSwitchRequests(this)
   }
 }
 ```

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1073,3 +1073,7 @@ class MainActivity : AppCompatActivity() {
   }
 }
 ```
+
+### Android 9 Known Issues
+
+TODO: explain Android 9 issues that have been encountered by merchants in the past and provide a workaround

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1023,7 +1023,9 @@ public class PaymentsActivity extends AppCompatActivity implements PayPalListene
 
 ## Manual Browser Switching for Browser-Based Flows
 
-For more control over browser-based interactions, consider the manual browser switch integration pattern:
+For more control over browser-based payment flows, consider the manual browser switch integration pattern.
+
+Here is an example of manual browser switching using `PayPalClient`:
 
 ```kotlin
 class MainActivity : AppCompatActivity() {
@@ -1033,41 +1035,37 @@ class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val authorization = "<TOKENIZATION_KEY>"
-    val customUrlScheme = "my-custom-url-scheme"
-    val braintreeClient = BraintreeClient(this, authorization, customUrlScheme)
+    val braintreeClient = BraintreeClient(this, "<TOKENIZATION_KEY>", "my-custom-url-scheme")
     payPalClient = PayPalClient(braintreeClient)
   }
 
   override fun onResume() {
     super.onResume()
-    payPalClient.getPendingBrowserSwitchRequest(this)?.let { pendingRequest ->
-      resumePendingBrowserSwitchRequestIfPossible(pendingRequest, intent)
+    payPalClient.parseBrowserSwitchResult(this, intent)?.let {
+      handleBrowserSwitchResult(it)
     }
   }
 
-  override fun onNewIntent(intent: Intent?) {
-    super.onNewIntent(intent)
-    payPalClient.getPendingBrowserSwitchRequest(this)?.let { pendingRequest ->
-      resumePendingBrowserSwitchRequestIfPossible(pendingRequest, intent)
+  override fun onNewIntent(newIntent: Intent?) {
+    super.onNewIntent(newIntent)
+      
+    // required if your activity's launch mode is "singleTop", "singleTask", or "singleInstance"
+    payPalClient.parseBrowserSwitchResult(this, newIntent)?.let {
+      handleBrowserSwitchResult(it)
     }
   }
 
-  private fun resumePendingBrowserSwitchRequestIfPossible(
-    request: BrowserSwitchRequest,
-    intent: Intent?
-  ) = intent?.let {
-    val browserSwitchResult = payPalClient.parseBrowserSwitchResult(request, intent)
-    if (browserSwitchResult != null) {
-      payPalClient.onBrowserSwitchResult(browserSwitchResult) { payPalAccountNonce, error ->
-        payPalAccountNonce?.let {
-          // forward nonce to server
-        } ?: error?.let {
-          // handle error
-        }
+  private fun handleBrowserSwitchResult(result: BrowserSwitchResult) {
+    payPalClient.onBrowserSwitchResult(result) { payPalAccountNonce, error ->
+      payPalAccountNonce?.let {
+        // forward nonce to server
+      } ?: error?.let {
+        // handle error
       }
-      payPalClient.clearPendingBrowserSwitchRequest(this)
     }
+
+    // clear pending request to guard against additional browser switch result invocations
+    payPalClient.clearPendingBrowserSwitchRequest(this)
   }
 }
 ```

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -25,6 +25,7 @@ _Documentation for v4 is available at https://developer.paypal.com/braintree/doc
 1. [Venmo](#venmo)
 1. [3D Secure](#3d-secure)
 1. [Integrating Multiple Payment Methods](#integrating-multiple-payment-methods)
+1. [Manual Browser Switching for Browser-Based Flows](#manual-browser-switching-for-browser-based-flows)
 
 ## Gradle
 
@@ -1016,6 +1017,57 @@ public class PaymentsActivity extends AppCompatActivity implements PayPalListene
   @Override
   protected void onVenmoFailure(Exception error) {
       // handle Venmo error 
+  }
+}
+```
+
+## Manual Browser Switching for Browser-Based Flows
+
+For more control over browser-based interactions, consider the manual browser switch integration pattern:
+
+```kotlin
+class MainActivity : AppCompatActivity() {
+
+  private lateinit var payPalClient: PayPalClient
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val authorization = "<TOKENIZATION_KEY>"
+    val customUrlScheme = "my-custom-url-scheme"
+    val braintreeClient = BraintreeClient(this, authorization, customUrlScheme)
+    payPalClient = PayPalClient(braintreeClient)
+  }
+
+  override fun onResume() {
+    super.onResume()
+    payPalClient.getPendingBrowserSwitchRequest(this)?.let { pendingRequest ->
+      resumePendingBrowserSwitchRequestIfPossible(pendingRequest, intent)
+    }
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    payPalClient.getPendingBrowserSwitchRequest(this)?.let { pendingRequest ->
+      resumePendingBrowserSwitchRequestIfPossible(pendingRequest, intent)
+    }
+  }
+
+  private fun resumePendingBrowserSwitchRequestIfPossible(
+    request: BrowserSwitchRequest,
+    intent: Intent?
+  ) = intent?.let {
+    val browserSwitchResult = payPalClient.parseBrowserSwitchResult(request, intent)
+    if (browserSwitchResult != null) {
+      payPalClient.onBrowserSwitchResult(browserSwitchResult) { payPalAccountNonce, error ->
+        payPalAccountNonce?.let {
+          // forward nonce to server
+        } ?: error?.let {
+          // handle error
+        }
+      }
+      payPalClient.clearPendingBrowserSwitchRequest(this)
+    }
   }
 }
 ```

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1038,6 +1038,9 @@ class MainActivity : AppCompatActivity() {
     val authorization = "<TOKENIZATION_KEY_OR_CLIENT_TOKEN>"
     val braintreeClient = BraintreeClient(this, authorization, "my-custom-url-scheme")
     payPalClient = PayPalClient(braintreeClient)
+
+    val payPalRequest = PayPalCheckoutRequest("1.00")
+    payPalClient.tokenizePayPalAccount(payPalRequest)
   }
 
   override fun onResume() {

--- a/v4.9.0+_MIGRATION_GUIDE.md
+++ b/v4.9.0+_MIGRATION_GUIDE.md
@@ -1035,7 +1035,8 @@ class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val braintreeClient = BraintreeClient(this, "<TOKENIZATION_KEY>", "my-custom-url-scheme")
+    val authorization = "<TOKENIZATION_KEY_OR_CLIENT_TOKEN>"
+    val braintreeClient = BraintreeClient(this, authorization, "my-custom-url-scheme")
     payPalClient = PayPalClient(braintreeClient)
   }
 


### PR DESCRIPTION
### Summary of changes

 - Create a separate integration pattern for merchants who want more control over the browser switch lifecycle
 - Depends on https://github.com/braintree/browser-switch-android/pull/64

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
