### PR TITLE
Return Auth/Config Error in PayPalClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Fix issue where inaccurate error message was being returned on authorization or configuration error (fixes #821)
+
 ## 4.40.0 (2023-11-16)
 
 * PayPalNativeCheckout

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -209,6 +209,11 @@ public class PayPalClient {
         braintreeClient.getConfiguration(new ConfigurationCallback() {
             @Override
             public void onResult(@Nullable final Configuration configuration, @Nullable Exception error) {
+                if (error != null) {
+                    callback.onResult(error);
+                    return;
+                }
+
                 if (payPalConfigInvalid(configuration)) {
                     Exception configInvalidError = createPayPalError();
                     callback.onResult(configInvalidError);
@@ -239,6 +244,11 @@ public class PayPalClient {
         braintreeClient.getConfiguration(new ConfigurationCallback() {
             @Override
             public void onResult(@Nullable final Configuration configuration, @Nullable Exception error) {
+                if (error != null) {
+                    callback.onResult(error);
+                    return;
+                }
+
                 if (payPalConfigInvalid(configuration)) {
                     Exception configInvalidError = createPayPalError();
                     callback.onResult(configInvalidError);

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -353,6 +353,22 @@ public class PayPalClientUnitTest {
     }
 
     @Test
+    public void requestOneTimePayment_whenConfigError_forwardsErrorToListener() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+
+        Exception authError = new Exception("Error fetching auth");
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configurationError(authError)
+                .build();
+
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
+        sut.tokenizePayPalAccount(activity, new PayPalCheckoutRequest("1.00"));
+
+        verify(listener).onPayPalFailure(authError);
+    }
+
+    @Test
     public void requestOneTimePayment_whenDeviceCantPerformBrowserSwitch_returnsErrorToListener() {
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -369,6 +369,22 @@ public class PayPalClientUnitTest {
     }
 
     @Test
+    public void requestBillingAgreement_whenConfigError_forwardsErrorToListener() {
+        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
+
+        Exception authError = new Exception("Error fetching auth");
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .configurationError(authError)
+                .build();
+
+        PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
+        sut.setListener(listener);
+        sut.tokenizePayPalAccount(activity, new PayPalVaultRequest());
+
+        verify(listener).onPayPalFailure(authError);
+    }
+
+    @Test
     public void requestOneTimePayment_whenDeviceCantPerformBrowserSwitch_returnsErrorToListener() {
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 


### PR DESCRIPTION
### Summary of changes

 - Propagate errors fetching configuration (which propagates authorization errors under the hood) to `PayPalListener` when auth is invalid or config is unable to be fetched, rather than returning a generic error message that PayPal is not enabled.
 - Note: This will return the merchant's own auth error defined in their `ClientTokenProvider` if an error is thrown at that level, or will propagate config fetching errors or other auth errors (ex if ClientTokenProvider is null).
 - Fixes #821 

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
