### PR TITLE
GooglePay Credit Card Disabled Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * BraintreeCore
   * Remove beta features `PreferredPaymentMethodsClient`, `PreferredPaymentMethodsResult`, and `PreferredPaymentmethodsCallback`
+* GooglePay
+  * Fix bug where credit cards were allowed when `GooglePayRequest#setAllowedCreditCards(false)`
 
 ## 4.38.2 (2023-09-18)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
@@ -92,11 +92,8 @@ public class GooglePayFragment extends BaseFragment implements GooglePayListener
                 .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
                 .build());
         googlePayRequest.setAllowPrepaidCards(Settings.areGooglePayPrepaidCardsAllowed(activity));
-        googlePayRequest.setAllowCreditCards(true);
-        googlePayRequest.setPayPalEnabled(true);
         googlePayRequest.setBillingAddressFormat(WalletConstants.BILLING_ADDRESS_FORMAT_FULL);
-//        googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
-        googlePayRequest.setBillingAddressRequired(true);
+        googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
         googlePayRequest.setEmailRequired(Settings.isGooglePayEmailRequired(activity));
         googlePayRequest.setPhoneNumberRequired(Settings.isGooglePayPhoneNumberRequired(activity));
         googlePayRequest.setShippingAddressRequired(Settings.isGooglePayShippingAddressRequired(activity));

--- a/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/GooglePayFragment.java
@@ -92,8 +92,11 @@ public class GooglePayFragment extends BaseFragment implements GooglePayListener
                 .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
                 .build());
         googlePayRequest.setAllowPrepaidCards(Settings.areGooglePayPrepaidCardsAllowed(activity));
+        googlePayRequest.setAllowCreditCards(true);
+        googlePayRequest.setPayPalEnabled(true);
         googlePayRequest.setBillingAddressFormat(WalletConstants.BILLING_ADDRESS_FORMAT_FULL);
