### PR TITLE
Rename Venmo APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
   * PayPalDataCollector
     * Remove `paypal-data-collector` module (use `data-collector`)
   * Venmo
-    * Remove `VenmoListener`, `VenmoTokenizeAccountCallback`
+    * Remove `VenmoListener`, `VenmoTokenizeAccountCallback`, and `VenmoResultCallback`
     * Add `VenmoLauncher`, `VenmoPaymentAuthRequest`, `VenmoPaymentAuthRequestCallback`, 
-      `VenmoPaymentAuthResult`, `VenmoResult`, and 
+      `VenmoPaymentAuthResult`, `VenmoResult`, `VenmoTokenizeCallback`, and 
       `VenmoLauncherCallback`
     * Rename `VenmoOnActivityResultCallback` to `VenmoResultCallback`
     * Remove overload constructors, `setListener`, and `onActivityResult` from `VenmoClient`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
     * Remove `paypal-data-collector` module (use `data-collector`)
   * Venmo
     * Remove `VenmoListener`, `VenmoTokenizeAccountCallback`
-    * Add `VenmoLauncher`, `VenmoPaymentAuthRequest`, `VenmoAuthChallengeCallback`, 
+    * Add `VenmoLauncher`, `VenmoPaymentAuthRequest`, `VenmoPaymentAuthRequestCallback`, 
       `VenmoPaymentAuthResult`, `VenmoResult`, and 
-      `VenmoAuthChallengeResultCallback`
+      `VenmoLauncherCallback`
     * Rename `VenmoOnActivityResultCallback` to `VenmoResultCallback`
     * Remove overload constructors, `setListener`, and `onActivityResult` from `VenmoClient`
     * Change `VenmoClient#tokenizeVenmoAccount` parameters and rename to 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@
     * Remove `paypal-data-collector` module (use `data-collector`)
   * Venmo
     * Remove `VenmoListener`, `VenmoTokenizeAccountCallback`
-    * Add `VenmoLauncher`, `VenmoAuthChallenge`, `VenmoAuthChallengeCallback`, 
-      `VenmoAuthChallengeResult`, `VenmoResult`, and 
+    * Add `VenmoLauncher`, `VenmoPaymentAuthRequest`, `VenmoAuthChallengeCallback`, 
+      `VenmoPaymentAuthResult`, `VenmoResult`, and 
       `VenmoAuthChallengeResultCallback`
     * Rename `VenmoOnActivityResultCallback` to `VenmoResultCallback`
     * Remove overload constructors, `setListener`, and `onActivityResult` from `VenmoClient`
-    * Change `VenmoClient#tokenizeVenmoAccount` parameters
-    * Add `VenmoClient#requestAuthChallenge`
+    * Change `VenmoClient#tokenizeVenmoAccount` parameters and rename to 
+      `VenmoClient#tokenize`
+    * Add `VenmoClient#createPaymentAuthRequest`
   * GooglePay
     * Remove `GooglePayListener` and `GooglePayRequestPaymentCallback`
     * Add `GooglePayLauncher`, `GooglePayIntentData`, `GooglePayIntentDataCallback`, `GooglePayResult`, and `GooglePayResultCallback`

--- a/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
@@ -38,7 +38,7 @@ public class VenmoFragment extends BaseFragment {
         venmoButton.setOnClickListener(this::launchVenmo);
 
         venmoLauncher = new VenmoLauncher(this, venmoAuthChallengeResult ->
-                venmoClient.tokenizeVenmoAccount(venmoAuthChallengeResult, this::handleVenmoResult));
+                venmoClient.tokenize(venmoAuthChallengeResult, this::handleVenmoResult));
 
         return view;
     }
