### PR TITLE
Bump Browser Switch to Version 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * ThreeDSecure
   * Bump Cardinal version to `2.2.7-4`
 * BraintreeCore
-  * Bump `browser-switch` version to `2.5.1`
+  * Bump `browser-switch` version to `2.6.0`
 * PayPalNativeCheckout
   * Bump min SDK version to 23 to prevent crashes on lower Android versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ buildscript {
             // kotlin libraries. Make sure to keep this dependency in line with the kotlin version used.
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
-            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.5.1",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.6.0",
             "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-4",
             "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",


### PR DESCRIPTION
### Summary of changes

 - Bump `browser-switch` version to `2.6.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