-        googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
+//        googlePayRequest.setBillingAddressRequired(Settings.isGooglePayBillingAddressRequired(activity));
+        googlePayRequest.setBillingAddressRequired(true);
         googlePayRequest.setEmailRequired(Settings.isGooglePayEmailRequired(activity));
         googlePayRequest.setPhoneNumberRequired(Settings.isGooglePayPhoneNumberRequired(activity));
         googlePayRequest.setShippingAddressRequired(Settings.isGooglePayShippingAddressRequired(activity));

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayRequest.java
@@ -272,16 +272,17 @@ public class GooglePayRequest implements Parcelable {
                         .put("tokenizationSpecification", tokenizationSpecifications.get(pm.getKey()));
 
                 if ("CARD".equals(pm.getKey())) {
+                    JSONObject paymentMethodParams = paymentMethod.getJSONObject("parameters");
+                    paymentMethodParams
+                            .put("billingAddressRequired", isBillingAddressRequired())
+                            .put("allowPrepaidCards", getAllowPrepaidCards())
+                            .put("allowCreditCards", isCreditCardsAllowed());
                     try {
-                        pm.getValue().get("billingAddressParameters");
-                    } catch (JSONException ignored) {
-                        JSONObject paymentMethodParams = paymentMethod.getJSONObject("parameters");
+                        JSONObject billingAddressParameters = (JSONObject) pm.getValue().get(
+                                "billingAddressParameters");
                         paymentMethodParams
-                                .put("billingAddressRequired", isBillingAddressRequired())
-                                .put("allowPrepaidCards", getAllowPrepaidCards())
-                                .put("allowCreditCards", isCreditCardsAllowed());
-
-
+                                .put("billingAddressParameters", billingAddressParameters);
+                    } catch (JSONException ignored) {
                         if (isBillingAddressRequired()) {
                             paymentMethodParams
                                     .put("billingAddressParameters", new JSONObject()

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
@@ -231,7 +231,7 @@ public class GooglePayRequestUnitTest {
     }
 
     @Test
-    public void generatesToJsonRequest_whenCreditCardNotAllowed_billingAddressNotRequired() throws JSONException {
+    public void generatesToJsonRequest_whenCreditCardNotAllowed_billingAddressRequired() throws JSONException {
         GooglePayRequest request = new GooglePayRequest();
         String expected = Fixtures.PAYMENT_METHODS_GOOGLE_PAY_REQUEST_NO_CREDIT_CARDS;
         List<String> shippingAllowedCountryCodes = Arrays.asList("US", "CA", "MX", "GB");
@@ -281,7 +281,7 @@ public class GooglePayRequestUnitTest {
         request.setEmailRequired(true);
         request.setShippingAddressRequired(true);
         request.setShippingAddressRequirements(shippingAddressRequirements);
-        request.setBillingAddressRequired(false);
+        request.setBillingAddressRequired(true);
         request.setAllowPrepaidCards(true);
         request.setAllowCreditCards(false);
         request.setAllowedPaymentMethod("CARD", cardAllowedPaymentMethodParams);

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayRequestUnitTest.java
@@ -231,6 +231,74 @@ public class GooglePayRequestUnitTest {
     }
 
     @Test
+    public void generatesToJsonRequest_whenCreditCardNotAllowed_billingAddressNotRequired() throws JSONException {
+        GooglePayRequest request = new GooglePayRequest();
+        String expected = Fixtures.PAYMENT_METHODS_GOOGLE_PAY_REQUEST_NO_CREDIT_CARDS;
+        List<String> shippingAllowedCountryCodes = Arrays.asList("US", "CA", "MX", "GB");
+
+        ShippingAddressRequirements shippingAddressRequirements = ShippingAddressRequirements.newBuilder()
+                .addAllowedCountryCodes(shippingAllowedCountryCodes)
+                .build();
+
+
+        TransactionInfo info = TransactionInfo.newBuilder()
+                .setCurrencyCode("USD")
+                .setTotalPrice("12.24")
+                .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
+                .build();
+
+        JSONObject tokenizationSpecificationParams = new JSONObject()
+                .put("type", "PAYMENT_GATEWAY")
+                .put("parameters", new JSONObject()
+                        .put("gateway", "braintree")
+                        .put("braintree:apiVersion", "v1")
+                        .put("braintree:sdkVersion", "BETA")
+                        .put("braintree:merchantId", "BRAINTREE_MERCHANT_ID")
+                        .put("braintree:authorizationFingerprint", "BRAINTREE_AUTH_FINGERPRINT")
+                );
+
+        JSONArray cardAllowedAuthMethods = new JSONArray()
+                .put("PAN_ONLY")
+                .put("CRYPTOGRAM_3DS");
+
+        JSONArray cardAllowedCardNetworks = new JSONArray()
+                .put("VISA")
+                .put("AMEX")
+                .put("JCB")
+                .put("DISCOVER")
+                .put("MASTERCARD");
+
+        JSONObject cardAllowedPaymentMethodParams = new JSONObject()
+                .put("allowedAuthMethods", cardAllowedAuthMethods)
+                .put("allowedCardNetworks", cardAllowedCardNetworks);
+
+        JSONObject paypalAllowedPaymentMethodParams = new JSONObject()
+                .put("purchase_context", "{\"purchase_context\":{\"purchase_units\":[{\"payee\":{\"client_id\":\"FAKE_PAYPAL_CLIENT_ID\"},\"recurring_payment\":false}]}}");
+
+        request.setTransactionInfo(info);
+        request.setCountryCode("US");
+        request.setPhoneNumberRequired(true);
+        request.setEmailRequired(true);
+        request.setShippingAddressRequired(true);
+        request.setShippingAddressRequirements(shippingAddressRequirements);
+        request.setBillingAddressRequired(false);
+        request.setAllowPrepaidCards(true);
+        request.setAllowCreditCards(false);
+        request.setAllowedPaymentMethod("CARD", cardAllowedPaymentMethodParams);
+        request.setTokenizationSpecificationForType("CARD", tokenizationSpecificationParams);
+        request.setAllowedPaymentMethod("PAYPAL", paypalAllowedPaymentMethodParams);
+        request.setTokenizationSpecificationForType("PAYPAL", tokenizationSpecificationParams);
+
+        request.setEnvironment("production");
+        request.setGoogleMerchantId("GOOGLE_MERCHANT_ID");
+        request.setGoogleMerchantName("GOOGLE_MERCHANT_NAME");
+
+        String actual = request.toJson();
+
+        JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    @Test
     public void allowsNullyOptionalParameters() throws JSONException {
         GooglePayRequest request = new GooglePayRequest();
         String expected = "{\"apiVersion\":2,\"apiVersionMinor\":0,\"allowedPaymentMethods\":[],\"shippingAddressRequired\":true,\"merchantInfo\":{},\"transactionInfo\":{\"totalPriceStatus\":\"FINAL\",\"totalPrice\":\"12.24\",\"currencyCode\":\"USD\"},\"shippingAddressParameters\":{}}";

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -2449,6 +2449,84 @@ object Fixtures {
     """
 
     // language=JSON
+    const val PAYMENT_METHODS_GOOGLE_PAY_REQUEST_NO_CREDIT_CARDS = """
+        {
+          "apiVersion": 2,
+          "apiVersionMinor": 0,
+          "allowedPaymentMethods": [
+            {
+              "type": "CARD",
+              "parameters": {
+                "billingAddressRequired": false, 
+                "allowPrepaidCards": true,
+                "allowCreditCards": true,
+                "allowedAuthMethods": [
+                  "PAN_ONLY",
+                  "CRYPTOGRAM_3DS"
+                ],
+                "allowedCardNetworks": [
+                  "VISA",
+                  "AMEX",
+                  "JCB",
+                  "DISCOVER",
+                  "MASTERCARD"
+                ],
+                "allowCreditCards": false
+              },
+              "tokenizationSpecification": {
+                "type": "PAYMENT_GATEWAY",
+                "parameters": {
+                  "gateway": "braintree",
+                  "braintree:apiVersion": "v1",
+                  "braintree:sdkVersion": "BETA",
+                  "braintree:merchantId": "BRAINTREE_MERCHANT_ID",
+                  "braintree:authorizationFingerprint": "BRAINTREE_AUTH_FINGERPRINT"
+                }
+              }
+            },
+            {
+              "type": "PAYPAL",
+              "parameters": {
+                "purchase_context": "{\"purchase_context\":{\"purchase_units\":[{\"payee\":{\"client_id\":\"FAKE_PAYPAL_CLIENT_ID\"},\"recurring_payment\":false}]}}"
+              },
+              "tokenizationSpecification": {
+                "type": "PAYMENT_GATEWAY",
+                "parameters": {
+                  "gateway": "braintree",
+                  "braintree:apiVersion": "v1",
+                  "braintree:sdkVersion": "BETA",
+                  "braintree:merchantId": "BRAINTREE_MERCHANT_ID",
+                  "braintree:authorizationFingerprint": "BRAINTREE_AUTH_FINGERPRINT"
+                }
+              }
+            }
+          ],
+          "emailRequired": true,
+          "shippingAddressRequired": true,
+          "shippingAddressParameters": {
+            "allowedCountryCodes": [
+              "US",
+              "CA",
+              "MX",
+              "GB"
+            ],
+            "phoneNumberRequired": true
+          },
+          "environment": "PRODUCTION",
+          "merchantInfo": {
+            "merchantId": "GOOGLE_MERCHANT_ID",
+            "merchantName": "GOOGLE_MERCHANT_NAME"
+          },
+          "transactionInfo": {
+            "totalPriceStatus": "FINAL",
+            "totalPrice": "12.24",
+            "currencyCode": "USD",
+            "countryCode": "US"
+          }
+        } 
+    """
+
+    // language=JSON
     const val RESPONSE_GOOGLE_PAY_CARD = """
         {
           "apiVersionMinor": 0,

--- a/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Fixtures.kt
@@ -2457,7 +2457,7 @@ object Fixtures {
             {
               "type": "CARD",
               "parameters": {
-                "billingAddressRequired": false, 
+                "billingAddressRequired": true, 
                 "allowPrepaidCards": true,
                 "allowCreditCards": true,
                 "allowedAuthMethods": [


### PR DESCRIPTION
### Summary of changes

 - Fix issue where credit cards were enabled in Google Pay when `GooglePayRequest.setAllowCreditCards(false)` and `GooglePayRequest.setBillingAddressRequired(true)`

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
