### PR TITLE
VenmoListener NPE Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Venmo
+  * Fix NPE when `VenmoListener` is null (fixes #832)
+
 ## 4.40.0 (2023-11-16)
 
 * PayPalNativeCheckout

--- a/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
@@ -1,0 +1,16 @@
+package com.braintreepayments.api
+
+import androidx.annotation.RestrictTo
+
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object LoggingUtils {
+
+    const val TAG = "Braintree"
+
+    const val LISTENER_WARNING = "Unable to deliver result to null listener"
+}
+
+

--- a/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
@@ -8,7 +8,7 @@ import androidx.annotation.RestrictTo
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object LoggingUtils {
 
-    const val TAG = "Braintree"
+    const val TAG = "Braintree SDK"
 
     const val LISTENER_WARNING = "Unable to deliver result to null listener"
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/LoggingUtils.kt
@@ -12,5 +12,3 @@ object LoggingUtils {
 
     const val LISTENER_WARNING = "Unable to deliver result to null listener"
 }
-
-

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -34,8 +34,6 @@ public class VenmoClient {
     static final String EXTRA_USERNAME = "com.braintreepayments.api.EXTRA_USER_NAME";
     static final String EXTRA_RESOURCE_ID = "com.braintreepayments.api.EXTRA_RESOURCE_ID";
 
-    static final String LOGGING_TAG = "Braintree";
-
     private final BraintreeClient braintreeClient;
     private final VenmoApi venmoApi;
     private final VenmoSharedPrefsWriter sharedPrefsWriter;
@@ -313,7 +311,7 @@ public class VenmoClient {
         if (listener != null) {
             listener.onVenmoSuccess(venmoAccountNonce);
         } else {
-            Log.w(LOGGING_TAG, "Unable to deliver result to null listener");
+            Log.w(LoggingUtils.TAG, LoggingUtils.LISTENER_WARNING);
         }
     }
 
@@ -321,7 +319,7 @@ public class VenmoClient {
         if (listener != null) {
             listener.onVenmoFailure(error);
         } else {
-            Log.w(LOGGING_TAG, "Unable to deliver result to null listener");
+            Log.w(LoggingUtils.TAG, LoggingUtils.LISTENER_WARNING);
         }
     }
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -131,7 +131,7 @@ public class VenmoClient {
         tokenizeVenmoAccount(activity, request, new VenmoTokenizeAccountCallback() {
             @Override
             public void onResult(@Nullable Exception error) {
-                if (error != null ) {
+                if (error != null) {
                     deliverVenmoFailure(error);
                 }
             }
@@ -278,11 +278,11 @@ public class VenmoClient {
                                 vaultVenmoAccountNonce(nonce, new VenmoOnActivityResultCallback() {
                                     @Override
                                     public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
-                                            if (venmoAccountNonce != null) {
-                                                deliverVenmoSuccess(venmoAccountNonce);
-                                            } else if (error != null) {
-                                                deliverVenmoFailure(error);
-                                            }
+                                        if (venmoAccountNonce != null) {
+                                            deliverVenmoSuccess(venmoAccountNonce);
+                                        } else if (error != null) {
+                                            deliverVenmoFailure(error);
+                                        }
                                     }
                                 });
                             } else {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -32,6 +33,8 @@ public class VenmoClient {
     static final String EXTRA_PAYMENT_METHOD_NONCE = "com.braintreepayments.api.EXTRA_PAYMENT_METHOD_NONCE";
     static final String EXTRA_USERNAME = "com.braintreepayments.api.EXTRA_USER_NAME";
     static final String EXTRA_RESOURCE_ID = "com.braintreepayments.api.EXTRA_RESOURCE_ID";
+
+    static final String LOGGING_TAG = "Braintree";
 
     private final BraintreeClient braintreeClient;
     private final VenmoApi venmoApi;
@@ -309,12 +312,16 @@ public class VenmoClient {
     private void deliverVenmoSuccess(VenmoAccountNonce venmoAccountNonce) {
         if (listener != null) {
             listener.onVenmoSuccess(venmoAccountNonce);
+        } else {
+            Log.w(LOGGING_TAG, "Unable to deliver result to null listener");
         }
     }
 
     private void deliverVenmoFailure(Exception error) {
         if (listener != null) {
             listener.onVenmoFailure(error);
+        } else {
+            Log.w(LOGGING_TAG, "Unable to deliver result to null listener");
         }
     }
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -131,8 +131,8 @@ public class VenmoClient {
         tokenizeVenmoAccount(activity, request, new VenmoTokenizeAccountCallback() {
             @Override
             public void onResult(@Nullable Exception error) {
-                if (error != null) {
-                    listener.onVenmoFailure(error);
+                if (error != null ) {
+                    deliverVenmoFailure(error);
                 }
             }
         });
@@ -254,19 +254,19 @@ public class VenmoClient {
                                                 @Override
                                                 public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
                                                     if (venmoAccountNonce != null) {
-                                                        listener.onVenmoSuccess(venmoAccountNonce);
+                                                        deliverVenmoSuccess(venmoAccountNonce);
                                                     } else if (error != null) {
-                                                        listener.onVenmoFailure(error);
+                                                        deliverVenmoFailure(error);
                                                     }
                                                 }
                                             });
                                         } else {
                                             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                            listener.onVenmoSuccess(nonce);
+                                            deliverVenmoSuccess(nonce);
                                         }
                                     } else {
                                         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure");
-                                        listener.onVenmoFailure(error);
+                                        deliverVenmoFailure(error);
                                     }
                                 }
                             });
@@ -278,22 +278,22 @@ public class VenmoClient {
                                 vaultVenmoAccountNonce(nonce, new VenmoOnActivityResultCallback() {
                                     @Override
                                     public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
-                                        if (venmoAccountNonce != null) {
-                                            listener.onVenmoSuccess(venmoAccountNonce);
-                                        } else if (error != null) {
-                                            listener.onVenmoFailure(error);
-                                        }
+                                            if (venmoAccountNonce != null) {
+                                                deliverVenmoSuccess(venmoAccountNonce);
+                                            } else if (error != null) {
+                                                deliverVenmoFailure(error);
+                                            }
                                     }
                                 });
                             } else {
                                 String venmoUsername = venmoResult.getVenmoUsername();
                                 VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(nonce, venmoUsername, false);
-                                listener.onVenmoSuccess(venmoAccountNonce);
+                                deliverVenmoSuccess(venmoAccountNonce);
                             }
 
                         }
                     } else if (authError != null) {
-                        listener.onVenmoFailure(authError);
+                        deliverVenmoFailure(authError);
                     }
                 }
             });
