### PR TITLE
Make BraintreeClient Constructor with BraintreeOptions Library Private

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -62,7 +62,8 @@ open class BraintreeClient @VisibleForTesting internal constructor(
         braintreeDeepLinkReturnUrlScheme = params.braintreeReturnUrlScheme
     )
 
-    internal constructor(options: BraintreeOptions) : this(BraintreeClientParams(options))
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(options: BraintreeOptions) : this(BraintreeClientParams(options))
 
     /**
      * Create a new instance of [BraintreeClient] using a tokenization key or client token.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeOptions.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeOptions.kt
@@ -1,8 +1,13 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 
-internal data class BraintreeOptions(
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class BraintreeOptions @JvmOverloads constructor(
     val context: Context,
     val sessionId: String? = null,
     val returnUrlScheme: String? = null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* BraintreeCore
+  * Internal Fixes
+
 ## 4.38.1 (2023-09-14)
 
 * ThreeDSecure


### PR DESCRIPTION
### Summary of changes

 - Make BraintreeClient Constructor with BraintreeOptions `library-private`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
