### PR TITLE
[3.x] Fix LPM Configuration Bug

### DIFF
--- a/Braintree/src/main/java/com/braintreepayments/api/LocalPayment.java
+++ b/Braintree/src/main/java/com/braintreepayments/api/LocalPayment.java
@@ -61,7 +61,7 @@ public class LocalPayment {
         fragment.waitForConfiguration(new ConfigurationListener() {
             @Override
             public void onConfigurationFetched(Configuration configuration) {
-                if (!configuration.getPayPal().isEnabled()) {
+                if (!configuration.isPayPalEnabled()) {
                     fragment.postCallback(new ConfigurationException("Local payments are not enabled for this merchant."));
                     return;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* LocalPayment
+  * Fixed bug where the configuration was not returned the expected result for Local Payment Methods being enabled
+
 ## 3.21.0
 
 * BraintreeDataCollector

--- a/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentsActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentsActivity.java
@@ -40,7 +40,7 @@ public class LocalPaymentsActivity extends BaseActivity implements PaymentMethod
         }
 
         try {
-            mBraintreeFragment = BraintreeFragment.newInstance(this, Settings.getLocalPaymentsTokenizationKey(this));
+            mBraintreeFragment = BraintreeFragment.newInstance(this, "sandbox_f252zhq7_hh4cpc39zq4rgjcg");
             mIdealButton.setEnabled(true);
         } catch (InvalidArgumentException e) {
             onError(e);


### PR DESCRIPTION
### Summary of changes

 - Seems like something changed with client tokens/the gateway and `configuration.getPayPal().isEnabled()` now returns for merchants enabled for PayPal/Local Payment Methods. We note that `isEnabled` is deprecated and switching to use `isPayPalEnabled` returns the correct result for LPM enabled merchants.
 - The tokenization key we were using didn't support LPMs - pulled the one being used from iOS in the LPM ViewController to test things are now working as expected.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 