### PR TITLE
Update PayPalNativeCheckout Min SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPalNativeCheckout
+  * Bumpe min SDK version to 23 to prevent crashes on lower Android versions
+
 ## 4.37.0 (2023-08-22)
 
 * PayPalNativeCheckout

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -8,7 +8,8 @@ android {
 
     defaultConfig {
         applicationId "com.braintreepayments.demo"
-        minSdkVersion rootProject.minSdkVersion
+        // required for PayPalNativeCheckout module
+        minSdkVersion 23
         targetSdkVersion rootProject.targetSdkVersion
         versionCode rootProject.versionCode
         versionName rootProject.versionName

--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.braintreepayments.demo">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".DemoApplication"

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -10,7 +10,8 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
+        // required to be out of sync with other modules due to checkout SDK min version
+        minSdkVersion 23
         targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 **The Braintree SDK supports Android API 21 and above.**
 
 The PayPalNativeCheckout module supports Android API 23 and above.
+
 The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
+
 The Braintree SDK uses Kotlin 1.7. 
 
 ## Adding It To Your Project

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 
 > The PayPalNativeCheckout module supports Android API 23 and above.
 
-> The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
-
-> The Braintree SDK uses Kotlin 1.7. 
+The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details. The Braintree SDK uses Kotlin 1.7. 
 
 ## Adding It To Your Project
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 
 :mega:&nbsp;&nbsp;A new major version of the SDK is now available. See the [v4.9.0+ migration guide](v4.9.0+_MIGRATION_GUIDE.md) for details.
 
-**The Braintree SDK supports Android API 21 and above.**
+**The Braintree SDK supports Android API 21 and above. **
 
-> Note: The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
+> The PayPalNativeCheckout module supports Android API 23 and above.
+> The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
+> The Braintree SDK uses Kotlin 1.7. 
 
 ## Adding It To Your Project
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 
 **The Braintree SDK supports Android API 21 and above.**
 
-The PayPalNativeCheckout module supports Android API 23 and above.
+> The PayPalNativeCheckout module supports Android API 23 and above.
 
-The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
+> The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
 
-The Braintree SDK uses Kotlin 1.7. 
+> The Braintree SDK uses Kotlin 1.7. 
 
 ## Adding It To Your Project
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 
 :mega:&nbsp;&nbsp;A new major version of the SDK is now available. See the [v4.9.0+ migration guide](v4.9.0+_MIGRATION_GUIDE.md) for details.
 
-**The Braintree SDK supports Android API 21 and above. **
+**The Braintree SDK supports Android API 21 and above.**
 
-> The PayPalNativeCheckout module supports Android API 23 and above.
-> The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
-> The Braintree SDK uses Kotlin 1.7. 
+The PayPalNativeCheckout module supports Android API 23 and above.
+The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md#4240) for more details.
+The Braintree SDK uses Kotlin 1.7. 
 
 ## Adding It To Your Project
 


### PR DESCRIPTION
### Summary of changes

 - Update PayPalNativeCheckout module min SDK version to 23 to prevent crashes on lower API versions
 - Fix lint error in Demo app

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
