### PR TITLE
[DO NOT MERGE] Spike v5 Launcher API

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PreferredPaymentMethodsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PreferredPaymentMethodsFragment.java
@@ -108,6 +108,6 @@ public class PreferredPaymentMethodsFragment extends BaseFragment {
             if (requestError != null) {
                 handleError(requestError);
             }
-        });
+        }, null);
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
@@ -45,8 +45,8 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
 
         venmoLauncher = new VenmoLauncher(this, new VenmoResultCallback() {
             @Override
-            public void onVenmoResult(VenmoAccountNonce venmoAccountNonce) {
-                onVenmoSuccess(venmoAccountNonce);
+            public void onVenmoResult(VenmoResult venmoResult) {
+                venmoClient.onVenmoResult(venmoResult);
             }
         });
 
@@ -70,6 +70,7 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
                 Settings.vaultVenmo(activity) && !TextUtils.isEmpty(Settings.getCustomerId(activity));
         braintreeClient = getBraintreeClient();
         venmoClient = new VenmoClient(this, braintreeClient);
+        venmoClient.setListener(this);
 
         braintreeClient.getConfiguration((configuration, error) -> {
             if (venmoClient.isVenmoAppSwitchAvailable(activity)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
@@ -43,12 +43,7 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
         venmoButton = view.findViewById(R.id.venmo_button);
         venmoButton.setOnClickListener(this::launchVenmo);
 
-        venmoLauncher = new VenmoLauncher(this, new VenmoResultCallback() {
-            @Override
-            public void onVenmoResult(VenmoResult venmoResult) {
-                venmoClient.onVenmoResult(venmoResult);
-            }
-        });
+        venmoLauncher = new VenmoLauncher(this, venmoResult -> venmoClient.onVenmoResult(venmoResult));
 
         return view;
     }
@@ -69,7 +64,7 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
         boolean shouldVault =
                 Settings.vaultVenmo(activity) && !TextUtils.isEmpty(Settings.getCustomerId(activity));
         braintreeClient = getBraintreeClient();
-        venmoClient = new VenmoClient(this, braintreeClient);
+        venmoClient = new VenmoClient(braintreeClient);
         venmoClient.setListener(this);
 
         braintreeClient.getConfiguration((configuration, error) -> {
@@ -88,12 +83,7 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
                 lineItems.add(new VenmoLineItem(VenmoLineItem.KIND_DEBIT, "Two Items", 2, "10"));
                 venmoRequest.setLineItems(lineItems);
 
-                venmoClient.tokenizeVenmoAccount(activity, venmoRequest, null, new VenmoIntenDataCallback() {
-                    @Override
-                    public void onVenmoIntentData(VenmoIntentData venmoIntentData) {
-                        venmoLauncher.launch(venmoIntentData);
-                    }
-                });
+                venmoClient.tokenizeVenmoAccount(activity, venmoRequest, venmoIntentData -> venmoLauncher.launch(venmoIntentData));
             } else if (configuration.isVenmoEnabled()) {
                 showDialog("Please install the Venmo app first.");
             } else {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -254,7 +254,7 @@ public class VenmoClient {
         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
     }
 
-    void onVenmoResult(final VenmoResult venmoResult) {
+    public void onVenmoResult(final VenmoResult venmoResult) {
         if (venmoResult.getError() == null) {
             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success");
 
@@ -267,7 +267,6 @@ public class VenmoClient {
                         String paymentContextId = venmoResult.getPaymentContextId();
                         if (paymentContextId != null) {
                             venmoApi.createNonceFromPaymentContext(paymentContextId, new VenmoOnActivityResultCallback() {
-                                @Override
                                 public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
                                     if (nonce != null) {
                                         boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -144,6 +144,16 @@ public class VenmoClient {
                 });
     }
 
+    public void tokenizeVenmoAccount(@NonNull final FragmentActivity activity, @NonNull final VenmoRequest request, VenmoIntenDataCallback callback) {
+       tokenizeVenmoAccount(activity, request, new VenmoTokenizeAccountCallback() {
+           @Override
+           public void onResult(@Nullable Exception error) {
+               if (error != null) {
+                   listener.onVenmoFailure(error);
+               }
+           }
+       }, callback);
+    }
     /**
      * Start the Pay With Venmo flow. This will app switch to the Venmo app.
      * <p>
@@ -201,7 +211,7 @@ public class VenmoClient {
                                 @Override
                                 public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception authError) {
                                     if (authorization != null) {
-                                        startVenmoActivityForResult(activity, request, configuration, authorization, finalVenmoProfileId, paymentContextId, intentDataCallback);
+                                        createVenmoIntentData(activity, request, configuration, authorization, finalVenmoProfileId, paymentContextId, intentDataCallback);
                                     } else {
                                         callback.onResult(authError);
                                     }
@@ -237,7 +247,7 @@ public class VenmoClient {
         }
         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
     }
-    private void startVenmoActivityForResult(
+    private void createVenmoIntentData(
             final FragmentActivity activity,
             final VenmoRequest request,
             final Configuration configuration,

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoIntenDataCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoIntenDataCallback.java
@@ -1,0 +1,6 @@
+package com.braintreepayments.api;
+
+public interface VenmoIntenDataCallback {
+
+    void onVenmoIntentData(VenmoIntentData venmoIntentData);
+}

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoIntentData.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoIntentData.java
@@ -1,6 +1,6 @@
 package com.braintreepayments.api;
 
-class VenmoIntentData {
+public class VenmoIntentData {
 
     private final Configuration configuration;
     private final String profileId;

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -13,10 +13,6 @@ public class VenmoLauncher {
         activityLauncher = fragment.getActivity().getActivityResultRegistry().register(VENMO_SECURE_RESULT, fragment.getViewLifecycleOwner(), new VenmoActivityResultContract(), callback::onVenmoResult);
     }
 
-    public VenmoLauncher(FragmentActivity activity, VenmoResultCallback callback) {
-        activityLauncher = activity.getActivityResultRegistry().register(VENMO_SECURE_RESULT, activity, new VenmoActivityResultContract(), callback::onVenmoResult);
-    }
-
     public void launch(VenmoIntentData venmoIntentData) {
         activityLauncher.launch(venmoIntentData);
     }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -1,0 +1,25 @@
+package com.braintreepayments.api;
+
+
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.fragment.app.Fragment;
+
+public class VenmoLauncher {
+    ActivityResultLauncher<VenmoIntentData> activityLauncher;
+    private static final String VENMO_SECURE_RESULT = "com.braintreepayments.api.Venmo.RESULT";
+
+    public VenmoLauncher(Fragment fragment, VenmoResultCallback callback) {
+        activityLauncher = fragment.getActivity().getActivityResultRegistry().register(VENMO_SECURE_RESULT, fragment.getViewLifecycleOwner(), new VenmoActivityResultContract(), new ActivityResultCallback<VenmoResult>() {
+            @Override
+            public void onActivityResult(VenmoResult venmoResult) {
+                VenmoAccountNonce nonce = new VenmoAccountNonce(venmoResult.getVenmoAccountNonce(), venmoResult.getVenmoUsername(), false);
+                callback.onVenmoResult(nonce);
+            }
+        });
+    }
+
+    public void launch(VenmoIntentData venmoIntentData) {
+        activityLauncher.launch(venmoIntentData);
+    }
+}

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -1,21 +1,20 @@
 package com.braintreepayments.api;
 
 
-import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 
 public class VenmoLauncher {
     ActivityResultLauncher<VenmoIntentData> activityLauncher;
     private static final String VENMO_SECURE_RESULT = "com.braintreepayments.api.Venmo.RESULT";
 
     public VenmoLauncher(Fragment fragment, VenmoResultCallback callback) {
-        activityLauncher = fragment.getActivity().getActivityResultRegistry().register(VENMO_SECURE_RESULT, fragment.getViewLifecycleOwner(), new VenmoActivityResultContract(), new ActivityResultCallback<VenmoResult>() {
-            @Override
-            public void onActivityResult(VenmoResult venmoResult) {
-                callback.onVenmoResult(venmoResult);
-            }
-        });
+        activityLauncher = fragment.getActivity().getActivityResultRegistry().register(VENMO_SECURE_RESULT, fragment.getViewLifecycleOwner(), new VenmoActivityResultContract(), callback::onVenmoResult);
+    }
+
+    public VenmoLauncher(FragmentActivity activity, VenmoResultCallback callback) {
+        activityLauncher = activity.getActivityResultRegistry().register(VENMO_SECURE_RESULT, activity, new VenmoActivityResultContract(), callback::onVenmoResult);
     }
 
     public void launch(VenmoIntentData venmoIntentData) {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -13,8 +13,7 @@ public class VenmoLauncher {
         activityLauncher = fragment.getActivity().getActivityResultRegistry().register(VENMO_SECURE_RESULT, fragment.getViewLifecycleOwner(), new VenmoActivityResultContract(), new ActivityResultCallback<VenmoResult>() {
             @Override
             public void onActivityResult(VenmoResult venmoResult) {
-                VenmoAccountNonce nonce = new VenmoAccountNonce(venmoResult.getVenmoAccountNonce(), venmoResult.getVenmoUsername(), false);
-                callback.onVenmoResult(nonce);
+                callback.onVenmoResult(venmoResult);
             }
         });
     }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoResult.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoResult.java
@@ -24,7 +24,7 @@ public class VenmoResult {
         return paymentContextId;
     }
 
-    public String getVenmoAccountNonce() {
+    String getVenmoAccountNonce() {
         return venmoAccountNonce;
     }
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoResult.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoResult.java
@@ -2,7 +2,7 @@ package com.braintreepayments.api;
 
 import androidx.annotation.Nullable;
 
-class VenmoResult {
+public class VenmoResult {
 
     private final Exception error;
     private final String paymentContextId;
@@ -24,7 +24,7 @@ class VenmoResult {
         return paymentContextId;
     }
 
-    String getVenmoAccountNonce() {
+    public String getVenmoAccountNonce() {
         return venmoAccountNonce;
     }
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoResultCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoResultCallback.java
@@ -1,0 +1,6 @@
+package com.braintreepayments.api;
+
+public interface VenmoResultCallback {
+
+    void onVenmoResult(VenmoAccountNonce venmoAccountNonce);
+}

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoResultCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoResultCallback.java
@@ -2,5 +2,5 @@ package com.braintreepayments.api;
 
 public interface VenmoResultCallback {
 
-    void onVenmoResult(VenmoAccountNonce venmoAccountNonce);
+    void onVenmoResult(VenmoResult venmoResult);
 }


### PR DESCRIPTION
### Summary of changes

This PR spikes out the new API described by [this ADR](https://github.com/braintree/braintree_android/pull/729/files?short_path=2d6a306#diff-2d6a306fd0619500139b9b9405e53b0e91e02475a81bf3f704f4c25cf5247dac) using the Venmo flow as an example.

These changes remove Android Lifecycle from the client objects and allow for increased merchant integration flexibility (in this PR I've moved the instantiation of BraintreeClient and VenmoClient out of onCreate to immediately before tokenize - which is not currently possible with v4). 

Some open questions:

**Result Handling**
- v4 added optional listeners that merchants could implement to handle results instead of callbacks - do we want to continue using the listeners to lessen integration changes for merchants or use callbacks or async methods for results?

**Deprecating/Removing API**
- How much of the v4 API should we continue to support? 
- We have three existing constructors for each client, and this new API will use the currently deprecated one. Removing the other two and keeping the deprecated one would be best for code cleanliness and reducing future confusion, but it is not the best for merchant developer experience to keep a deprecated API and remove the non-deprecated ones.
- We also have multiple "tokenize" and result handling code paths in v4 - for simplicity it might be best to just move forward with the launcher pattern, but it is more difficult for merchant upgrades.

 ### Checklist

 ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
- @sshropshire 
