### PR TITLE
Rename 3DS APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,12 @@
     * Add `GooglePayClient#tokenize` 
   * ThreeDSecure
     * Remove `ThreeDSecureListener`
-    * Add `ThreeDSecureLauncher`, `CardinalResult`, and `CardinalResultCallback`
+    * Add `ThreeDSecureLauncher`, `ThreeDSecurePaymentAuthResult`, and `ThreeDSecureLancherCallback`
     * Remove overload constructors, `setListener`, `continuePerformVerification`, `onBrowserSwitchResult` and `onActivityResult` from `ThreeDSecureClient`
-    * Change `ThreeDSecureClient#performVerification` and `ThreeDSecureClient#initializeChallengeWithLookupResponse` parameters
-    * Add `ThreeDSecureClient#onCardinalResult`
+    * Change `ThreeDSecureClient#initializeChallengeWithLookupResponse` parameters
+    * Add `ThreeDSecureClient#tokenize`
+    * Rename `ThreeDSecureClient#performVerification` to 
+      `ThreeDSecureClient#createPaymentAuthRequest` and change parameters
     * Remove `versionRequested` from `ThreeDSecureRequest`
     * Add `ThreeDSecureNonce` class
     * Rename `ThreeDSecureResult#tokenizedCard` to `ThreeDSecureResult#threeDSecureNonce`

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -90,7 +90,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         View view = inflater.inflate(R.layout.fragment_card, container, false);
 
         threeDSecureLauncher = new ThreeDSecureLauncher(this,
-                cardinalResult -> threeDSecureClient.onCardinalResult(cardinalResult,
+                cardinalResult -> threeDSecureClient.tokenize(cardinalResult,
                         this::handleThreeDSecureResult));
 
         cardForm = view.findViewById(R.id.card_form);

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -228,7 +228,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
                     getString(R.string.loading), true, false);
 
             ThreeDSecureRequest threeDSecureRequest = threeDSecureRequest(paymentMethodNonce);
