### PR TITLE
Fix MXO User Action Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPalNativeCheckout (BETA)
+  * Fix bug where setting `setUserAction()` does not update button as expected
+
 ## 4.32.0
 
 * Bump target Kotlin version to `1.8.0`
@@ -38,7 +43,7 @@
 
 ## 4.29.0
 
-* PayPalNativeCheckout
+* PayPalNativeCheckout (BETA)
   * Reverting native version upgrade
 * ThreeDSecure
   * Bump Cardinal version to `2.2.7-3`
@@ -46,7 +51,7 @@
 
 ## 4.28.0
 
-* PayPalNativeCheckout
+* PayPalNativeCheckout (BETA)
   * Bump native-checkout version to release `0.112.0`
 
 ## 4.27.2
@@ -183,7 +188,7 @@
 
 ## 4.16.0
 
-* PayPalNativeCheckoutClient
+* PayPalNativeCheckout (BETA)
   * Bumping native-checkout version to 0.8.1 
   * Adding in Native checkout support for one time password
 * BraintreeCore

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -213,6 +213,10 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
             experienceProfile.put(LOCALE_CODE_KEY, getLocaleCode());
         }
 
+        if (getUserAction() != USER_ACTION_DEFAULT) {
+            experienceProfile.put(USER_ACTION_KEY, getUserAction());
+        }
+
         if (getShippingAddressOverride() != null) {
             experienceProfile.put(ADDRESS_OVERRIDE_KEY, !isShippingAddressEditable());
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
@@ -14,8 +14,6 @@ class PayPalInternalClient {
     private static final String CREATE_SINGLE_PAYMENT_ENDPOINT = "paypal_hermes/create_payment_resource";
     private static final String SETUP_BILLING_AGREEMENT_ENDPOINT = "paypal_hermes/setup_billing_agreement";
 
-    private static final String USER_ACTION_KEY = "useraction";
-
     private final String cancelUrl;
     private final String successUrl;
 
@@ -82,11 +80,7 @@ class PayPalInternalClient {
                                                                 .clientMetadataId(clientMetadataId);
                                                     }
 
-                                                    String approvalUrl = parsedRedirectUri
-                                                            .buildUpon()
-                                                            .appendQueryParameter(USER_ACTION_KEY, payPalResponse.getUserAction())
-                                                            .toString();
-                                                    payPalResponse.approvalUrl(approvalUrl);
+                                                    payPalResponse.approvalUrl(parsedRedirectUri.toString());
                                                 }
                                                 callback.onResult(payPalResponse, null);
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -42,6 +42,7 @@ public abstract class PayPalRequest implements Parcelable {
     static final String MERCHANT_ACCOUNT_ID = "merchant_account_id";
     static final String CORRELATION_ID_KEY = "correlation_id";
     static final String LINE_ITEMS_KEY = "line_items";
+    static final String USER_ACTION_KEY = "user_action";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({PayPalRequest.LANDING_PAGE_TYPE_BILLING, PayPalRequest.LANDING_PAGE_TYPE_LOGIN})

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -500,9 +500,7 @@ public class PayPalInternalClientUnitTest {
         ArgumentCaptor<PayPalResponse> captor = ArgumentCaptor.forClass(PayPalResponse.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
-        String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource\u0026authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8\u0026cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel\u0026controller=client_api%2Fpaypal_hermes\u0026experience_profile%5Baddress_override%5D=false\u0026experience_profile%5Bno_shipping%5D=false\u0026merchant_id=dcpspy2brwdjr3qn\u0026return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess\u0026ba_token=EC-HERMES-SANDBOX-EC-TOKEN\u0026offer_paypal_credit=true\u0026version=1\u0026useraction=";
-
+        String expectedUrl = "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&ba_token=EC-HERMES-SANDBOX-EC-TOKEN&offer_paypal_credit=true&version=1";
         PayPalResponse payPalResponse = captor.getValue();
         assertTrue(payPalResponse.isBillingAgreement());
         assertEquals("sample-merchant-account-id", payPalResponse.getMerchantAccountId());
@@ -535,9 +533,7 @@ public class PayPalInternalClientUnitTest {
         ArgumentCaptor<PayPalResponse> captor = ArgumentCaptor.forClass(PayPalResponse.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
-        String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource\u0026amount=1.00\u0026authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8\u0026cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel\u0026controller=client_api%2Fpaypal_hermes\u0026currency_iso_code=USD\u0026experience_profile%5Baddress_override%5D=false\u0026experience_profile%5Bno_shipping%5D=false\u0026merchant_id=dcpspy2brwdjr3qn\u0026return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess\u0026token=EC-HERMES-SANDBOX-EC-TOKEN\u0026offer_paypal_credit=true\u0026version=1\u0026useraction=commit";
-
+        String expectedUrl = "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource&amount=1.00&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&currency_iso_code=USD&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&token=EC-HERMES-SANDBOX-EC-TOKEN&offer_paypal_credit=true&version=1";
         PayPalResponse payPalResponse = captor.getValue();
         assertFalse(payPalResponse.isBillingAgreement());
         assertEquals("authorize", payPalResponse.getIntent());
@@ -545,56 +541,6 @@ public class PayPalInternalClientUnitTest {
         assertEquals("sample-scheme://onetouch/v1/success", payPalResponse.getSuccessUrl());
         assertEquals("EC-HERMES-SANDBOX-EC-TOKEN", payPalResponse.getPairingId());
         assertEquals("sample-client-metadata-id", payPalResponse.getClientMetadataId());
-        assertEquals(expectedUrl, payPalResponse.getApprovalUrl());
-    }
-
-    @Test
-    public void sendRequest_withPayPalCheckoutRequest_setsApprovalUrlUserActionToEmptyStringOnDefault() {
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
-                .build();
-
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
-
-        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
-        payPalRequest.setIntent("authorize");
-        payPalRequest.setMerchantAccountId("sample-merchant-account-id");
-
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
-
-        ArgumentCaptor<PayPalResponse> captor = ArgumentCaptor.forClass(PayPalResponse.class);
-        verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
-
-        String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource\u0026amount=1.00\u0026authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8\u0026cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel\u0026controller=client_api%2Fpaypal_hermes\u0026currency_iso_code=USD\u0026experience_profile%5Baddress_override%5D=false\u0026experience_profile%5Bno_shipping%5D=false\u0026merchant_id=dcpspy2brwdjr3qn\u0026return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess\u0026token=EC-HERMES-SANDBOX-EC-TOKEN\u0026offer_paypal_credit=true\u0026version=1\u0026useraction=";
-
-        PayPalResponse payPalResponse = captor.getValue();
-        assertEquals(expectedUrl, payPalResponse.getApprovalUrl());
-    }
-
-    @Test
-    public void sendRequest_withPayPalVaultRequest_setsApprovalUrlUserActionToEmptyStringOnDefault() {
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_BILLING_AGREEMENT_RESPONSE)
-                .build();
-
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
-
-        PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
-
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
-
-        ArgumentCaptor<PayPalResponse> captor = ArgumentCaptor.forClass(PayPalResponse.class);
-        verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
-
-        String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?action=create_payment_resource\u0026authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8\u0026cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel\u0026controller=client_api%2Fpaypal_hermes\u0026experience_profile%5Baddress_override%5D=false\u0026experience_profile%5Bno_shipping%5D=false\u0026merchant_id=dcpspy2brwdjr3qn\u0026return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess\u0026ba_token=EC-HERMES-SANDBOX-EC-TOKEN\u0026offer_paypal_credit=true\u0026version=1\u0026useraction=";
-
-        PayPalResponse payPalResponse = captor.getValue();
         assertEquals(expectedUrl, payPalResponse.getApprovalUrl());
     }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutRequest.java
@@ -212,6 +212,10 @@ public class PayPalNativeCheckoutRequest extends PayPalNativeRequest implements 
             experienceProfile.put(LOCALE_CODE_KEY, getLocaleCode());
         }
 
+        if (getUserAction() != USER_ACTION_DEFAULT) {
+            experienceProfile.put(USER_ACTION_KEY, getUserAction());
+        }
+
         if (getShippingAddressOverride() != null) {
             experienceProfile.put(ADDRESS_OVERRIDE_KEY, !isShippingAddressEditable());
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
@@ -38,6 +38,7 @@ public abstract class PayPalNativeRequest implements Parcelable {
     static final String MERCHANT_ACCOUNT_ID = "merchant_account_id";
     static final String CORRELATION_ID_KEY = "correlation_id";
     static final String LINE_ITEMS_KEY = "line_items";
+    static final String USER_ACTION_KEY = "user_action";
 
     private String localeCode;
     private String billingAgreementDescription;


### PR DESCRIPTION
### Summary of changes

- Remove appending query parameters to the URL from the PayPal flow and instead pass the `user_action` into the `experience_profile`
    - Not sure the historical context on passing this as a query item, but there is no regression on web when passing this in the `experience_profile` instead

### Visuals
This is the result of setting `request.setUserAction()` to `USER_ACTION_COMMIT` in both the web and MXO checkout flows with the changes in this PR:

| Web | MXO |
|-----|-----|
|![android-web-commit](https://github.com/braintree/braintree_android/assets/20733831/35826892-f575-499d-a7f7-171f294f61d7)|![mxo-commit](https://github.com/braintree/braintree_android/assets/20733831/1469c53b-6a09-443b-887c-e2dfede88433)|

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 