### PR TITLE
Android 14 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* All Modules
+  * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34
 * ThreeDSecure
   * Bump Cardinal version to `2.2.7-4`
 * BraintreeCore

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
 
     androidTestImplementation 'com.braintreepayments:device-automator:1.0.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/SharedUtils/src/main/java/com/braintreepayments/api/SynchronousHttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/SynchronousHttpClient.java
@@ -73,8 +73,8 @@ class SynchronousHttpClient {
             httpRequest.dispose();
         }
 
-        int responseCode = connection.getResponseCode();
         try {
+            int responseCode = connection.getResponseCode();
             return parser.parse(responseCode, connection);
         } finally {
             connection.disconnect();

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -906,7 +906,7 @@ object Fixtures {
             "merchantId": "some-merchant-id",
             "merchantAccountId": "some-merchant-account-id",
             "analytics": {
-                "url": "https://client-analytics.braintreegateway.com/some-merchant-id"
+                "url": "https://client-analytics.braintreegateway.com/dcpspy2brwdjr3qn"
             }
         }
     """

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -906,7 +906,7 @@ object Fixtures {
             "merchantId": "some-merchant-id",
             "merchantAccountId": "some-merchant-account-id",
             "analytics": {
-                "url": "https://client-analytics.braintreegateway.com/dcpspy2brwdjr3qn"
+                "url": "https://client-analytics.braintreegateway.com/abc"
             }
         }
     """
@@ -951,7 +951,7 @@ object Fixtures {
             "merchantId": "some-merchant-id",
             "merchantAccountId": "some-merchant-account-id",
             "analytics": {
-                "url": "https://origin-analytics-sand.sandbox.braintree-api.com/dcpspy2brwdjr3qn"
+                "url": "https://origin-analytics-sand.sandbox.braintree-api.com/abc"
             }
         }
     """

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -951,7 +951,7 @@ object Fixtures {
             "merchantId": "some-merchant-id",
             "merchantAccountId": "some-merchant-account-id",
             "analytics": {
-                "url": "https://origin-analytics-sand.sandbox.braintree-api.com/some-merchant-id"
+                "url": "https://origin-analytics-sand.sandbox.braintree-api.com/dcpspy2brwdjr3qn"
             }
         }
     """

--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ allprojects {
 
 version '4.37.1-SNAPSHOT'
 ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     minSdkVersion = 21
     versionCode = 179
-    targetSdkVersion = 33
+    targetSdkVersion = 34
     versionName = version
 }
 


### PR DESCRIPTION
### Summary of changes

 - Update compileSdkVersion and targetSdkVersion to API 34 (Android 14) 
 - TODO: Update browser switch version when released with [Android 14 support change](https://github.com/braintree/browser-switch-android/pull/69)

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
