### PR TITLE
Add Date to CHANGELOG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ task changeMigrationGuideVersion {
 task updateCHANGELOGVersion {
     doLast {
         def changelogFile = new File('CHANGELOG.md')
-        def changelogFileText = changelogFile.text.replaceFirst("## unreleased", "## " + versionParam)
+        def changelogFileText = changelogFile.text.replaceFirst("## unreleased", "## " + versionParam + " (" + new Date().format('yyyy-MM-dd') + ")")
         changelogFile.write(changelogFileText)
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Add date to android changelog
     - We should decide if we want a separate PR to retroactively add all dates, or just want to roll with dates moving forward
     - This matches the date format of the [iOS CHANGELOG](https://github.com/braintree/braintree_ios/blob/main/CHANGELOG.md#braintree-ios-sdk-release-notes)

You can test this locally by adding an `##unreleased` section to to changelog and running `./gradlew -PversionParam=9999.9999.9999 updateCHANGELOGVersion` in the terminal. Below is a screenshot of my test.

| Before | After |
|-----|-----|
|![Screenshot 2023-07-21 at 1 33 13 PM](https://github.com/braintree/braintree_android/assets/20733831/37af2333-47c3-49db-941b-65229c1890df)|![Screenshot 2023-07-21 at 1 35 31 PM](https://github.com/braintree/braintree_android/assets/20733831/7e38e314-d96f-4785-8b9d-79b51ae71f21)|

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
