### PR TITLE
Adding auth email config

### DIFF
--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -157,6 +157,11 @@ public class PayPalNativeCheckoutClient {
                 } else {
                     environment = Environment.LIVE;
                 }
+                String email = payPalRequest.getAuthEmail();
+                AuthConfig authConfig = null;
+                if (email != null) {
+                    authConfig = new AuthConfig(email);
+                }
 
                 // Start PayPalCheckout flow
                 PayPalCheckout.setConfig(
@@ -169,9 +174,10 @@ public class PayPalNativeCheckoutClient {
                         null,
                         new SettingsConfig(),
                         new UIConfig(
-                                false
+                            false
                         ),
-                        payPalRequest.getReturnUrl()
+                        payPalRequest.getReturnUrl(),
+                        authConfig
                     )
                 );
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
@@ -51,7 +51,7 @@ public abstract class PayPalNativeRequest implements Parcelable {
     private String riskCorrelationId;
     private final ArrayList<PayPalNativeCheckoutLineItem> lineItems;
     private String returnUrl;
-
+    private String authEmail;
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
      */
@@ -203,6 +203,21 @@ public abstract class PayPalNativeRequest implements Parcelable {
         this.returnUrl = returnUrl;
     }
 
+    @Nullable
+    public String getAuthEmail() {
+        return authEmail;
+    }
+
+    /**
+     * Optional: Sets the email of the user prior to calling authentication
+     *
+     * @param authEmail the users email address
+     */
+    public void setAuthEmail(@NonNull String authEmail) {
+        this.authEmail = authEmail;
+    }
+
+
     public String getReturnUrl() {
         return returnUrl;
     }
@@ -255,6 +270,7 @@ public abstract class PayPalNativeRequest implements Parcelable {
         riskCorrelationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalNativeCheckoutLineItem.CREATOR);
         returnUrl = in.readString();
+        authEmail = in.readString();
     }
 
     @Override
@@ -275,6 +291,6 @@ public abstract class PayPalNativeRequest implements Parcelable {
         parcel.writeString(riskCorrelationId);
         parcel.writeTypedList(lineItems);
         parcel.writeString(returnUrl);
-
+        parcel.writeString(authEmail);
     }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Adding in the auth config for nxo to be able to set the merchant passed email

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
