### PR TITLE
Remove Lint from Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,6 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_KEY_FILE: ${{ env.SIGNING_KEY_FILE_PATH }}
 
-  # Run static analysis after successful build
-  static_analysis:
-    name: Static Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Setup Java
-        uses: ./.github/actions/setup
-      - name: Run Static Analysis
-        uses: ./.github/actions/static_analysis
-
   # Once building is finished, we unit test every module in parallel
   unit_test_american_express:
     name: AmericanExpress Unit Tests


### PR DESCRIPTION
### Summary of changes

 - Lint (gradle and detekt) was added to this repo for pull requests but it is not set up to run on release. Removing this step from the release process since the linting is run on each individual PR.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
- @KunJeongPark 