@@ -302,7 +302,19 @@ public class VenmoClient {
             if (venmoResult.getError() instanceof UserCanceledException) {
                 braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled");
             }
-            listener.onVenmoFailure(venmoResult.getError());
+            deliverVenmoFailure(venmoResult.getError());
+        }
+    }
+
+    private void deliverVenmoSuccess(VenmoAccountNonce venmoAccountNonce) {
+        if (listener != null) {
+            listener.onVenmoSuccess(venmoAccountNonce);
+        }
+    }
+
+    private void deliverVenmoFailure(Exception error) {
+        if (listener != null) {
+            listener.onVenmoFailure(error);
         }
     }
 

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -157,6 +157,31 @@ public class VenmoClientUnitTest {
     }
 
     @Test
+    public void tokenizeVenmoAccount_whenListenerNull_returnsNothing() {
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configuration(venmoEnabledConfiguration)
+                .sessionId("session-id")
+                .integration("custom")
+                .authorizationSuccess(clientToken)
+                .build();
+
+        VenmoApi venmoApi = new MockVenmoApiBuilder()
+                .createPaymentContextSuccess("venmo-payment-context-id")
+                .build();
+
+        when(deviceInspector.isVenmoAppSwitchAvailable(activity)).thenReturn(true);
+
+        VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
+        request.setProfileId("sample-venmo-merchant");
+        request.setCollectCustomerBillingAddress(true);
+
+        VenmoClient sut = new VenmoClient(null, null, braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
+        sut.tokenizeVenmoAccount(activity, request);
+        verify(listener, never()).onVenmoFailure(any(Exception.class));
+        verify(listener, never()).onVenmoSuccess(any(VenmoAccountNonce.class));
+    }
+
+    @Test
     public void tokenizeVenmoAccount_whenCreatePaymentContextSucceeds_withObserver_launchesObserverWithVenmoIntentData_andSendsAnalytics() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(venmoEnabledConfiguration)


### PR DESCRIPTION
### Summary of changes

 - Fix NPE in `VenmoClient` when listener is null by checking if listener exists before returning success or failure (does nothing on result without listener, but does not crash) 
 - Fixes #832 

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
