### PR TITLE
Add `setLocale()` to `SEPADirectDebitRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * PayPalNativeCheckout (BETA)
   * Fix bug where setting `setUserAction()` does not update button as expected
+* SEPADirectDebit
+  * Add `SEPADirectDebitRequest.setLocale()`
 
 ## 4.32.0
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitApi.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitApi.java
@@ -119,6 +119,10 @@ class SEPADirectDebitApi {
             requestData.putOpt("merchant_account_id", sepaDirectDebitRequest.getMerchantAccountId());
         }
 
+        if (sepaDirectDebitRequest.getLocale() != null) {
+            requestData.putOpt("locale", sepaDirectDebitRequest.getLocale());
+        }
+
         return requestData;
     }
 }

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitRequest.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitRequest.java
@@ -14,6 +14,7 @@ public class SEPADirectDebitRequest {
     private SEPADirectDebitMandateType mandateType = SEPADirectDebitMandateType.ONE_OFF;
     private PostalAddress billingAddress;
     private String merchantAccountId;
+    private String locale;
 
     /**
      * @return The account holder name
@@ -109,5 +110,21 @@ public class SEPADirectDebitRequest {
      */
     public void setMerchantAccountId(@Nullable String merchantAccountId) {
         this.merchantAccountId = merchantAccountId;
+    }
+
+    /**
+     * @return A locale code to use for creating a mandate.
+     */
+    @Nullable
+    public String getLocale() {
+        return locale;
+    }
+
+    /**
+     * Optional.
+     * @param locale A locale code to use for creating a mandate.
+     */
+    public void setLocale(@Nullable String locale) {
+        this.locale = locale;
     }
 }

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitRequest.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/SEPADirectDebitRequest.java
@@ -123,6 +123,9 @@ public class SEPADirectDebitRequest {
     /**
      * Optional.
      * @param locale A locale code to use for creating a mandate.
+     *
+     * @see <a href="https://developer.paypal.com/reference/locale-codes/">Documentation</a>
+     * for possible values. Locale code should be supplied as a BCP-47 formatted locale code.
      */
     public void setLocale(@Nullable String locale) {
         this.locale = locale;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/SEPADirectDebitApiUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/SEPADirectDebitApiUnitTest.java
@@ -10,8 +10,6 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import junit.framework.Assert;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/SEPADirectDebitApiUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/SEPADirectDebitApiUnitTest.java
@@ -3,12 +3,17 @@ package com.braintreepayments.api;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import junit.framework.Assert;
+
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +42,7 @@ public class SEPADirectDebitApiUnitTest {
         request.setIban("FR7618106000321234566666610");
         request.setMandateType(SEPADirectDebitMandateType.RECURRENT);
         request.setMerchantAccountId("a_merchant_account_id");
+        request.setLocale("fr-FR");
 
         billingAddress = new PostalAddress();
         billingAddress.setStreetAddress("Kantstraße 70");
@@ -45,6 +51,8 @@ public class SEPADirectDebitApiUnitTest {
         billingAddress.setRegion("Annaberg-buchholz");
         billingAddress.setPostalCode("09456");
         billingAddress.setCountryCodeAlpha2("FR");
+
+        request.setBillingAddress(billingAddress);
 
         returnUrl = "com.example";
     }
@@ -153,5 +161,39 @@ public class SEPADirectDebitApiUnitTest {
         sut.tokenize("1234", "a-customer-id", "a-bank-reference-token", "ONE_OFF", sepaDirectDebitTokenizeCallback);
 
         verify(sepaDirectDebitTokenizeCallback).onResult(null, error);
+    }
+
+    @Test
+    public void createMandate_properlyFormatsPOSTBody() throws JSONException {
+        BraintreeClient mockBraintreeClient = new MockBraintreeClientBuilder()
+                .returnUrlScheme("com.example")
+                .build();
+
+        SEPADirectDebitApi sut = new SEPADirectDebitApi(mockBraintreeClient);
+        sut.createMandate(request, returnUrl, createMandateCallback);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockBraintreeClient).sendPOST(eq("v1/sepa_debit"), String.valueOf(captor.capture()), any(HttpResponseCallback.class));
+
+        String result = captor.getValue();
+        JSONObject json = new JSONObject(result);
+        assertEquals("com.example://sepa/cancel", json.getString("cancel_url"));
+        assertEquals("com.example://sepa/success", json.getString("return_url"));
+        assertEquals("a_merchant_account_id", json.getString("merchant_account_id"));
+        assertEquals("fr-FR", json.getString("locale"));
+
+        JSONObject sepaJson = json.getJSONObject("sepa_debit");
+        assertEquals("John Doe", sepaJson.getString("account_holder_name"));
+        assertEquals("a-customer-id", sepaJson.getString("merchant_or_partner_customer_id"));
+        assertEquals("FR7618106000321234566666610", sepaJson.getString("iban"));
+        assertEquals("RECURRENT", sepaJson.getString("mandate_type"));
+
+        JSONObject billingAddressJson = sepaJson.getJSONObject("billing_address");
+        assertEquals("Kantstraße 70", billingAddressJson.getString("address_line_1"));
+        assertEquals("#170", billingAddressJson.getString("address_line_2"));
+        assertEquals("Freistaat Sachsen", billingAddressJson.getString("admin_area_1"));
+        assertEquals("Annaberg-buchholz", billingAddressJson.getString("admin_area_2"));
+        assertEquals("09456", billingAddressJson.getString("postal_code"));
+        assertEquals("FR", billingAddressJson.getString("country_code"));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Add the ability to set a locale when creating a SEPA direct debit request

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
