### PR TITLE
Bump Min SDK to 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Breaking Changes
+  * All Modules
+    * Bump `minSdkVersion` to API 23
   * UnionPay
     * Remove `union-pay` module
       * UnionPay cards can now be processed as regular cards (through the `card` module) due to their partnership with Discover

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -8,8 +8,7 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        // required to be out of sync with other modules due to checkout SDK min version
-        minSdkVersion 23
+        minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Welcome to Braintree's Android SDK. This library will help you accept card and a
 
 :mega:&nbsp;&nbsp;A new major version of the SDK is now available. See the [v4.9.0+ migration guide](v4.9.0+_MIGRATION_GUIDE.md) for details.
 
-**The Braintree SDK supports Android API 21 and above.**
-
-> The PayPalNativeCheckout module supports Android API 23 and above.
+**The Braintree SDK supports Android API 23 and above.**
 
 The Braintree SDK requires Java 8 as of version 4.24.0. See the [CHANGELOG](https://github.com/braintree/braintree_android/blob/main/CHANGELOG.md#4240) for more details. The Braintree SDK uses Kotlin 1.7. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ version '4.38.3-SNAPSHOT'
 group 'com.braintreepayments'
 ext {
     compileSdkVersion = 34
-    minSdkVersion = 21
+    minSdkVersion = 23
     versionCode = 182
     targetSdkVersion = 34
     versionName = version

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -4,8 +4,13 @@ See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migratio
 
 ## Table of Contents
 
+1. [Android API](#android-api)
 1. [Union Pay](#union-pay)
 
+## Android API
+
+The minimum supported Android API level for v5 of this SDK has increased to 23.
+ 
 ## Union Pay
 
 The `union-pay` module, and all containing classes, was removed in v5. UnionPay cards can now be processed as regular cards, through the `card` module. You no longer need to manage card enrollment via SMS authorization.


### PR DESCRIPTION
### Summary of changes

 - Bump the minimum required Android API version to 23 across all modules

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
