### PR TITLE
Revert Kotlin Version to 1.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* All Modules
+  * Revert Kotlin version to `1.7.10`
+
 ## 4.35.0
 
 * GooglePay

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     def roomVersion = System.getenv('CI') ? java7SafeRoomVersion : m1MacSafeRoomVersion
 
     ext.versions = [
-            "kotlin"         : "1.8.0",
+            "kotlin"         : "1.7.10",
             "androidxTest"   : "1.4.0",
             // NEXT MAJOR VERSION: Use a single up-to-date room version once we remove Java 7 support in favor of Java 11
             "room"           : roomVersion,


### PR DESCRIPTION
### Summary of changes

 - Revert Kotlin version to `1.7.10`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
