### PR TITLE
fixing execute nonce request for paypal native checkout

### DIFF
--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccount.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccount.java
@@ -53,10 +53,7 @@ class PayPalNativeCheckoutAccount extends PaymentMethod {
         Iterator<String> urlResponseDataKeyIterator = urlResponseData.keys();
         while (urlResponseDataKeyIterator.hasNext()) {
             String key = urlResponseDataKeyIterator.next();
-
-            JSONObject response = new JSONObject();
-            response.put("webURL", urlResponseData.get(key));
-            paymentMethodNonceJson.put("response", response);
+            paymentMethodNonceJson.put(key, urlResponseData.get(key));
         }
 
         if (merchantAccountId != null) {

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -293,7 +293,7 @@ public class PayPalNativeCheckoutClient {
             }
             urlResponseData.put("response", response);
             urlResponseData.put("response_type", "web");
-            payPalAccount.setUrlResponseData(response);
+            payPalAccount.setUrlResponseData(urlResponseData);
         } catch (JSONException jsonException) {
             listener.onPayPalFailure(jsonException);
         }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Fixing the `request` to execute nonce API call for PayPal Native Checkout

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ghbhatt