-            threeDSecureClient.performVerification(requireContext(), threeDSecureRequest,
+            threeDSecureClient.createPaymentAuthRequest(requireContext(), threeDSecureRequest,
                     (threeDSecureResult, error) -> {
                         if (threeDSecureResult != null &&
                                 threeDSecureResult.getLookup().requiresUserAuthentication()) {

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -90,7 +90,7 @@ public class CardFragment extends BaseFragment implements OnCardFormSubmitListen
         View view = inflater.inflate(R.layout.fragment_card, container, false);
 
         threeDSecureLauncher = new ThreeDSecureLauncher(this,
-                cardinalResult -> threeDSecureClient.tokenize(cardinalResult,
+                paymentAuthResult -> threeDSecureClient.tokenize(paymentAuthResult,
                         this::handleThreeDSecureResult));
 
         cardForm = view.findViewById(R.id.card_form);

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalResultCallback.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalResultCallback.java
@@ -7,5 +7,5 @@ import androidx.annotation.NonNull;
  */
 public interface CardinalResultCallback {
 
-    void onCardinalResult(@NonNull CardinalResult cardinalResult);
+    void onCardinalResult(@NonNull ThreeDSecurePaymentAuthResult paymentAuthResult);
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivityResultContract.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivityResultContract.java
@@ -17,7 +17,7 @@ import androidx.annotation.Nullable;
 import com.cardinalcommerce.cardinalmobilesdk.models.ValidateResponse;
 
 class ThreeDSecureActivityResultContract
-        extends ActivityResultContract<ThreeDSecureResult, CardinalResult> {
+        extends ActivityResultContract<ThreeDSecureResult, ThreeDSecurePaymentAuthResult> {
 
     @NonNull
     @Override
@@ -31,25 +31,25 @@ class ThreeDSecureActivityResultContract
     }
 
     @Override
-    public CardinalResult parseResult(int resultCode, @Nullable Intent intent) {
-        CardinalResult result;
+    public ThreeDSecurePaymentAuthResult parseResult(int resultCode, @Nullable Intent intent) {
+        ThreeDSecurePaymentAuthResult result;
 
         if (resultCode == Activity.RESULT_CANCELED) {
-            result = new CardinalResult(new UserCanceledException("User canceled 3DS."));
+            result = new ThreeDSecurePaymentAuthResult(new UserCanceledException("User canceled 3DS."));
         } else if (intent == null) {
             String unknownErrorMessage =
                     "An unknown Android error occurred with the activity result API.";
-            result = new CardinalResult(new BraintreeException(unknownErrorMessage));
+            result = new ThreeDSecurePaymentAuthResult(new BraintreeException(unknownErrorMessage));
         } else if (resultCode == ThreeDSecureActivity.RESULT_COULD_NOT_START_CARDINAL) {
             String errorMessage = intent.getStringExtra(EXTRA_ERROR_MESSAGE);
-            result = new CardinalResult(new BraintreeException(errorMessage));
+            result = new ThreeDSecurePaymentAuthResult(new BraintreeException(errorMessage));
         } else {
             ThreeDSecureResult threeDSecureResult =
                     intent.getParcelableExtra(EXTRA_THREE_D_SECURE_RESULT);
             ValidateResponse validateResponse =
                     (ValidateResponse) intent.getSerializableExtra(EXTRA_VALIDATION_RESPONSE);
             String jwt = intent.getStringExtra(EXTRA_JWT);
-            result = new CardinalResult(threeDSecureResult, jwt, validateResponse);
+            result = new ThreeDSecurePaymentAuthResult(threeDSecureResult, jwt, validateResponse);
         }
         return result;
     }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -61,9 +61,9 @@ public class ThreeDSecureClient {
      * @param request  the {@link ThreeDSecureRequest} with information used for authentication.
      * @param callback {@link ThreeDSecureResultCallback}
      */
-    public void performVerification(@NonNull final Context context,
-                                    @NonNull final ThreeDSecureRequest request,
-                                    @NonNull final ThreeDSecureResultCallback callback) {
+    public void createPaymentAuthRequest(@NonNull final Context context,
+                                         @NonNull final ThreeDSecureRequest request,
+                                         @NonNull final ThreeDSecureResultCallback callback) {
         if (request.getAmount() == null || request.getNonce() == null) {
             callback.onResult(null, new InvalidArgumentException(
                     "The ThreeDSecureRequest nonce and amount cannot be null"));

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -267,18 +267,18 @@ public class ThreeDSecureClient {
      * Call this method from the {@link CardinalResultCallback} passed to the
      * {@link ThreeDSecureLauncher} used to launch the 3DS authentication challenge.
      *
-     * @param cardinalResult a {@link CardinalResult} received in {@link CardinalResultCallback}
+     * @param paymentAuthResult a {@link ThreeDSecurePaymentAuthResult} received in {@link CardinalResultCallback}
      * @param callback       a {@link ThreeDSecureResultCallback}
      */
-    public void onCardinalResult(CardinalResult cardinalResult,
-                                 ThreeDSecureResultCallback callback) {
-        Exception threeDSecureError = cardinalResult.getError();
+    public void tokenize(ThreeDSecurePaymentAuthResult paymentAuthResult,
+                         ThreeDSecureResultCallback callback) {
+        Exception threeDSecureError = paymentAuthResult.getError();
         if (threeDSecureError != null) {
             callback.onResult(null, threeDSecureError);
         } else {
-            ThreeDSecureResult threeDSecureResult = cardinalResult.getThreeSecureResult();
-            ValidateResponse validateResponse = cardinalResult.getValidateResponse();
-            String jwt = cardinalResult.getJWT();
+            ThreeDSecureResult threeDSecureResult = paymentAuthResult.getThreeSecureResult();
+            ValidateResponse validateResponse = paymentAuthResult.getValidateResponse();
+            String jwt = paymentAuthResult.getJWT();
 
             braintreeClient.sendAnalyticsEvent(
                     String.format("three-d-secure.verification-flow.cardinal-sdk.action-code.%s",

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -257,10 +257,10 @@ public class ThreeDSecureClient {
     }
 
     /**
-     * Call this method from the {@link CardinalResultCallback} passed to the
+     * Call this method from the {@link ThreeDSecureLauncherCallback} passed to the
      * {@link ThreeDSecureLauncher} used to launch the 3DS authentication challenge.
      *
-     * @param paymentAuthResult a {@link ThreeDSecurePaymentAuthResult} received in {@link CardinalResultCallback}
+     * @param paymentAuthResult a {@link ThreeDSecurePaymentAuthResult} received in {@link ThreeDSecureLauncherCallback}
      * @param callback       a {@link ThreeDSecureResultCallback}
      */
     public void tokenize(ThreeDSecurePaymentAuthResult paymentAuthResult,

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureClient.java
@@ -94,7 +94,7 @@ public class ThreeDSecureClient {
             ThreeDSecureResultCallback internalResultCallback =
                     (threeDSecureResult, performLookupError) -> {
                 if (threeDSecureResult != null) {
-                    continuePerformVerification(threeDSecureResult, callback);
+                    sendAnalyticsAndCallbackResult(threeDSecureResult, callback);
                 } else {
                     callback.onResult(null, performLookupError);
                 }
@@ -193,13 +193,6 @@ public class ThreeDSecureClient {
         });
     }
 
-    void continuePerformVerification(@NonNull final ThreeDSecureResult result,
-                                            @NonNull final ThreeDSecureResultCallback callback) {
-        braintreeClient.getConfiguration(
-                (configuration, error) -> startVerificationFlow(
-                        result, callback));
-    }
-
     /**
      * Initialize a challenge from a server side lookup call.
      *
@@ -213,15 +206,16 @@ public class ThreeDSecureClient {
             ThreeDSecureResult result;
             try {
                 result = ThreeDSecureResult.fromJson(lookupResponse);
-                startVerificationFlow(result, callback);
+                sendAnalyticsAndCallbackResult(result, callback);
             } catch (JSONException e) {
                 callback.onResult(null, e);
             }
         });
     }
 
-    private void startVerificationFlow(ThreeDSecureResult result,
-                                       ThreeDSecureResultCallback callback) {
+    // TODO: Consolidate this method with createPaymentAuthRequest when analytics refactor is complete
+    void sendAnalyticsAndCallbackResult(ThreeDSecureResult result,
+                                        ThreeDSecureResultCallback callback) {
         ThreeDSecureLookup lookup = result.getLookup();
 
         boolean showChallenge = lookup.getAcsUrl() != null;
@@ -258,7 +252,6 @@ public class ThreeDSecureClient {
             return;
         }
 
-        // perform cardinal authentication
         braintreeClient.sendAnalyticsEvent("three-d-secure.verification-flow.started");
         callback.onResult(result, null);
     }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
@@ -81,7 +81,7 @@ public class ThreeDSecureLauncher {
                         + "Please contact Braintree Support for assistance.";
                 BraintreeException threeDSecureResponseTooLargeError =
                         new BraintreeException(errorMessage, runtimeException);
-                callback.onCardinalResult(new CardinalResult(threeDSecureResponseTooLargeError));
+                callback.onCardinalResult(new ThreeDSecurePaymentAuthResult(threeDSecureResponseTooLargeError));
             } else {
                 throw runtimeException;
             }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
@@ -62,7 +62,7 @@ public class ThreeDSecureLauncher {
     /**
      * Launches the 3DS flow by switching to an authentication Activity. Call this method in the
      * callback of
-     * {@link ThreeDSecureClient#performVerification(Context, ThreeDSecureRequest,
+     * {@link ThreeDSecureClient#createPaymentAuthRequest(Context, ThreeDSecureRequest,
      * ThreeDSecureResultCallback)} if user authentication is required
      * {@link ThreeDSecureLookup#requiresUserAuthentication()}
      *

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncher.java
@@ -20,18 +20,18 @@ public class ThreeDSecureLauncher {
             "com.braintreepayments.api.ThreeDSecure.RESULT";
     @VisibleForTesting
     ActivityResultLauncher<ThreeDSecureResult> activityLauncher;
-    private final CardinalResultCallback callback;
+    private final ThreeDSecureLauncherCallback callback;
 
     /**
      * Used to launch the 3DS authentication flow to tokenize a 3DS card. This class must be
      * instantiated in the onCreateView method of your Fragment
      *
      * @param fragment an Android Fragment from which you will launch the 3DS flow
-     * @param callback a {@link CardinalResultCallback} to received the result of the 3DS
+     * @param callback a {@link ThreeDSecureLauncherCallback} to received the result of the 3DS
      *                 authentication flow
      */
     public ThreeDSecureLauncher(@NonNull Fragment fragment,
-                                @NonNull CardinalResultCallback callback) {
+                                @NonNull ThreeDSecureLauncherCallback callback) {
         this(fragment.getActivity().getActivityResultRegistry(), fragment.getViewLifecycleOwner(),
                 callback);
     }
@@ -41,22 +41,22 @@ public class ThreeDSecureLauncher {
      * instantiated in the onCreate method of your FragmentActivity
      *
      * @param activity an Android Activity from which you will launch the 3DS flow
-     * @param callback a {@link CardinalResultCallback} to received the result of the 3DS
+     * @param callback a {@link ThreeDSecureLauncherCallback} to received the result of the 3DS
      *                 authentication flow
      */
     public ThreeDSecureLauncher(@NonNull FragmentActivity activity,
-                                @NonNull CardinalResultCallback callback) {
+                                @NonNull ThreeDSecureLauncherCallback callback) {
         this(activity.getActivityResultRegistry(), activity, callback);
     }
 
     @VisibleForTesting
     ThreeDSecureLauncher(ActivityResultRegistry registry, LifecycleOwner lifecycleOwner,
-                         CardinalResultCallback callback) {
+                         ThreeDSecureLauncherCallback callback) {
         this.callback = callback;
         activityLauncher =
                 registry.register(THREE_D_SECURE_RESULT, lifecycleOwner,
                         new ThreeDSecureActivityResultContract(),
-                        callback::onCardinalResult);
+                        callback::onThreeDSecurePaymentAuthResult);
     }
 
     /**
@@ -81,7 +81,7 @@ public class ThreeDSecureLauncher {
                         + "Please contact Braintree Support for assistance.";
                 BraintreeException threeDSecureResponseTooLargeError =
                         new BraintreeException(errorMessage, runtimeException);
-                callback.onCardinalResult(new ThreeDSecurePaymentAuthResult(threeDSecureResponseTooLargeError));
+                callback.onThreeDSecurePaymentAuthResult(new ThreeDSecurePaymentAuthResult(threeDSecureResponseTooLargeError));
             } else {
                 throw runtimeException;
             }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncherCallback.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureLauncherCallback.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 /**
  * Callback for receiving the results via {@link ThreeDSecureLauncher}
  */
-public interface CardinalResultCallback {
+public interface ThreeDSecureLauncherCallback {
 
-    void onCardinalResult(@NonNull ThreeDSecurePaymentAuthResult paymentAuthResult);
+    void onThreeDSecurePaymentAuthResult(@NonNull ThreeDSecurePaymentAuthResult paymentAuthResult);
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecurePaymentAuthResult.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecurePaymentAuthResult.java
@@ -2,7 +2,7 @@ package com.braintreepayments.api;
 
 import com.cardinalcommerce.cardinalmobilesdk.models.ValidateResponse;
 
-public class CardinalResult {
+public class ThreeDSecurePaymentAuthResult {
 
     private final String jwt;
     private final ValidateResponse validateResponse;
@@ -10,15 +10,15 @@ public class CardinalResult {
 
     private final Exception error;
 
-    CardinalResult(ThreeDSecureResult threeDSecureResult, String jwt,
-                   ValidateResponse validateResponse) {
+    ThreeDSecurePaymentAuthResult(ThreeDSecureResult threeDSecureResult, String jwt,
+                                  ValidateResponse validateResponse) {
         this.jwt = jwt;
         this.validateResponse = validateResponse;
         this.threeDSecureResult = threeDSecureResult;
         this.error = null;
     }
 
-    CardinalResult(Exception error) {
+    ThreeDSecurePaymentAuthResult(Exception error) {
         this.error = error;
         this.jwt = null;
         this.validateResponse = null;

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureResult.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureResult.java
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 /**
  * Class to parse and contain 3D Secure authentication responses
  */
+// TODO: Split into separate result objects for createPaymentAuthRequest and tokenize methods
 public class ThreeDSecureResult implements Parcelable {
 
     private static final String ERRORS_KEY = "errors";

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureResultCallback.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureResultCallback.java
@@ -1,17 +1,15 @@
 package com.braintreepayments.api;
 
-import android.content.Intent;
 
 import androidx.annotation.Nullable;
 
 /**
  * Callback for receiving result of
- * {@link ThreeDSecureClient#performVerification(android.content.Context, ThreeDSecureRequest, ThreeDSecureResultCallback)},
- * {@link ThreeDSecureClient#continuePerformVerification(ThreeDSecureResult, ThreeDSecureResultCallback)},
- * {@link ThreeDSecureClient#onBrowserSwitchResult(BrowserSwitchResult,
- * ThreeDSecureResultCallback)}, and
- * {@link ThreeDSecureClient#onActivityResult(int, Intent, ThreeDSecureResultCallback)}.
+ * {@link ThreeDSecureClient#createPaymentAuthRequest(android.content.Context, ThreeDSecureRequest, ThreeDSecureResultCallback)},
+
  */
+// TODO: Split into separate callbacks for internal and public methods and for
+//  createPaymentAuthRequest and tokenize methods
 public interface ThreeDSecureResultCallback {
 
     /**

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityResultContractUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityResultContractUnitTest.java
@@ -59,22 +59,23 @@ public class ThreeDSecureActivityResultContractUnitTest {
         String jwt = "sample-jwt";
         successIntent.putExtra(EXTRA_JWT, jwt);
 
-        CardinalResult cardinalResult = sut.parseResult(Activity.RESULT_OK, successIntent);
-        assertNotNull(cardinalResult);
+        ThreeDSecurePaymentAuthResult
+                paymentAuthResult = sut.parseResult(Activity.RESULT_OK, successIntent);
+        assertNotNull(paymentAuthResult);
 
-        assertSame(threeDSecureResult, cardinalResult.getThreeSecureResult());
-        assertSame(validateResponse, cardinalResult.getValidateResponse());
-        assertSame(jwt, cardinalResult.getJWT());
+        assertSame(threeDSecureResult, paymentAuthResult.getThreeSecureResult());
+        assertSame(validateResponse, paymentAuthResult.getValidateResponse());
+        assertSame(jwt, paymentAuthResult.getJWT());
     }
 
     @Test
     public void parseResult_whenResultIsOKAndIntentIsNull_returnsCardinalResultWithError() {
         sut = new ThreeDSecureActivityResultContract();
 
-        CardinalResult cardinalResult = sut.parseResult(Activity.RESULT_OK, null);
-        assertNotNull(cardinalResult);
+        ThreeDSecurePaymentAuthResult paymentAuthResult = sut.parseResult(Activity.RESULT_OK, null);
+        assertNotNull(paymentAuthResult);
 
-        BraintreeException error = (BraintreeException) cardinalResult.getError();
+        BraintreeException error = (BraintreeException) paymentAuthResult.getError();
         String expectedMessage = "An unknown Android error occurred with the activity result API.";
         assertNotNull(expectedMessage, error.getMessage());
     }
@@ -83,10 +84,11 @@ public class ThreeDSecureActivityResultContractUnitTest {
     public void parseResult_whenResultIsCANCELED_returnsCardinalResultWithError() {
         sut = new ThreeDSecureActivityResultContract();
 
-        CardinalResult cardinalResult = sut.parseResult(Activity.RESULT_CANCELED, new Intent());
-        assertNotNull(cardinalResult);
+        ThreeDSecurePaymentAuthResult
+                paymentAuthResult = sut.parseResult(Activity.RESULT_CANCELED, new Intent());
+        assertNotNull(paymentAuthResult);
 
-        UserCanceledException error = (UserCanceledException) cardinalResult.getError();
+        UserCanceledException error = (UserCanceledException) paymentAuthResult.getError();
         assertEquals("User canceled 3DS.", error.getMessage());
     }
 
@@ -97,11 +99,11 @@ public class ThreeDSecureActivityResultContractUnitTest {
         Intent intent = new Intent();
         intent.putExtra(ThreeDSecureActivity.EXTRA_ERROR_MESSAGE, "sample error message");
 
-        CardinalResult cardinalResult =
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
             sut.parseResult(ThreeDSecureActivity.RESULT_COULD_NOT_START_CARDINAL, intent);
-        assertNotNull(cardinalResult);
+        assertNotNull(paymentAuthResult);
 
-        BraintreeException error = (BraintreeException) cardinalResult.getError();
+        BraintreeException error = (BraintreeException) paymentAuthResult.getError();
         assertEquals("sample error message", error.getMessage());
     }
 }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -218,10 +218,10 @@ public class ThreeDSecureClientUnitTest {
 
     // endregion
 
-    // region performVerification
+    // region createPaymentAuthRequest
 
     @Test
-    public void performVerification_sendsAnalyticEvent() throws BraintreeException {
+    public void createPaymentAuthRequest_sendsAnalyticEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("sample-session-id")
                 .build();
@@ -233,13 +233,13 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
-        sut.performVerification(activity, basicRequest, threeDSecureResultCallback);
+        sut.createPaymentAuthRequest(activity, basicRequest, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("three-d-secure.initialized");
     }
 
     @Test
-    public void performVerification_sendsParamsInLookupRequest()
+    public void createPaymentAuthRequest_sendsParamsInLookupRequest()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
@@ -261,7 +261,7 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
-        sut.performVerification(activity, request, threeDSecureResultCallback);
+        sut.createPaymentAuthRequest(activity, request, threeDSecureResultCallback);
 
         String expectedUrl = "/v1/payment_methods/a-nonce/three_d_secure/lookup";
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
@@ -277,7 +277,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_performsLookup_WhenCardinalSDKInitFails()
+    public void createPaymentAuthRequest_performsLookup_WhenCardinalSDKInitFails()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("error"))
@@ -298,7 +298,7 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
-        sut.performVerification(activity, request, threeDSecureResultCallback);
+        sut.createPaymentAuthRequest(activity, request, threeDSecureResultCallback);
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
@@ -319,7 +319,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_callsLookupListener() throws BraintreeException {
+    public void createPaymentAuthRequest_callsLookupListener() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("sample-session-id")
                 .build();
@@ -341,14 +341,14 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
 
-        sut.performVerification(activity, request, threeDSecureResultCallback);
+        sut.createPaymentAuthRequest(activity, request, threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(any(ThreeDSecureResult.class),
                 isNull());
     }
 
     @Test
-    public void performVerification_withInvalidRequest_postsException() throws BraintreeException {
+    public void createPaymentAuthRequest_withInvalidRequest_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -359,7 +359,7 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setAmount("5");
-        sut.performVerification(activity, request, threeDSecureResultCallback);
+        sut.createPaymentAuthRequest(activity, request, threeDSecureResultCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(threeDSecureResultCallback).onResult(isNull(), captor.capture());
@@ -368,7 +368,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void performVerification_initializesCardinal() throws BraintreeException {
+    public void createPaymentAuthRequest_initializesCardinal() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
                 .build();
@@ -381,14 +381,14 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
-        sut.performVerification(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
+        sut.createPaymentAuthRequest(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
 
         verify(cardinalClient).initialize(same(activity), same(threeDSecureEnabledConfig),
                 same(basicRequest), any(CardinalInitializeCallback.class));
     }
 
     @Test
-    public void performVerification_whenCardinalClientInitializeFails_forwardsError()
+    public void createPaymentAuthRequest_whenCardinalClientInitializeFails_forwardsError()
             throws BraintreeException {
         BraintreeException initializeRuntimeError = new BraintreeException("initialize error");
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
@@ -405,13 +405,13 @@ public class ThreeDSecureClientUnitTest {
                         new ThreeDSecureAPI(braintreeClient));
 
         ThreeDSecureResultCallback callback = mock(ThreeDSecureResultCallback.class);
-        sut.performVerification(activity, basicRequest, callback);
+        sut.createPaymentAuthRequest(activity, basicRequest, callback);
 
         verify(callback).onResult(null, initializeRuntimeError);
     }
 
     @Test
-    public void performVerification_whenCardinalSetupCompleted_sendsAnalyticEvent()
+    public void createPaymentAuthRequest_whenCardinalSetupCompleted_sendsAnalyticEvent()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("df-reference-id")
@@ -425,14 +425,14 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
-        sut.performVerification(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
+        sut.createPaymentAuthRequest(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
 
         verify(braintreeClient).sendAnalyticsEvent(
                 "three-d-secure.cardinal-sdk.init.setup-completed");
     }
 
     @Test
-    public void performVerification_whenCardinalSetupFailed_sendsAnalyticEvent()
+    public void createPaymentAuthRequest_whenCardinalSetupFailed_sendsAnalyticEvent()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .error(new Exception("cardinal error"))
@@ -446,13 +446,13 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureClient sut =
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         new ThreeDSecureAPI(braintreeClient));
-        sut.performVerification(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
+        sut.createPaymentAuthRequest(activity, basicRequest, mock(ThreeDSecureResultCallback.class));
 
         verify(braintreeClient).sendAnalyticsEvent("three-d-secure.cardinal-sdk.init.setup-failed");
     }
 
     @Test
-    public void performVerification_withoutCardinalJWT_postsException() throws BraintreeException {
+    public void createPaymentAuthRequest_withoutCardinalJWT_postsException() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
 
         Configuration configuration = new TestConfigurationBuilder()
@@ -469,7 +469,7 @@ public class ThreeDSecureClientUnitTest {
                         new ThreeDSecureAPI(braintreeClient));
 
         ThreeDSecureResultCallback callback = mock(ThreeDSecureResultCallback.class);
-        sut.performVerification(activity, basicRequest, callback);
+        sut.createPaymentAuthRequest(activity, basicRequest, callback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(callback).onResult(isNull(), captor.capture());

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -639,8 +639,8 @@ public class ThreeDSecureClientUnitTest {
                         threeDSecureAPI);
 
         Exception threeDSecureError = new Exception("3DS error.");
-        CardinalResult cardinalResult = new CardinalResult(threeDSecureError);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult = new ThreeDSecurePaymentAuthResult(threeDSecureError);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(threeDSecureResultCallback).onResult(isNull(), captor.capture());
@@ -658,9 +658,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(
                 "three-d-secure.verification-flow.cardinal-sdk.action-code.success");
@@ -680,9 +680,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(threeDSecureResultCallback).onResult(isNull(), captor.capture());
@@ -705,9 +705,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(threeDSecureResultCallback).onResult(isNull(), captor.capture());
@@ -740,9 +740,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(threeDSecureResult, null);
         verify(braintreeClient).sendAnalyticsEvent(
@@ -778,9 +778,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(threeDSecureResult, null);
         verify(braintreeClient).sendAnalyticsEvent(
@@ -811,9 +811,9 @@ public class ThreeDSecureClientUnitTest {
                 new ThreeDSecureClient(braintreeClient, cardinalClient,
                         threeDSecureAPI);
 
-        CardinalResult cardinalResult =
-                new CardinalResult(threeDSecureResult, "jwt", validateResponse);
-        sut.onCardinalResult(cardinalResult, threeDSecureResultCallback);
+        ThreeDSecurePaymentAuthResult paymentAuthResult =
+                new ThreeDSecurePaymentAuthResult(threeDSecureResult, "jwt", validateResponse);
+        sut.tokenize(paymentAuthResult, threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(null, exception);
         braintreeClient.sendAnalyticsEvent(

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -481,9 +481,9 @@ public class ThreeDSecureClientUnitTest {
 
     // endregion
 
-    // region continuePerformVerification
+    // region sendAnalyticsAndCallbackResult
     @Test
-    public void continuePerformVerification_whenAuthenticatingWithCardinal_sendsAnalyticsEvent()
+    public void sendAnalyticsAndCallbackResult_whenAuthenticatingWithCardinal_sendsAnalyticsEvent()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -500,13 +500,13 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
-        sut.continuePerformVerification(threeDSecureResult, threeDSecureResultCallback);
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent("three-d-secure.verification-flow.started");
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsPresented_sendsAnalyticsEvent()
+    public void sendAnalyticsAndCallbackResult_whenChallengeIsPresented_sendsAnalyticsEvent()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -524,14 +524,14 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE);
-        sut.continuePerformVerification(threeDSecureResult, threeDSecureResultCallback);
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(
                 "three-d-secure.verification-flow.challenge-presented.true");
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsNotPresented_sendsAnalyticsEvent()
+    public void sendAnalyticsAndCallbackResult_whenChallengeIsNotPresented_sendsAnalyticsEvent()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -548,14 +548,14 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE_NO_ACS_URL);
-        sut.continuePerformVerification(threeDSecureResult, threeDSecureResultCallback);
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(
                 "three-d-secure.verification-flow.challenge-presented.false");
     }
 
     @Test
-    public void continuePerformVerification_whenChallengeIsNotPresented_returnsResult()
+    public void sendAnalyticsAndCallbackResult_whenChallengeIsNotPresented_returnsResult()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -572,13 +572,13 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE_NO_ACS_URL);
-        sut.continuePerformVerification(threeDSecureResult, threeDSecureResultCallback);
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult, threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(threeDSecureResult, null);
     }
 
     @Test
-    public void continuePerformVerification_sendsAnalyticsEvent()
+    public void sendAnalyticsAndCallbackResult_sendsAnalyticsEvent()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -595,14 +595,14 @@ public class ThreeDSecureClientUnitTest {
 
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
-        sut.continuePerformVerification(threeDSecureResult, threeDSecureResultCallback);
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult, threeDSecureResultCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(
                 "three-d-secure.verification-flow.3ds-version.2.1.0");
     }
 
     @Test
-    public void continuePerformVerification_callsBackThreeDSecureResultForLaunch()
+    public void sendAnalyticsAndCallbackResult_callsBackThreeDSecureResultForLaunch()
             throws JSONException, BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder()
                 .successReferenceId("reference-id")
@@ -619,7 +619,7 @@ public class ThreeDSecureClientUnitTest {
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
 
-        sut.continuePerformVerification(threeDSecureResult,
+        sut.sendAnalyticsAndCallbackResult(threeDSecureResult,
                 threeDSecureResultCallback);
 
         verify(threeDSecureResultCallback).onResult(threeDSecureResult, null);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureClientUnitTest.java
@@ -627,9 +627,9 @@ public class ThreeDSecureClientUnitTest {
 
     // endregion
 
-    // region onCardinalResult
+    // region tokenize
     @Test
-    public void onCardinalResult_whenErrorExists_forwardsErrorToCallback_andSendsAnalytics()
+    public void tokenize_whenErrorExists_forwardsErrorToCallback_andSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -647,7 +647,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_onSuccess_sendsAnalyticsEvent() throws BraintreeException {
+    public void tokenize_onSuccess_sendsAnalyticsEvent() throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
@@ -667,7 +667,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseTimeout_returnsErrorAndSendsAnalytics()
+    public void tokenize_whenValidateResponseTimeout_returnsErrorAndSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -693,7 +693,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseCancel_returnsUserCanceledErrorAndSendsAnalytics()
+    public void tokenize_whenValidateResponseCancel_returnsUserCanceledErrorAndSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -720,7 +720,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResult_returnsResultAndSendsAnalytics()
+    public void tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTResult_returnsResultAndSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -755,7 +755,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTResultWithError_returnsResultAndSendsAnalytics()
+    public void tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTResultWithError_returnsResultAndSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -789,7 +789,7 @@ public class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    public void onCardinalResult_whenValidateResponseSuccess_onAuthenticateCardinalJWTError_returnsErrorAndSendsAnalytics()
+    public void tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTError_returnsErrorAndSendsAnalytics()
             throws BraintreeException {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLauncherUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLauncherUnitTest.java
@@ -31,12 +31,12 @@ public class ThreeDSecureLauncherUnitTest {
 
     @Mock
     ActivityResultLauncher<ThreeDSecureResult> activityResultLauncher;
-    private CardinalResultCallback callback;
+    private ThreeDSecureLauncherCallback callback;
 
     @Before
     public void beforeEach() {
         MockitoAnnotations.openMocks(this);
-        callback = mock(CardinalResultCallback.class);
+        callback = mock(ThreeDSecureLauncherCallback.class);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ThreeDSecureLauncherUnitTest {
 
         ArgumentCaptor<ThreeDSecurePaymentAuthResult> captor =
                 ArgumentCaptor.forClass(ThreeDSecurePaymentAuthResult.class);
-        verify(callback).onCardinalResult(captor.capture());
+        verify(callback).onThreeDSecurePaymentAuthResult(captor.capture());
 
         Exception exception = captor.getValue().getError();
         assertTrue(exception instanceof BraintreeException);

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLauncherUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureLauncherUnitTest.java
@@ -49,7 +49,7 @@ public class ThreeDSecureLauncherUnitTest {
                 callback);
 
         verify(activityResultRegistry).register(eq(expectedKey), same(lifecycleOwner),
-                Mockito.<ActivityResultContract<ThreeDSecureResult, CardinalResult>>any(),
+                Mockito.<ActivityResultContract<ThreeDSecureResult, ThreeDSecurePaymentAuthResult>>any(),
                 Mockito.any());
     }
 
@@ -89,8 +89,8 @@ public class ThreeDSecureLauncherUnitTest {
 
         sut.launch(threeDSecureResult);
 
-        ArgumentCaptor<CardinalResult> captor =
-                ArgumentCaptor.forClass(CardinalResult.class);
+        ArgumentCaptor<ThreeDSecurePaymentAuthResult> captor =
+                ArgumentCaptor.forClass(ThreeDSecurePaymentAuthResult.class);
         verify(callback).onCardinalResult(captor.capture());
 
         Exception exception = captor.getValue().getError();

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -183,8 +183,8 @@ class MyActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 +       // can initialize clients outside of onCreate if desired
 -       initializeClients()
-+       threeDSecureLauncher = ThreeDSecureLauncher(this) { cardinalResult ->
-+            threeDSecureClient.onCardinalResult(cardinalResult) { threeDSecureResult, error ->
++       threeDSecureLauncher = ThreeDSecureLauncher(this) { paymentAuthResult ->
++            threeDSecureClient.onCardinalResult(paymentAuthResult) { threeDSecureResult, error ->
 +                error?.let { /* handle error */ }
 +                threeDSecureResult?.let { /* handle threeDSecureResult.tokenizedCard */ }
 +            }

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -184,7 +184,7 @@ class MyActivity : FragmentActivity() {
 +       // can initialize clients outside of onCreate if desired
 -       initializeClients()
 +       threeDSecureLauncher = ThreeDSecureLauncher(this) { paymentAuthResult ->
-+            threeDSecureClient.onCardinalResult(paymentAuthResult) { threeDSecureResult, error ->
++            threeDSecureClient.tokenize(paymentAuthResult) { threeDSecureResult, error ->
 +                error?.let { /* handle error */ }
 +                threeDSecureResult?.let { /* handle threeDSecureResult.tokenizedCard */ }
 +            }
@@ -200,7 +200,7 @@ class MyActivity : FragmentActivity() {
     
     fun onCardTokenization() {
 -       threeDSecureClient.performVerification(activity, threeDSecureRequest) { 
-+       threeDSecureClient.performVerification(requireContext(), threeDSecureRequest) { 
++       threeDSecureClient.createPaymentAuthRequest(requireContext(), threeDSecureRequest) { 
           threeDSecureResult, error ->
              error?.let { /* handle error */ }
              threeDSecureResult?.let {


### PR DESCRIPTION
### Summary of changes

 - Rename 3DS APIs to follow `createPaymentAuthRequest` and `tokenize` pattern
 - Remove internal `continuePerformVerification` method and rename `startVerificationFlow` internal method to `sendAnalyticsAndCallbackResult` (this method can also likely be refactored and removed when analytics are updated).
 - 3DS is slightly different than the other modules because it uses a single `ThreeDSecureResult` object for both steps of the flow, there is also a single callback for those results that is used internally and externally. For now, I left the `ThreeDSecureResult` object naming the same and kept the callback. I've added TODOs to refactor that object and those callbacks in the PR to migrate to a single result object pattern.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
