### PR TITLE
Add `getCardNetwork` to `GooglePayCardNonce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* GooglePay
+  * Add `GooglePayCardNonce.getCardNetwork()`
+
 ## 4.34.0
 
 * GooglePay

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -228,7 +228,6 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         return cardNetwork;
     }
 
-
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -24,6 +24,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
     private static final String LAST_TWO_KEY = "lastTwo";
     private static final String LAST_FOUR_KEY = "lastFour";
     private static final String IS_NETWORK_TOKENIZED_KEY = "isNetworkTokenized";
+    private static final String CARD_NETWORK_KEY = "cardNetwork";
 
     private static final String PAYMENT_METHOD_NONCE_KEY = "nonce";
     private static final String PAYMENT_METHOD_DEFAULT_KEY = "default";
@@ -33,6 +34,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
     private final String lastTwo;
     private final String lastFour;
     private final String email;
+    private final String cardNetwork;
     private boolean isNetworkTokenized;
     private final PostalAddress billingAddress;
     private final PostalAddress shippingAddress;
@@ -68,6 +70,8 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
                 .getJSONObject("paymentMethodData")
                 .getJSONObject("info");
 
+        String cardNetwork = info.getString(CARD_NETWORK_KEY);
+
         JSONObject billingAddressJson = new JSONObject();
         if (info.has("billingAddress")) {
             billingAddressJson = info.getJSONObject("billingAddress");
@@ -89,7 +93,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         String cardType = details.getString(CARD_TYPE_KEY);
         boolean isNetworkTokenized = details.optBoolean(IS_NETWORK_TOKENIZED_KEY, false);
 
-        return new GooglePayCardNonce(cardType, bin, lastTwo, lastFour, email, isNetworkTokenized, billingAddress, shippingAddress, binData, nonce, isDefault);
+        return new GooglePayCardNonce(cardType, bin, lastTwo, lastFour, email, isNetworkTokenized, billingAddress, shippingAddress, binData, nonce, isDefault, cardNetwork);
     }
 
     GooglePayCardNonce(
@@ -103,8 +107,9 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
             PostalAddress shippingAddress,
             BinData binData,
             String nonce,
-            boolean isDefault
-    ) {
+            boolean isDefault,
+            String cardNetwork
+            ) {
         super(nonce, isDefault);
         this.cardType = cardType;
         this.bin = bin;
@@ -115,6 +120,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         this.billingAddress = billingAddress;
         this.shippingAddress = shippingAddress;
         this.binData = binData;
+        this.cardNetwork = cardNetwork;
     }
 
     static PostalAddress postalAddressFromJson(JSONObject json) {
@@ -214,6 +220,15 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         return binData;
     }
 
+    /**
+     * @return The card network. This card network value should not be displayed.
+     */
+    @NonNull
+    public String getCardNetwork() {
+        return cardNetwork;
+    }
+
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
@@ -226,6 +241,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         dest.writeParcelable(shippingAddress, flags);
         dest.writeParcelable(binData, flags);
         dest.writeByte(isNetworkTokenized ? (byte) 1 : (byte) 0);
+        dest.writeString(cardNetwork);
     }
 
     private GooglePayCardNonce(Parcel in) {
@@ -239,6 +255,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
         shippingAddress = in.readParcelable(PostalAddress.class.getClassLoader());
         binData = in.readParcelable(BinData.class.getClassLoader());
         isNetworkTokenized = in.readByte() > 0;
+        cardNetwork = in.readString();
     }
 
     public static final Creator<GooglePayCardNonce> CREATOR = new Creator<GooglePayCardNonce>() {

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -221,7 +221,7 @@ public class GooglePayCardNonce extends PaymentMethodNonce {
     }
 
     /**
-     * @return The card network. This card network value should not be displayed.
+     * @return The card network. This card network value should not be displayed to the buyer.
      */
     @NonNull
     public String getCardNetwork() {

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayCardNonceUnitTest.java
@@ -37,6 +37,7 @@ public class GooglePayCardNonceUnitTest {
         assertPostalAddress(billingPostalAddress, googlePayCardNonce.getBillingAddress());
         assertPostalAddress(shippingPostalAddress, googlePayCardNonce.getShippingAddress());
         assertTrue(googlePayCardNonce.isNetworkTokenized());
+        assertEquals("VISA", googlePayCardNonce.getCardNetwork());
     }
 
     @Test
@@ -109,6 +110,7 @@ public class GooglePayCardNonceUnitTest {
         assertTrue(parceled.isNetworkTokenized());
         assertPostalAddress(billingPostalAddress, parceled.getBillingAddress());
         assertPostalAddress(shippingPostalAddress, parceled.getShippingAddress());
+        assertEquals("VISA", parceled.getCardNetwork());
 
         assertBinDataEqual(googlePayCardNonce.getBinData(), parceled.getBinData());
     }


### PR DESCRIPTION
### Summary of changes

 - Add `getCardNetwork` to `GooglePayCardNonce`
 - Update test to add `getCardNetwork`
 - Verified card network is returned as expected in demo app
     - **Note:** we do not have a way to explicity test Maestro cards since Google does not provide them in their test card suite and we do not not have access to a valid Maestro card to add to the Google Wallet

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 