@@ -86,7 +86,7 @@ public class VenmoFragment extends BaseFragment {
                 lineItems.add(new VenmoLineItem(VenmoLineItem.KIND_DEBIT, "Two Items", 2, "10"));
                 venmoRequest.setLineItems(lineItems);
 
-                venmoClient.requestAuthChallenge(requireActivity(), venmoRequest, (venmoAuthChallenge, authError) -> {
+                venmoClient.createPaymentAuthRequest(requireActivity(), venmoRequest, (venmoAuthChallenge, authError) -> {
                     if (authError != null) {
                         handleError(authError);
                         return;

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoActivityResultContract.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoActivityResultContract.java
@@ -14,7 +14,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 class VenmoActivityResultContract
-        extends ActivityResultContract<VenmoAuthChallenge, VenmoAuthChallengeResult> {
+        extends ActivityResultContract<VenmoPaymentAuthRequest, VenmoPaymentAuthResult> {
 
     static final String VENMO_PACKAGE_NAME = "com.venmo";
     static final String APP_SWITCH_ACTIVITY = "controller.SetupMerchantActivity";
@@ -33,7 +33,7 @@ class VenmoActivityResultContract
 
     @NonNull
     @Override
-    public Intent createIntent(@NonNull Context context, VenmoAuthChallenge input) {
+    public Intent createIntent(@NonNull Context context, VenmoPaymentAuthRequest input) {
         Intent venmoIntent = getVenmoIntent()
                 .putExtra(EXTRA_MERCHANT_ID, input.getProfileId())
                 .putExtra(EXTRA_ACCESS_TOKEN, input.getConfiguration().getVenmoAccessToken())
@@ -62,18 +62,18 @@ class VenmoActivityResultContract
     }
 
     @Override
-    public VenmoAuthChallengeResult parseResult(int resultCode, @Nullable Intent intent) {
+    public VenmoPaymentAuthResult parseResult(int resultCode, @Nullable Intent intent) {
         if (resultCode == AppCompatActivity.RESULT_OK) {
             if (intent == null) {
-                return new VenmoAuthChallengeResult(null, null, null, new BraintreeException(
+                return new VenmoPaymentAuthResult(null, null, null, new BraintreeException(
                         "An unknown Android error occurred with the activity result API."));
             }
             String paymentContextId = intent.getStringExtra(EXTRA_RESOURCE_ID);
             String nonce = intent.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
             String venmoUsername = intent.getStringExtra(EXTRA_USERNAME);
-            return new VenmoAuthChallengeResult(paymentContextId, nonce, venmoUsername, null);
+            return new VenmoPaymentAuthResult(paymentContextId, nonce, venmoUsername, null);
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
-            return new VenmoAuthChallengeResult(null, null, null,
+            return new VenmoPaymentAuthResult(null, null, null,
                     new UserCanceledException("User canceled Venmo."));
         }
         return null;

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
@@ -84,7 +84,7 @@ class VenmoApi {
     }
 
     void createNonceFromPaymentContext(String paymentContextId,
-                                       final VenmoResultCallback callback) {
+                                       final VenmoTokenizeCallback callback) {
         JSONObject params = new JSONObject();
         try {
             params.put("query",
@@ -115,7 +115,7 @@ class VenmoApi {
         }
     }
 
-    void vaultVenmoAccountNonce(String nonce, final VenmoResultCallback callback) {
+    void vaultVenmoAccountNonce(String nonce, final VenmoTokenizeCallback callback) {
         VenmoAccount venmoAccount = new VenmoAccount();
         venmoAccount.setNonce(nonce);
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeCallback.java
@@ -4,10 +4,10 @@ import androidx.annotation.Nullable;
 
 /**
  * Callback to handle result from
- * {@link VenmoClient#tokenize(VenmoAuthChallengeResult, VenmoResultCallback)}
+ * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
  */
 public interface VenmoAuthChallengeCallback {
-    void onVenmoAuthChallenge(@Nullable VenmoAuthChallenge venmoAuthChallenge,
+    void onVenmoAuthChallenge(@Nullable VenmoPaymentAuthRequest venmoPaymentAuthRequest,
                               @Nullable Exception error);
 
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeCallback.java
@@ -4,7 +4,7 @@ import androidx.annotation.Nullable;
 
 /**
  * Callback to handle result from
- * {@link VenmoClient#tokenizeVenmoAccount(VenmoAuthChallengeResult, VenmoResultCallback)}
+ * {@link VenmoClient#tokenize(VenmoAuthChallengeResult, VenmoResultCallback)}
  */
 public interface VenmoAuthChallengeCallback {
     void onVenmoAuthChallenge(@Nullable VenmoAuthChallenge venmoAuthChallenge,

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeResultCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeResultCallback.java
@@ -1,6 +1,0 @@
-package com.braintreepayments.api;
-
-public interface VenmoAuthChallengeResultCallback {
-
-    void onVenmoResult(VenmoPaymentAuthResult venmoPaymentAuthResult);
-}

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeResultCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoAuthChallengeResultCallback.java
@@ -2,5 +2,5 @@ package com.braintreepayments.api;
 
 public interface VenmoAuthChallengeResultCallback {
 
-    void onVenmoResult(VenmoAuthChallengeResult venmoAuthChallengeResult);
+    void onVenmoResult(VenmoPaymentAuthResult venmoPaymentAuthResult);
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -65,15 +65,15 @@ public class VenmoClient {
      * VenmoLauncher#launch(VenmoPaymentAuthRequest)}
      * <p>
      * If the Venmo app is not available, {@link AppSwitchNotAvailableException} will be sent to
-     * {@link VenmoCreatePaymentAuthRequestCallback#onPaymentAuthRequest(VenmoPaymentAuthRequest, Exception)}
+     * {@link VenmoPaymentAuthRequestCallback#onPaymentAuthRequest(VenmoPaymentAuthRequest, Exception)}
      *
      * @param activity Android FragmentActivity
      * @param request  {@link VenmoRequest}
-     * @param callback {@link VenmoCreatePaymentAuthRequestCallback}
+     * @param callback {@link VenmoPaymentAuthRequestCallback}
      */
     public void createPaymentAuthRequest(@NonNull final FragmentActivity activity,
                                          @NonNull final VenmoRequest request,
-                                         @NonNull VenmoCreatePaymentAuthRequestCallback callback) {
+                                         @NonNull VenmoPaymentAuthRequestCallback callback) {
         braintreeClient.sendAnalyticsEvent("pay-with-venmo.selected");
         braintreeClient.getConfiguration((configuration, error) -> {
             if (configuration == null) {
@@ -141,7 +141,7 @@ public class VenmoClient {
             Authorization authorization,
             final String venmoProfileId,
             @Nullable final String paymentContextId,
-            VenmoCreatePaymentAuthRequestCallback callback
+            VenmoPaymentAuthRequestCallback callback
     ) {
         boolean isClientTokenAuth = (authorization instanceof ClientToken);
         boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
@@ -155,7 +155,7 @@ public class VenmoClient {
 
     /**
      * After successfully authenticating a Venmo user account via {@link 
-     * VenmoClient#createPaymentAuthRequest(FragmentActivity, VenmoRequest, VenmoCreatePaymentAuthRequestCallback)},
+     * VenmoClient#createPaymentAuthRequest(FragmentActivity, VenmoRequest, VenmoPaymentAuthRequestCallback)},
      * this method should be invoked to tokenize the account to retrieve a
      * {@link VenmoAccountNonce}.
      * 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -65,19 +65,19 @@ public class VenmoClient {
      * VenmoLauncher#launch(VenmoPaymentAuthRequest)}
      * <p>
      * If the Venmo app is not available, {@link AppSwitchNotAvailableException} will be sent to
-     * {@link VenmoAuthChallengeCallback#onVenmoAuthChallenge(VenmoPaymentAuthRequest, Exception)}
+     * {@link VenmoCreatePaymentAuthRequestCallback#onPaymentAuthRequest(VenmoPaymentAuthRequest, Exception)}
      *
      * @param activity Android FragmentActivity
      * @param request  {@link VenmoRequest}
-     * @param callback {@link VenmoAuthChallengeCallback}
+     * @param callback {@link VenmoCreatePaymentAuthRequestCallback}
      */
     public void createPaymentAuthRequest(@NonNull final FragmentActivity activity,
                                          @NonNull final VenmoRequest request,
-                                         @NonNull VenmoAuthChallengeCallback callback) {
+                                         @NonNull VenmoCreatePaymentAuthRequestCallback callback) {
         braintreeClient.sendAnalyticsEvent("pay-with-venmo.selected");
         braintreeClient.getConfiguration((configuration, error) -> {
             if (configuration == null) {
-                callback.onVenmoAuthChallenge(null, error);
+                callback.onPaymentAuthRequest(null, error);
                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
                 return;
             }
@@ -90,7 +90,7 @@ public class VenmoClient {
             }
 
             if (exceptionMessage != null) {
-                callback.onVenmoAuthChallenge(null,
+                callback.onPaymentAuthRequest(null,
                         new AppSwitchNotAvailableException(exceptionMessage));
                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
                 return;
@@ -101,7 +101,7 @@ public class VenmoClient {
             if ((request.getCollectCustomerShippingAddress() ||
                     request.getCollectCustomerBillingAddress()) &&
                     !configuration.getVenmoEnrichedCustomerDataEnabled()) {
-                callback.onVenmoAuthChallenge(null, new BraintreeException(
+                callback.onPaymentAuthRequest(null, new BraintreeException(
                         "Cannot collect customer data when ECD is disabled. Enable this feature " +
                                 "in the Control Panel to collect this data."));
                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
@@ -123,11 +123,11 @@ public class VenmoClient {
                                             authorization, finalVenmoProfileId,
                                             paymentContextId, callback);
                                 } else {
-                                    callback.onVenmoAuthChallenge(null, authError);
+                                    callback.onPaymentAuthRequest(null, authError);
                                 }
                             });
                         } else {
-                            callback.onVenmoAuthChallenge(null, exception);
+                            callback.onPaymentAuthRequest(null, exception);
                             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
                         }
                     });
@@ -141,7 +141,7 @@ public class VenmoClient {
             Authorization authorization,
             final String venmoProfileId,
             @Nullable final String paymentContextId,
-            VenmoAuthChallengeCallback callback
+            VenmoCreatePaymentAuthRequestCallback callback
     ) {
         boolean isClientTokenAuth = (authorization instanceof ClientToken);
         boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
@@ -149,13 +149,13 @@ public class VenmoClient {
         VenmoPaymentAuthRequest authChallenge =
                 new VenmoPaymentAuthRequest(configuration, venmoProfileId, paymentContextId,
                         braintreeClient.getSessionId(), braintreeClient.getIntegrationType());
-        callback.onVenmoAuthChallenge(authChallenge, null);
+        callback.onPaymentAuthRequest(authChallenge, null);
         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started");
     }
 
     /**
      * After successfully authenticating a Venmo user account via {@link 
-     * VenmoClient#createPaymentAuthRequest(FragmentActivity, VenmoRequest, VenmoAuthChallengeCallback)},
+     * VenmoClient#createPaymentAuthRequest(FragmentActivity, VenmoRequest, VenmoCreatePaymentAuthRequestCallback)},
      * this method should be invoked to tokenize the account to retrieve a
      * {@link VenmoAccountNonce}.
      * 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -160,11 +160,11 @@ public class VenmoClient {
      * {@link VenmoAccountNonce}.
      * 
      * @param venmoPaymentAuthResult the result of {@link VenmoLauncher#launch(VenmoPaymentAuthRequest)}
-     * @param callback a {@link VenmoResultCallback} to receive a {@link VenmoAccountNonce} or 
+     * @param callback a {@link VenmoTokenizeCallback} to receive a {@link VenmoAccountNonce} or
      *                 error from Venmo tokenization
      */
     public void tokenize(@NonNull final VenmoPaymentAuthResult venmoPaymentAuthResult,
-                         @NonNull VenmoResultCallback callback) {
+                         @NonNull VenmoTokenizeCallback callback) {
         if (venmoPaymentAuthResult.getError() == null) {
             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success");
 
@@ -236,7 +236,7 @@ public class VenmoClient {
         }
     }
 
-    private void vaultVenmoAccountNonce(String nonce, final VenmoResultCallback callback) {
+    private void vaultVenmoAccountNonce(String nonce, final VenmoTokenizeCallback callback) {
         venmoApi.vaultVenmoAccountNonce(nonce, (venmoAccountNonce, error) -> {
             if (venmoAccountNonce != null) {
                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.vault.success");

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoCreatePaymentAuthRequestCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoCreatePaymentAuthRequestCallback.java
@@ -6,8 +6,8 @@ import androidx.annotation.Nullable;
  * Callback to handle result from
  * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
  */
-public interface VenmoAuthChallengeCallback {
-    void onVenmoAuthChallenge(@Nullable VenmoPaymentAuthRequest venmoPaymentAuthRequest,
+public interface VenmoCreatePaymentAuthRequestCallback {
+    void onPaymentAuthRequest(@Nullable VenmoPaymentAuthRequest venmoPaymentAuthRequest,
                               @Nullable Exception error);
 
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -23,11 +23,11 @@ public class VenmoLauncher {
      * instantiated in the OnCreate method of your Fragment.
      *
      * @param fragment an Android Fragment from which you will launch the Venmo app
-     * @param callback a {@link VenmoAuthChallengeResultCallback} to receive the result of the Venmo
+     * @param callback a {@link VenmoLauncherCallback} to receive the result of the Venmo
      *                 app switch authentication flow
      */
     public VenmoLauncher(@NonNull Fragment fragment,
-                         @NonNull VenmoAuthChallengeResultCallback callback) {
+                         @NonNull VenmoLauncherCallback callback) {
         this(fragment.getActivity().getActivityResultRegistry(), fragment.getViewLifecycleOwner(),
                 callback);
     }
@@ -37,17 +37,17 @@ public class VenmoLauncher {
      * instantiated in the OnCreate method of your Activity.
      *
      * @param activity an Android Activity from which you will launch the Venmo app
-     * @param callback a {@link VenmoAuthChallengeResultCallback} to receive the result of the Venmo
+     * @param callback a {@link VenmoLauncherCallback} to receive the result of the Venmo
      *                 app switch authentication flow
      */
     public VenmoLauncher(@NonNull FragmentActivity activity,
-                         @NonNull VenmoAuthChallengeResultCallback callback) {
+                         @NonNull VenmoLauncherCallback callback) {
         this(activity.getActivityResultRegistry(), activity, callback);
     }
 
     @VisibleForTesting
     VenmoLauncher(ActivityResultRegistry registry, LifecycleOwner lifecycleOwner,
-                  VenmoAuthChallengeResultCallback callback) {
+                  VenmoLauncherCallback callback) {
         activityLauncher = registry.register(VENMO_SECURE_RESULT, lifecycleOwner,
                 new VenmoActivityResultContract(), callback::onVenmoResult);
     }
@@ -57,7 +57,7 @@ public class VenmoLauncher {
      *
      * @param venmoPaymentAuthRequest the result of
      *                           {@link VenmoClient#createPaymentAuthRequest(FragmentActivity,
-     *                           VenmoRequest, VenmoAuthChallengeCallback)}
+     *                           VenmoRequest, VenmoCreatePaymentAuthRequestCallback)}
      */
     public void launch(VenmoPaymentAuthRequest venmoPaymentAuthRequest) {
         activityLauncher.launch(venmoPaymentAuthRequest);

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -57,7 +57,7 @@ public class VenmoLauncher {
      *
      * @param venmoPaymentAuthRequest the result of
      *                           {@link VenmoClient#createPaymentAuthRequest(FragmentActivity,
-     *                           VenmoRequest, VenmoCreatePaymentAuthRequestCallback)}
+     *                           VenmoRequest, VenmoPaymentAuthRequestCallback)}
      */
     public void launch(VenmoPaymentAuthRequest venmoPaymentAuthRequest) {
         activityLauncher.launch(venmoPaymentAuthRequest);

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -56,7 +56,7 @@ public class VenmoLauncher {
      * Launches the Venmo authentication flow by switching to the Venmo app.
      *
      * @param venmoAuthChallenge the result of
-     *                           {@link VenmoClient#requestAuthChallenge(FragmentActivity,
+     *                           {@link VenmoClient#createPaymentAuthRequest(FragmentActivity,
      *                           VenmoRequest, VenmoAuthChallengeCallback)}
      */
     public void launch(VenmoAuthChallenge venmoAuthChallenge) {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncher.java
@@ -15,7 +15,7 @@ import androidx.lifecycle.LifecycleOwner;
 public class VenmoLauncher {
 
     @VisibleForTesting
-    ActivityResultLauncher<VenmoAuthChallenge> activityLauncher;
+    ActivityResultLauncher<VenmoPaymentAuthRequest> activityLauncher;
     private static final String VENMO_SECURE_RESULT = "com.braintreepayments.api.Venmo.RESULT";
 
     /**
@@ -55,11 +55,11 @@ public class VenmoLauncher {
     /**
      * Launches the Venmo authentication flow by switching to the Venmo app.
      *
-     * @param venmoAuthChallenge the result of
+     * @param venmoPaymentAuthRequest the result of
      *                           {@link VenmoClient#createPaymentAuthRequest(FragmentActivity,
      *                           VenmoRequest, VenmoAuthChallengeCallback)}
      */
-    public void launch(VenmoAuthChallenge venmoAuthChallenge) {
-        activityLauncher.launch(venmoAuthChallenge);
+    public void launch(VenmoPaymentAuthRequest venmoPaymentAuthRequest) {
+        activityLauncher.launch(venmoPaymentAuthRequest);
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncherCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncherCallback.java
@@ -1,0 +1,11 @@
+package com.braintreepayments.api;
+
+/**
+ * Used to receive notification that the Venmo payment authorization flow completed
+ * Once this is invoked, continue the flow by calling
+ * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
+ */
+public interface VenmoLauncherCallback {
+
+    void onVenmoResult(VenmoPaymentAuthResult venmoPaymentAuthResult);
+}

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncherCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoLauncherCallback.java
@@ -3,7 +3,7 @@ package com.braintreepayments.api;
 /**
  * Used to receive notification that the Venmo payment authorization flow completed
  * Once this is invoked, continue the flow by calling
- * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
+ * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoTokenizeCallback)}
  */
 public interface VenmoLauncherCallback {
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequest.java
@@ -1,9 +1,9 @@
 package com.braintreepayments.api;
 
 /**
- * Used to request Venmo authentication via {@link VenmoLauncher#launch(VenmoAuthChallenge)}
+ * Used to request Venmo authentication via {@link VenmoLauncher#launch(VenmoPaymentAuthRequest)}
  */
-public class VenmoAuthChallenge {
+public class VenmoPaymentAuthRequest {
 
     private Configuration configuration;
     private String profileId;
@@ -11,8 +11,8 @@ public class VenmoAuthChallenge {
     private String sessionId;
     private String integrationType;
 
-    VenmoAuthChallenge(Configuration configuration, String profileId, String paymentContextId,
-                       String sessionId, String integrationType) {
+    VenmoPaymentAuthRequest(Configuration configuration, String profileId, String paymentContextId,
+                            String sessionId, String integrationType) {
         this.configuration = configuration;
         this.profileId = profileId;
         this.paymentContextId = paymentContextId;

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequestCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequestCallback.java
@@ -4,7 +4,7 @@ import androidx.annotation.Nullable;
 
 /**
  * Callback to handle result from
- * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
+ * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoTokenizeCallback)}
  */
 public interface VenmoPaymentAuthRequestCallback {
     void onPaymentAuthRequest(@Nullable VenmoPaymentAuthRequest venmoPaymentAuthRequest,

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequestCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthRequestCallback.java
@@ -6,7 +6,7 @@ import androidx.annotation.Nullable;
  * Callback to handle result from
  * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoResultCallback)}
  */
-public interface VenmoCreatePaymentAuthRequestCallback {
+public interface VenmoPaymentAuthRequestCallback {
     void onPaymentAuthRequest(@Nullable VenmoPaymentAuthRequest venmoPaymentAuthRequest,
                               @Nullable Exception error);
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthResult.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoPaymentAuthResult.java
@@ -2,15 +2,15 @@ package com.braintreepayments.api;
 
 import androidx.annotation.Nullable;
 
-public class VenmoAuthChallengeResult {
+public class VenmoPaymentAuthResult {
 
     private final Exception error;
     private final String paymentContextId;
     private final String venmoAccountNonce;
     private final String venmoUsername;
 
-    VenmoAuthChallengeResult(@Nullable String paymentContextId, @Nullable String venmoAccountNonce,
-                             @Nullable String venmoUsername, @Nullable Exception error) {
+    VenmoPaymentAuthResult(@Nullable String paymentContextId, @Nullable String venmoAccountNonce,
+                           @Nullable String venmoUsername, @Nullable Exception error) {
         this.paymentContextId = paymentContextId;
         this.venmoAccountNonce = venmoAccountNonce;
         this.venmoUsername = venmoUsername;

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoTokenizeCallback.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoTokenizeCallback.java
@@ -7,9 +7,9 @@ import androidx.annotation.Nullable;
 
 /**
  * Callback for receiving result of
- * {@link VenmoClient#onActivityResult(Context, int, Intent, VenmoResultCallback)}.
+ * {@link VenmoClient#tokenize(VenmoPaymentAuthResult, VenmoTokenizeCallback)}.
  */
-public interface VenmoResultCallback {
+public interface VenmoTokenizeCallback {
 
     /**
      * @param venmoAccountNonce {@link VenmoAccountNonce}

--- a/Venmo/src/test/java/com/braintreepayments/api/MockVenmoApiBuilder.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/MockVenmoApiBuilder.java
@@ -65,7 +65,7 @@ public class MockVenmoApiBuilder {
                 any(VenmoApiCallback.class));
 
         doAnswer((Answer<Void>) invocation -> {
-            VenmoResultCallback callback = (VenmoResultCallback) invocation.getArguments()[1];
+            VenmoTokenizeCallback callback = (VenmoTokenizeCallback) invocation.getArguments()[1];
             if (createNonceFromPaymentContextSuccess != null) {
                 callback.onResult(createNonceFromPaymentContextSuccess, null);
             } else if (createNonceFromPaymentContextError != null) {
@@ -74,10 +74,10 @@ public class MockVenmoApiBuilder {
 
             return null;
         }).when(venmoApi)
-                .createNonceFromPaymentContext(anyString(), any(VenmoResultCallback.class));
+                .createNonceFromPaymentContext(anyString(), any(VenmoTokenizeCallback.class));
 
         doAnswer((Answer<Void>) invocation -> {
-            VenmoResultCallback callback = (VenmoResultCallback) invocation.getArguments()[1];
+            VenmoTokenizeCallback callback = (VenmoTokenizeCallback) invocation.getArguments()[1];
             if (vaultVenmoAccountNonceSuccess != null) {
                 callback.onResult(vaultVenmoAccountNonceSuccess, null);
             } else if (vaultVenmoAccountNonceError != null) {
@@ -85,7 +85,7 @@ public class MockVenmoApiBuilder {
             }
 
             return null;
-        }).when(venmoApi).vaultVenmoAccountNonce(anyString(), any(VenmoResultCallback.class));
+        }).when(venmoApi).vaultVenmoAccountNonce(anyString(), any(VenmoTokenizeCallback.class));
 
         return venmoApi;
     }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
@@ -41,7 +41,8 @@ public class VenmoActivityResultContractUnitTest {
     public void createIntent_returnsIntentWithExtras() throws JSONException {
         Configuration configuration =
                 Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO);
-        VenmoAuthChallenge input = new VenmoAuthChallenge(configuration, "sample-venmo-merchant",
+        VenmoPaymentAuthRequest
+                input = new VenmoPaymentAuthRequest(configuration, "sample-venmo-merchant",
                 "venmo-payment-context-id", "session-id", "custom");
         VenmoActivityResultContract sut = new VenmoActivityResultContract();
 
@@ -75,23 +76,23 @@ public class VenmoActivityResultContractUnitTest {
         successIntent.putExtra(EXTRA_PAYMENT_METHOD_NONCE, "payment_method_nonce");
         successIntent.putExtra(EXTRA_USERNAME, "username");
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
                 sut.parseResult(Activity.RESULT_OK, successIntent);
-        assertNotNull(venmoAuthChallengeResult);
-        assertEquals("resource_id", venmoAuthChallengeResult.getPaymentContextId());
-        assertEquals("payment_method_nonce", venmoAuthChallengeResult.getVenmoAccountNonce());
-        assertEquals("username", venmoAuthChallengeResult.getVenmoUsername());
+        assertNotNull(venmoPaymentAuthResult);
+        assertEquals("resource_id", venmoPaymentAuthResult.getPaymentContextId());
+        assertEquals("payment_method_nonce", venmoPaymentAuthResult.getVenmoAccountNonce());
+        assertEquals("username", venmoPaymentAuthResult.getVenmoUsername());
     }
 
     @Test
     public void parseResult_whenResultIsCANCELED_returnsVenomResultWithError() {
         VenmoActivityResultContract sut = new VenmoActivityResultContract();
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
                 sut.parseResult(Activity.RESULT_CANCELED, null);
-        assertNotNull(venmoAuthChallengeResult);
+        assertNotNull(venmoPaymentAuthResult);
 
-        UserCanceledException error = (UserCanceledException) venmoAuthChallengeResult.getError();
+        UserCanceledException error = (UserCanceledException) venmoPaymentAuthResult.getError();
         assertNotNull("User canceled Venmo.", error.getMessage());
         assertFalse(error.isExplicitCancelation());
     }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoActivityResultContractUnitTest.java
@@ -2,11 +2,11 @@ package com.braintreepayments.api;
 
 import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_PAYMENT_METHOD_NONCE;
 import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_USERNAME;
-import static com.braintreepayments.api.VenmoClient.EXTRA_ACCESS_TOKEN;
-import static com.braintreepayments.api.VenmoClient.EXTRA_BRAINTREE_DATA;
-import static com.braintreepayments.api.VenmoClient.EXTRA_ENVIRONMENT;
-import static com.braintreepayments.api.VenmoClient.EXTRA_MERCHANT_ID;
-import static com.braintreepayments.api.VenmoClient.EXTRA_RESOURCE_ID;
+import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_ACCESS_TOKEN;
+import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_BRAINTREE_DATA;
+import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_ENVIRONMENT;
+import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_MERCHANT_ID;
+import static com.braintreepayments.api.VenmoActivityResultContract.EXTRA_RESOURCE_ID;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
@@ -179,7 +179,7 @@ public class VenmoApiUnitTest {
     @Test
     public void createNonceFromPaymentContext_queriesGraphQLPaymentContext() throws JSONException {
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
-        sut.createNonceFromPaymentContext("payment-context-id", mock(VenmoResultCallback.class));
+        sut.createNonceFromPaymentContext("payment-context-id", mock(VenmoTokenizeCallback.class));
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendGraphQLPOST(captor.capture(), any(HttpResponseCallback.class));
@@ -202,7 +202,7 @@ public class VenmoApiUnitTest {
 
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
 
-        VenmoResultCallback callback = mock(VenmoResultCallback.class);
+        VenmoTokenizeCallback callback = mock(VenmoTokenizeCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
 
         ArgumentCaptor<VenmoAccountNonce> captor = ArgumentCaptor.forClass(VenmoAccountNonce.class);
@@ -218,7 +218,7 @@ public class VenmoApiUnitTest {
 
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
 
-        VenmoResultCallback callback = mock(VenmoResultCallback.class);
+        VenmoTokenizeCallback callback = mock(VenmoTokenizeCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
@@ -235,7 +235,7 @@ public class VenmoApiUnitTest {
 
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
 
-        VenmoResultCallback callback = mock(VenmoResultCallback.class);
+        VenmoTokenizeCallback callback = mock(VenmoTokenizeCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
 
         verify(callback).onResult(isNull(), same(error));
@@ -244,7 +244,7 @@ public class VenmoApiUnitTest {
     @Test
     public void vaultVenmoAccountNonce_performsVaultRequest() throws JSONException {
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
-        sut.vaultVenmoAccountNonce("nonce", mock(VenmoResultCallback.class));
+        sut.vaultVenmoAccountNonce("nonce", mock(VenmoTokenizeCallback.class));
 
         ArgumentCaptor<VenmoAccount> accountBuilderCaptor =
                 ArgumentCaptor.forClass(VenmoAccount.class);
@@ -263,7 +263,7 @@ public class VenmoApiUnitTest {
                 .build();
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
 
-        VenmoResultCallback callback = mock(VenmoResultCallback.class);
+        VenmoTokenizeCallback callback = mock(VenmoTokenizeCallback.class);
         sut.vaultVenmoAccountNonce("nonce", callback);
 
         ArgumentCaptor<VenmoAccountNonce> captor = ArgumentCaptor.forClass(VenmoAccountNonce.class);
@@ -281,7 +281,7 @@ public class VenmoApiUnitTest {
                 .build();
         VenmoApi sut = new VenmoApi(braintreeClient, apiClient);
 
-        VenmoResultCallback callback = mock(VenmoResultCallback.class);
+        VenmoTokenizeCallback callback = mock(VenmoTokenizeCallback.class);
         sut.vaultVenmoAccountNonce("nonce", callback);
 
         verify(callback).onResult(isNull(), same(error));

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -148,13 +148,13 @@ public class VenmoClientUnitTest {
 
         InOrder inOrder = Mockito.inOrder(venmoAuthChallengeCallback, braintreeClient);
 
-        ArgumentCaptor<VenmoAuthChallenge> captor =
-                ArgumentCaptor.forClass(VenmoAuthChallenge.class);
+        ArgumentCaptor<VenmoPaymentAuthRequest> captor =
+                ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
         inOrder.verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
 
         inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
 
-        VenmoAuthChallenge authChallenge = captor.getValue();
+        VenmoPaymentAuthRequest authChallenge = captor.getValue();
         assertEquals("sample-venmo-merchant", authChallenge.getProfileId());
         assertEquals("venmo-payment-context-id", authChallenge.getPaymentContextId());
         assertEquals("session-id", authChallenge.getSessionId());
@@ -252,8 +252,8 @@ public class VenmoClientUnitTest {
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
         sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
-        ArgumentCaptor<VenmoAuthChallenge> captor =
-                ArgumentCaptor.forClass(VenmoAuthChallenge.class);
+        ArgumentCaptor<VenmoPaymentAuthRequest> captor =
+                ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
         verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
         assertEquals("merchant-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
@@ -284,8 +284,8 @@ public class VenmoClientUnitTest {
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
         sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
-        ArgumentCaptor<VenmoAuthChallenge> captor =
-                ArgumentCaptor.forClass(VenmoAuthChallenge.class);
+        ArgumentCaptor<VenmoPaymentAuthRequest> captor =
+                ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
         verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
         assertEquals("second-pwv-profile-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
@@ -537,10 +537,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "payment-context-id",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
                 any(VenmoResultCallback.class));
@@ -562,10 +562,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "venmo-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         ArgumentCaptor<VenmoAccountNonce> captor = ArgumentCaptor.forClass(VenmoAccountNonce.class);
         verify(venmoResultCallback).onResult(captor.capture(), isNull());
@@ -593,10 +593,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "venmo-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
@@ -628,10 +628,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "some-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoApi).vaultVenmoAccountNonce(eq("some-nonce"), any(VenmoResultCallback.class));
     }
@@ -645,10 +645,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "payment-context-id",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
                 any(VenmoResultCallback.class));
@@ -659,10 +659,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "some-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success");
     }
@@ -672,10 +672,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", null, null,
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", null, null,
                         new UserCanceledException("User canceled Venmo."));
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");
     }
@@ -687,9 +687,9 @@ public class VenmoClientUnitTest {
 
         UserCanceledException error = new UserCanceledException("User canceled Venmo.");
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", null, null, error);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", null, null, error);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
     }
@@ -718,10 +718,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoApi).vaultVenmoAccountNonce(eq("fake-venmo-nonce"),
                 any(VenmoResultCallback.class));
@@ -740,10 +740,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoApi, never()).vaultVenmoAccountNonce(anyString(),
                 any(VenmoResultCallback.class));
@@ -769,9 +769,9 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult(null, "sample-nonce", "venmo-username", null);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
@@ -802,10 +802,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
@@ -831,9 +831,9 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult(null, "sample-nonce", "venmo-username", null);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));
@@ -865,10 +865,10 @@ public class VenmoClientUnitTest {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
-        VenmoAuthChallengeResult venmoAuthChallengeResult =
-                new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
+        VenmoPaymentAuthResult venmoPaymentAuthResult =
+                new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -36,7 +36,7 @@ public class VenmoClientUnitTest {
     private Configuration venmoEnabledConfiguration;
     private Configuration venmoDisabledConfiguration;
     private VenmoResultCallback venmoResultCallback;
-    private VenmoAuthChallengeCallback venmoAuthChallengeCallback;
+    private VenmoCreatePaymentAuthRequestCallback venmoCreatePaymentAuthRequestCallback;
     private VenmoSharedPrefsWriter sharedPrefsWriter;
     private DeviceInspector deviceInspector;
 
@@ -56,7 +56,7 @@ public class VenmoClientUnitTest {
         venmoDisabledConfiguration =
                 Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         venmoResultCallback = mock(VenmoResultCallback.class);
-        venmoAuthChallengeCallback = mock(VenmoAuthChallengeCallback.class);
+        venmoCreatePaymentAuthRequestCallback = mock(VenmoCreatePaymentAuthRequestCallback.class);
         sharedPrefsWriter = mock(VenmoSharedPrefsWriter.class);
 
         clientToken = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
@@ -114,9 +114,9 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
         assertEquals(
                 "Cannot collect customer data when ECD is disabled. Enable this feature in the Control Panel to collect this data.",
@@ -144,13 +144,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
-        InOrder inOrder = Mockito.inOrder(venmoAuthChallengeCallback, braintreeClient);
+        InOrder inOrder = Mockito.inOrder(venmoCreatePaymentAuthRequestCallback, braintreeClient);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        inOrder.verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
+        inOrder.verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
 
         inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
 
@@ -174,11 +174,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         ArgumentCaptor<Exception> captor =
                 ArgumentCaptor.forClass(Exception.class);
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Configuration fetching error", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -195,11 +195,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not enabled", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -218,13 +218,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(deviceInspector).isVenmoAppSwitchAvailable(same(activity));
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -250,11 +250,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
         assertEquals("merchant-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
         assertEquals("session-id", captor.getValue().getSessionId());
@@ -282,11 +282,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(captor.capture(), isNull());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
         assertEquals("second-pwv-profile-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
         assertEquals("session-id", captor.getValue().getSessionId());
@@ -305,7 +305,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
     }
@@ -329,7 +329,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
@@ -354,7 +354,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, true);
     }
@@ -378,7 +378,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -403,7 +403,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -426,13 +426,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
         InOrder order = inOrder(braintreeClient);
 
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
 
         order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
@@ -456,9 +456,9 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
 
-        verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(null, graphQLError);
+        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
 

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -36,7 +36,7 @@ public class VenmoClientUnitTest {
     private Configuration venmoEnabledConfiguration;
     private Configuration venmoDisabledConfiguration;
     private VenmoResultCallback venmoResultCallback;
-    private VenmoCreatePaymentAuthRequestCallback venmoCreatePaymentAuthRequestCallback;
+    private VenmoPaymentAuthRequestCallback venmoPaymentAuthRequestCallback;
     private VenmoSharedPrefsWriter sharedPrefsWriter;
     private DeviceInspector deviceInspector;
 
@@ -56,7 +56,7 @@ public class VenmoClientUnitTest {
         venmoDisabledConfiguration =
                 Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
         venmoResultCallback = mock(VenmoResultCallback.class);
-        venmoCreatePaymentAuthRequestCallback = mock(VenmoCreatePaymentAuthRequestCallback.class);
+        venmoPaymentAuthRequestCallback = mock(VenmoPaymentAuthRequestCallback.class);
         sharedPrefsWriter = mock(VenmoSharedPrefsWriter.class);
 
         clientToken = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
@@ -114,9 +114,9 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
         assertEquals(
                 "Cannot collect customer data when ECD is disabled. Enable this feature in the Control Panel to collect this data.",
@@ -144,13 +144,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
-        InOrder inOrder = Mockito.inOrder(venmoCreatePaymentAuthRequestCallback, braintreeClient);
+        InOrder inOrder = Mockito.inOrder(venmoPaymentAuthRequestCallback, braintreeClient);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        inOrder.verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
+        inOrder.verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
 
         inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
 
@@ -174,11 +174,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         ArgumentCaptor<Exception> captor =
                 ArgumentCaptor.forClass(Exception.class);
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Configuration fetching error", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -195,11 +195,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not enabled", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -218,13 +218,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(deviceInspector).isVenmoAppSwitchAvailable(same(activity));
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
@@ -250,11 +250,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
         assertEquals("merchant-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
         assertEquals("session-id", captor.getValue().getSessionId());
@@ -282,11 +282,11 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         ArgumentCaptor<VenmoPaymentAuthRequest> captor =
                 ArgumentCaptor.forClass(VenmoPaymentAuthRequest.class);
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(captor.capture(), isNull());
         assertEquals("second-pwv-profile-id", captor.getValue().getProfileId());
         assertEquals("venmo-payment-context-id", captor.getValue().getPaymentContextId());
         assertEquals("session-id", captor.getValue().getSessionId());
@@ -305,7 +305,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
     }
@@ -329,7 +329,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
@@ -354,7 +354,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, true);
     }
@@ -378,7 +378,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -403,7 +403,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -426,13 +426,13 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
         InOrder order = inOrder(braintreeClient);
 
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(isNull(), captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
 
         order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
@@ -456,9 +456,9 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.createPaymentAuthRequest(activity, request, venmoCreatePaymentAuthRequestCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoPaymentAuthRequestCallback);
 
-        verify(venmoCreatePaymentAuthRequestCallback).onPaymentAuthRequest(null, graphQLError);
+        verify(venmoPaymentAuthRequestCallback).onPaymentAuthRequest(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
     }
 

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -35,7 +35,7 @@ public class VenmoClientUnitTest {
 
     private Configuration venmoEnabledConfiguration;
     private Configuration venmoDisabledConfiguration;
-    private VenmoResultCallback venmoResultCallback;
+    private VenmoTokenizeCallback venmoTokenizeCallback;
     private VenmoPaymentAuthRequestCallback venmoPaymentAuthRequestCallback;
     private VenmoSharedPrefsWriter sharedPrefsWriter;
     private DeviceInspector deviceInspector;
@@ -55,7 +55,7 @@ public class VenmoClientUnitTest {
                 Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO);
         venmoDisabledConfiguration =
                 Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN);
-        venmoResultCallback = mock(VenmoResultCallback.class);
+        venmoTokenizeCallback = mock(VenmoTokenizeCallback.class);
         venmoPaymentAuthRequestCallback = mock(VenmoPaymentAuthRequestCallback.class);
         sharedPrefsWriter = mock(VenmoSharedPrefsWriter.class);
 
@@ -540,10 +540,10 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
-                any(VenmoResultCallback.class));
+                any(VenmoTokenizeCallback.class));
     }
 
     @Test
@@ -565,10 +565,10 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         ArgumentCaptor<VenmoAccountNonce> captor = ArgumentCaptor.forClass(VenmoAccountNonce.class);
-        verify(venmoResultCallback).onResult(captor.capture(), isNull());
+        verify(venmoTokenizeCallback).onResult(captor.capture(), isNull());
 
         VenmoAccountNonce nonce = captor.getValue();
         assertEquals("fake-venmo-nonce", nonce.getString());
@@ -596,9 +596,9 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(null, graphQLError);
+        verify(venmoTokenizeCallback).onResult(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
     }
 
@@ -631,9 +631,9 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoApi).vaultVenmoAccountNonce(eq("some-nonce"), any(VenmoResultCallback.class));
+        verify(venmoApi).vaultVenmoAccountNonce(eq("some-nonce"), any(VenmoTokenizeCallback.class));
     }
 
     @Test
@@ -648,10 +648,10 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
-                any(VenmoResultCallback.class));
+                any(VenmoTokenizeCallback.class));
     }
 
     @Test
@@ -662,7 +662,7 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success");
     }
@@ -675,7 +675,7 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", null, null,
                         new UserCanceledException("User canceled Venmo."));
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");
     }
@@ -689,9 +689,9 @@ public class VenmoClientUnitTest {
 
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", null, null, error);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(null, error);
+        verify(venmoTokenizeCallback).onResult(null, error);
     }
 
     @Test
@@ -721,10 +721,10 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(venmoApi).vaultVenmoAccountNonce(eq("fake-venmo-nonce"),
-                any(VenmoResultCallback.class));
+                any(VenmoTokenizeCallback.class));
     }
 
     @Test
@@ -743,10 +743,10 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
         verify(venmoApi, never()).vaultVenmoAccountNonce(anyString(),
-                any(VenmoResultCallback.class));
+                any(VenmoTokenizeCallback.class));
     }
 
     @Test
@@ -771,9 +771,9 @@ public class VenmoClientUnitTest {
 
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(venmoAccountNonce, null);
+        verify(venmoTokenizeCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
     }
 
@@ -805,9 +805,9 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(venmoAccountNonce, null);
+        verify(venmoTokenizeCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
     }
 
@@ -833,9 +833,9 @@ public class VenmoClientUnitTest {
 
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(null, error);
+        verify(venmoTokenizeCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));
     }
 
@@ -868,9 +868,9 @@ public class VenmoClientUnitTest {
         VenmoPaymentAuthResult venmoPaymentAuthResult =
                 new VenmoPaymentAuthResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenize(venmoPaymentAuthResult, venmoResultCallback);
+        sut.tokenize(venmoPaymentAuthResult, venmoTokenizeCallback);
 
-        verify(venmoResultCallback).onResult(null, error);
+        verify(venmoTokenizeCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -152,7 +152,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(isNull(), captor.capture());
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
@@ -182,7 +182,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         InOrder inOrder = Mockito.inOrder(venmoAuthChallengeCallback, braintreeClient);
 
@@ -212,7 +212,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         ArgumentCaptor<Exception> captor =
                 ArgumentCaptor.forClass(Exception.class);
@@ -233,7 +233,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
@@ -256,7 +256,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(deviceInspector).isVenmoAppSwitchAvailable(same(activity));
 
@@ -288,7 +288,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         ArgumentCaptor<VenmoAuthChallenge> captor =
                 ArgumentCaptor.forClass(VenmoAuthChallenge.class);
@@ -320,7 +320,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         ArgumentCaptor<VenmoAuthChallenge> captor =
                 ArgumentCaptor.forClass(VenmoAuthChallenge.class);
@@ -343,7 +343,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
     }
@@ -367,7 +367,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected");
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
@@ -392,7 +392,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, true);
     }
@@ -416,7 +416,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -441,7 +441,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
     }
@@ -464,7 +464,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         ArgumentCaptor<AppSwitchNotAvailableException> captor =
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
@@ -494,7 +494,7 @@ public class VenmoClientUnitTest {
 
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-        sut.requestAuthChallenge(activity, request, venmoAuthChallengeCallback);
+        sut.createPaymentAuthRequest(activity, request, venmoAuthChallengeCallback);
 
         verify(venmoAuthChallengeCallback).onVenmoAuthChallenge(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed");
@@ -578,7 +578,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
                 any(VenmoResultCallback.class));
@@ -603,7 +603,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         ArgumentCaptor<VenmoAccountNonce> captor = ArgumentCaptor.forClass(VenmoAccountNonce.class);
         verify(venmoResultCallback).onResult(captor.capture(), isNull());
@@ -634,7 +634,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "venmo-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, graphQLError);
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
@@ -669,7 +669,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoApi).vaultVenmoAccountNonce(eq("some-nonce"), any(VenmoResultCallback.class));
     }
@@ -686,7 +686,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "payment-context-id",
                         "venmo-username", null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoApi).createNonceFromPaymentContext(eq("payment-context-id"),
                 any(VenmoResultCallback.class));
@@ -700,7 +700,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "some-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success");
     }
@@ -713,7 +713,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", null, null,
                         new UserCanceledException("User canceled Venmo."));
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");
     }
@@ -727,7 +727,7 @@ public class VenmoClientUnitTest {
 
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", null, null, error);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
     }
@@ -759,7 +759,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoApi).vaultVenmoAccountNonce(eq("fake-venmo-nonce"),
                 any(VenmoResultCallback.class));
@@ -781,7 +781,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoApi, never()).vaultVenmoAccountNonce(anyString(),
                 any(VenmoResultCallback.class));
@@ -809,7 +809,7 @@ public class VenmoClientUnitTest {
 
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
@@ -843,7 +843,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(venmoAccountNonce, null);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.success"));
@@ -871,7 +871,7 @@ public class VenmoClientUnitTest {
 
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult(null, "sample-nonce", "venmo-username", null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));
@@ -906,7 +906,7 @@ public class VenmoClientUnitTest {
         VenmoAuthChallengeResult venmoAuthChallengeResult =
                 new VenmoAuthChallengeResult("payment-context-id", "sample-nonce", "venmo-username",
                         null);
-        sut.tokenizeVenmoAccount(venmoAuthChallengeResult, venmoResultCallback);
+        sut.tokenize(venmoAuthChallengeResult, venmoResultCallback);
 
         verify(venmoResultCallback).onResult(null, error);
         verify(braintreeClient).sendAnalyticsEvent(endsWith("pay-with-venmo.vault.failed"));

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -89,47 +89,9 @@ public class VenmoClientUnitTest {
         verify(activity).startActivity(captor.capture());
         verify(braintreeClient).sendAnalyticsEvent("android.pay-with-venmo.app-store.invoked");
     }
-//
-//    @Test
-//    public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() {
-//        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-//                .configuration(venmoEnabledConfiguration)
-//                .sessionId("session-id")
-//                .integration("custom")
-//                .authorizationSuccess(clientToken)
-//                .build();
-//
-//        VenmoApi venmoApi = new MockVenmoApiBuilder()
-//                .createPaymentContextSuccess("venmo-payment-context-id")
-//                .build();
-//
-//        when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
-//
-//        VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
-//        request.setProfileId("sample-venmo-merchant");
-//        request.setShouldVault(false);
-//
-//        VenmoClient sut = new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
-//        VenmoLifecycleObserver observer = mock(VenmoLifecycleObserver.class);
-//        sut.observer = observer;
-//        sut.requestAuthChallenge(activity, request);
-//
-//        ArgumentCaptor<VenmoAuthChallenge> captor = ArgumentCaptor.forClass(VenmoAuthChallenge.class);
-//        verify(observer).launch(captor.capture());
-//
-//        VenmoAuthChallenge intent = captor.getValue();
-//        assertEquals("venmo-payment-context-id", intent.getPaymentContextId());
-//        assertSame(venmoEnabledConfiguration, intent.getConfiguration());
-//        assertEquals("custom", intent.getIntegrationType());
-//        assertEquals("sample-venmo-merchant", intent.getProfileId());
-//        assertEquals("session-id", intent.getSessionId());
-//
-//        verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
-//        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started");
-//    }
 
     @Test
-    public void requestAuthChallenge_whenCreatePaymentContextFails_collectAddressWithEcdDisabled() {
+    public void createPaymentAuthRequest_whenCreatePaymentContextFails_collectAddressWithEcdDisabled() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -162,7 +124,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenCreatePaymentContextSucceeds_createsVenmoAuthChallenge() {
+    public void createPaymentAuthRequest_whenCreatePaymentContextSucceeds_createsVenmoAuthChallenge() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -201,7 +163,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenConfigurationException_forwardsExceptionToListener() {
+    public void createPaymentAuthRequest_whenConfigurationException_forwardsExceptionToListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configurationError(new Exception("Configuration fetching error"))
                 .build();
@@ -222,7 +184,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenVenmoNotEnabled_forwardsExceptionToListener() {
+    public void createPaymentAuthRequest_whenVenmoNotEnabled_forwardsExceptionToListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoDisabledConfiguration)
                 .build();
@@ -243,7 +205,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenVenmoNotInstalled_forwardsExceptionToListener() {
+    public void createPaymentAuthRequest_whenVenmoNotInstalled_forwardsExceptionToListener() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .build();
@@ -268,7 +230,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenProfileIdIsNull_appSwitchesWithMerchantId() {
+    public void createPaymentAuthRequest_whenProfileIdIsNull_appSwitchesWithMerchantId() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -300,7 +262,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenProfileIdIsSpecified_appSwitchesWithProfileIdAndAccessToken() {
+    public void createPaymentAuthRequest_whenProfileIdIsSpecified_appSwitchesWithProfileIdAndAccessToken() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -332,7 +294,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_sendsAnalyticsEvent() {
+    public void createPaymentAuthRequest_sendsAnalyticsEvent() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .build();
@@ -349,7 +311,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_sendsAnalyticsEventWhenStarted() {
+    public void createPaymentAuthRequest_sendsAnalyticsEventWhenStarted() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -374,7 +336,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
+    public void createPaymentAuthRequest_whenShouldVaultIsTrue_persistsVenmoVaultTrue() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -398,7 +360,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
+    public void createPaymentAuthRequest_whenShouldVaultIsFalse_persistsVenmoVaultFalse() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -422,7 +384,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_withTokenizationKey_persistsVenmoVaultFalse() {
+    public void createPaymentAuthRequest_withTokenizationKey_persistsVenmoVaultFalse() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -447,7 +409,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_sendsAnalyticsEventWhenUnavailableAndPostException() {
+    public void createPaymentAuthRequest_sendsAnalyticsEventWhenUnavailableAndPostException() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .build();
@@ -478,7 +440,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void requestAuthChallenge_whenVenmoApiError_forwardsErrorToListener_andSendsAnalytics() {
+    public void createPaymentAuthRequest_whenVenmoApiError_forwardsErrorToListener_andSendsAnalytics() {
         BraintreeException graphQLError = new BraintreeException("GraphQL error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
@@ -566,7 +528,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withPaymentContextId_requestFromVenmoApi() {
+    public void tokenize_withPaymentContextId_requestFromVenmoApi() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .authorizationSuccess(clientToken)
@@ -585,7 +547,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_onGraphQLPostSuccess_returnsNonceToListener_andSendsAnalytics()
+    public void tokenize_onGraphQLPostSuccess_returnsNonceToListener_andSendsAnalytics()
             throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
@@ -616,7 +578,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_onGraphQLPostFailure_forwardsExceptionToListener_andSendsAnalytics() {
+    public void tokenize_onGraphQLPostFailure_forwardsExceptionToListener_andSendsAnalytics() {
         BraintreeException graphQLError = new BraintreeException("graphQL error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
@@ -641,7 +603,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withPaymentContext_performsVaultRequestIfRequestPersisted() {
+    public void tokenize_withPaymentContext_performsVaultRequestIfRequestPersisted() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -675,7 +637,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_postsPaymentMethodNonceOnSuccess() {
+    public void tokenize_postsPaymentMethodNonceOnSuccess() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorizationSuccess(clientToken)
                 .build();
@@ -693,7 +655,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_sendsAnalyticsEventOnSuccess() {
+    public void tokenize_sendsAnalyticsEventOnSuccess() {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
@@ -706,7 +668,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_sendsAnalyticsEventOnCancel() {
+    public void tokenize_sendsAnalyticsEventOnCancel() {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
@@ -719,7 +681,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_forwardsExceptionToCallbackOnCancel() {
+    public void tokenize_forwardsExceptionToCallbackOnCancel() {
         VenmoClient sut =
                 new VenmoClient(braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
 
@@ -733,7 +695,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_performsVaultRequestIfRequestPersisted() throws JSONException {
+    public void tokenize_performsVaultRequestIfRequestPersisted() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)
                 .sessionId("session-id")
@@ -766,7 +728,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_doesNotPerformRequestIfTokenizationKeyUsed() {
+    public void tokenize_doesNotPerformRequestIfTokenizationKeyUsed() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("another-session-id")
                 .authorizationSuccess(tokenizationKey)
@@ -788,7 +750,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() {
+    public void tokenize_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -816,7 +778,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics()
+    public void tokenize_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics()
             throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
@@ -850,7 +812,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() {
+    public void tokenize_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")
                 .authorizationSuccess(clientToken)
@@ -878,7 +840,7 @@ public class VenmoClientUnitTest {
     }
 
     @Test
-    public void tokenizeVenmoAccount_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics()
+    public void tokenize_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics()
             throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sessionId("session-id")

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoLauncherUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoLauncherUnitTest.java
@@ -23,7 +23,7 @@ import org.robolectric.RobolectricTestRunner;
 public class VenmoLauncherUnitTest {
 
     @Mock
-    ActivityResultLauncher<VenmoAuthChallenge> activityResultLauncher;
+    ActivityResultLauncher<VenmoPaymentAuthRequest> activityResultLauncher;
     private VenmoAuthChallengeResultCallback callback;
 
     @Before
@@ -41,14 +41,14 @@ public class VenmoLauncherUnitTest {
         VenmoLauncher sut = new VenmoLauncher(activityResultRegistry, lifecycleOwner, callback);
 
         verify(activityResultRegistry).register(eq(expectedKey), same(lifecycleOwner),
-                Mockito.<ActivityResultContract<VenmoAuthChallenge, VenmoAuthChallengeResult>>any(),
+                Mockito.<ActivityResultContract<VenmoPaymentAuthRequest, VenmoPaymentAuthResult>>any(),
                 Mockito.any());
     }
 
     @Test
     public void launch_launchesAuthChallenge() throws JSONException {
-        VenmoAuthChallenge authChallenge =
-                new VenmoAuthChallenge(
+        VenmoPaymentAuthRequest authChallenge =
+                new VenmoPaymentAuthRequest(
                         Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO),
                         "profile-id", "payment-context-id", "session-id", "custom");
         ActivityResultRegistry activityResultRegistry = mock(ActivityResultRegistry.class);

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoLauncherUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoLauncherUnitTest.java
@@ -24,12 +24,12 @@ public class VenmoLauncherUnitTest {
 
     @Mock
     ActivityResultLauncher<VenmoPaymentAuthRequest> activityResultLauncher;
-    private VenmoAuthChallengeResultCallback callback;
+    private VenmoLauncherCallback callback;
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.openMocks(this);
-        callback = mock(VenmoAuthChallengeResultCallback.class);
+        callback = mock(VenmoLauncherCallback.class);
     }
 
     @Test

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -69,8 +69,8 @@ class MyActivity : FragmentActivity() {
     @override fun onCreate(savedInstanceState: Bundle?) {
 +       // can initialize clients outside of onCreate if desired
 -       initializeClients()
-+       venmoLauncher = VenmoLauncher(this) { authChallengeResult ->
-+            venmoClient.tokenizeVenmoAccount(authChallengeResult) { venmoAccountNonce, error ->
++       venmoLauncher = VenmoLauncher(this) { paymentAuthResult ->
++            venmoClient.tokenize(paymentAuthResult) { venmoAccountNonce, error ->
 +                error?.let { /* handle error */ }
 +                venmoAccountNonce?.let { /* handle Venmo account nonce */ }
 +            }
@@ -86,9 +86,9 @@ class MyActivity : FragmentActivity() {
     
     fun onVenmoButtonClick() {
 -       venmoClient.tokenizeVenmoAccount(activity, request)
-+       venmoClient.requestAuthChallenge(this, venmoRequest) { authChallenge, error ->
++       venmoClient.requestAuthChallenge(this, venmoRequest) { paymentAuthRequest, error ->
 +            error?.let { /* handle error */ }
-+            authChallenge?.let { venmoLauncher.launch(it) }
++            paymentAuthRequest?.let { venmoLauncher.launch(paymentAuthRequest) }
 +       }
     }
     

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -88,7 +88,7 @@ class MyActivity : FragmentActivity() {
 -       venmoClient.tokenizeVenmoAccount(activity, request)
 +       venmoClient.requestAuthChallenge(this, venmoRequest) { paymentAuthRequest, error ->
 +            error?.let { /* handle error */ }
-+            paymentAuthRequest?.let { venmoLauncher.launch(paymentAuthRequest) }
++            paymentAuthRequest?.let { venmoLauncher.launch(it) }
 +       }
     }
     


### PR DESCRIPTION
### Summary of changes

 - Rename Venmo APIs to `createPaymentAuthRequest` and `tokenize` and rename associated result objects and callbacks
 - Cleanup VenmoClient - remove unused static strings and use lambdas

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
