### PR TITLE
Bump Cardinal Version to 2.2.7-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ThreeDSecure
+  * Bump Cardinal version to `2.2.7-5`
+
 ## 4.38.0 (2023-09-06)
 
 * All Modules

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
 
             "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.6.0",
-            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-4",
+            "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-5",
             "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
 


### PR DESCRIPTION
### Summary of changes

* ThreeDSecure
  * Bump Cardinal version to `2.2.7-5`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
