### PR TITLE
Remove FragmentActivity from GooglePayClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
     * Remove overload constructors, `setListener, and `onActivityResult` from `GooglePayClient`
     * Change `GooglePayClient#requestPayment` parameters and rename to 
       `GooglePayClient#createPaymentAuthRequest`
-    * Change `GooglePayIsReadyToPayCallback` parameters
+    * Change `GooglePayClient#isReadyToPay` and `GooglePayIsReadyToPayCallback` parameters
     * Add `GooglePayClient#tokenize` 
     * Remove `merchantId` from `GooglePayRequest`
     * Change `GooglePayGetTokenizationParametersCallback` parameters

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCapabilities.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCapabilities.java
@@ -3,7 +3,6 @@ package com.braintreepayments.api;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -17,7 +16,7 @@ public class GooglePayCapabilities {
     /**
      * @return {@code true} if Google Pay is enabled and supported in the current environment,
      *         {@code false} otherwise. Note: this value only pertains to the Braintree configuration, to check if
-     *         the user has Google Pay setup use {@link GooglePayClient#isReadyToPay(FragmentActivity, GooglePayIsReadyToPayCallback)}
+     *         the user has Google Pay setup use {@link GooglePayClient#isReadyToPay(Context, GooglePayIsReadyToPayCallback)}
      */
     public static boolean isGooglePayEnabled(@NonNull Context context, @NonNull Configuration configuration) {
         try {

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -7,9 +7,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.fragment.app.FragmentActivity;
 
-import com.braintreepayments.api.googlepay.R;
 import com.google.android.gms.wallet.CardRequirements;
 import com.google.android.gms.wallet.IsReadyToPayRequest;
 import com.google.android.gms.wallet.PaymentData;
@@ -74,12 +72,12 @@ public class GooglePayClient {
      * supported and set up on the device. When the callback is called with {@code true}, show the
      * Google Pay button. When it is called with {@code false}, display other checkout options.
      *
-     * @param activity Android FragmentActivity
+     * @param context  Android FragmentActivity
      * @param callback {@link GooglePayIsReadyToPayCallback}
      */
-    public void isReadyToPay(@NonNull final FragmentActivity activity,
+    public void isReadyToPay(@NonNull final Context context,
                              @NonNull final GooglePayIsReadyToPayCallback callback) {
-        isReadyToPay(activity, null, callback);
+        isReadyToPay(context, null, callback);
     }
 
     /**
@@ -87,11 +85,11 @@ public class GooglePayClient {
      * supported and set up on the device. When the callback is called with {@code true}, show the
      * Google Pay button. When it is called with {@code false}, display other checkout options.
      *
-     * @param activity Android FragmentActivity
+     * @param context  Android FragmentActivity
      * @param request  {@link ReadyForGooglePayRequest}
      * @param callback {@link GooglePayIsReadyToPayCallback}
      */
-    public void isReadyToPay(@NonNull final FragmentActivity activity,
+    public void isReadyToPay(@NonNull final Context context,
                              @Nullable final ReadyForGooglePayRequest request,
                              @NonNull final GooglePayIsReadyToPayCallback callback) {
         try {
@@ -113,7 +111,7 @@ public class GooglePayClient {
             }
 
             //noinspection ConstantConditions
-            if (activity == null) {
+            if (context == null) {
                 callback.onGooglePayReadinessResult(new GooglePayReadinessResult.NotReadyToPay(new IllegalArgumentException("Activity cannot be null.")));
                 return;
             }
@@ -136,7 +134,7 @@ public class GooglePayClient {
             } catch (JSONException ignored) {
             }
             IsReadyToPayRequest request1 = IsReadyToPayRequest.fromJson(json.toString());
-            internalGooglePayClient.isReadyToPay(activity, configuration, request1, callback);
+            internalGooglePayClient.isReadyToPay(context, configuration, request1, callback);
         });
     }
 

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -73,7 +73,7 @@ public class GooglePayClient {
      * supported and set up on the device. When the callback is called with {@code true}, show the
      * Google Pay button. When it is called with {@code false}, display other checkout options.
      *
-     * @param context  Android FragmentActivity
+     * @param context  Android Context
      * @param callback {@link GooglePayIsReadyToPayCallback}
      */
     public void isReadyToPay(@NonNull final Context context,
@@ -86,7 +86,7 @@ public class GooglePayClient {
      * supported and set up on the device. When the callback is called with {@code true}, show the
      * Google Pay button. When it is called with {@code false}, display other checkout options.
      *
-     * @param context  Android FragmentActivity
+     * @param context  Android Context
      * @param request  {@link ReadyForGooglePayRequest}
      * @param callback {@link GooglePayIsReadyToPayCallback}
      */

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -15,6 +15,7 @@ import com.google.android.gms.wallet.PaymentDataRequest;
 import com.google.android.gms.wallet.PaymentMethodTokenizationParameters;
 import com.google.android.gms.wallet.PaymentsClient;
 import com.google.android.gms.wallet.WalletConstants;
+import com.braintreepayments.api.googlepay.R;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayInternalClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayInternalClient.java
@@ -1,6 +1,6 @@
 package com.braintreepayments.api;
 
-import androidx.fragment.app.FragmentActivity;
+import android.content.Context;
 
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.wallet.IsReadyToPayRequest;
@@ -10,8 +10,8 @@ import com.google.android.gms.wallet.WalletConstants;
 
 class GooglePayInternalClient {
 
-    void isReadyToPay(FragmentActivity activity, Configuration configuration, IsReadyToPayRequest isReadyToPayRequest, final GooglePayIsReadyToPayCallback callback) {
-        PaymentsClient paymentsClient = Wallet.getPaymentsClient(activity,
+    void isReadyToPay(Context context, Configuration configuration, IsReadyToPayRequest isReadyToPayRequest, final GooglePayIsReadyToPayCallback callback) {
+        PaymentsClient paymentsClient = Wallet.getPaymentsClient(context,
                 new Wallet.WalletOptions.Builder()
                         .setEnvironment(getGooglePayEnvironment(configuration))
                         .build());

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayIsReadyToPayCallback.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayIsReadyToPayCallback.java
@@ -1,11 +1,9 @@
 package com.braintreepayments.api;
 
-import androidx.fragment.app.FragmentActivity;
-
 /**
  * Callback for receiving result of
- * {@link GooglePayClient#isReadyToPay(FragmentActivity, GooglePayIsReadyToPayCallback)} and
- * {@link GooglePayClient#isReadyToPay(FragmentActivity, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)}.
+ * {@link GooglePayClient#isReadyToPay(android.content.Context, GooglePayIsReadyToPayCallback)} and
+ * {@link GooglePayClient#isReadyToPay(android.content.Context, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)}.
  */
 public interface GooglePayIsReadyToPayCallback {
 

--- a/GooglePay/src/main/java/com/braintreepayments/api/ReadyForGooglePayRequest.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/ReadyForGooglePayRequest.java
@@ -1,7 +1,5 @@
 package com.braintreepayments.api;
 
-import androidx.fragment.app.FragmentActivity;
-
 /**
  * Optional parameters to use when checking whether Google Pay is supported and set up on the customer's device.
  */
@@ -10,7 +8,7 @@ public class ReadyForGooglePayRequest {
     private boolean existingPaymentMethodRequired;
 
     /**
-     * If set to true, then the {@link GooglePayClient#isReadyToPay(FragmentActivity, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)}
+     * If set to true, then the {@link GooglePayClient#isReadyToPay(android.content.Context, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)}
      * method will call the listener with true if the customer is ready to pay with one or more of your
      * supported card networks.
      *

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api
 
 import android.app.Activity
 import android.content.Context
-import androidx.fragment.app.FragmentActivity
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.Status
@@ -20,7 +19,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 
 @RunWith(RobolectricTestRunner::class)

--- a/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/GooglePayInternalClientUnitTest.kt
@@ -1,7 +1,9 @@
 package com.braintreepayments.api
 
 import android.app.Activity
+import android.content.Context
 import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.tasks.*
@@ -65,7 +67,7 @@ class GooglePayInternalClientUnitTest {
         }
     }
 
-    private lateinit var activity: FragmentActivity
+    private lateinit var context: Context
     private lateinit var isReadyToPayCallback: GooglePayIsReadyToPayCallback
     private lateinit var paymentsClient: PaymentsClient
     private lateinit var isReadyToPayRequest: IsReadyToPayRequest
@@ -73,7 +75,7 @@ class GooglePayInternalClientUnitTest {
     @Before
     fun beforeEach() {
         mockkStatic(Wallet::class)
-        activity = mockk(relaxed = true)
+        context = ApplicationProvider.getApplicationContext()
         isReadyToPayCallback = mockk(relaxed = true)
         paymentsClient = mockk()
         isReadyToPayRequest = IsReadyToPayRequest.fromJson("{}")
@@ -85,10 +87,11 @@ class GooglePayInternalClientUnitTest {
         every { paymentsClient.isReadyToPay(isReadyToPayRequest) } returns Tasks.forResult(true)
 
         val walletOptionsSlot = slot<Wallet.WalletOptions>()
-        every { Wallet.getPaymentsClient(any(), capture(walletOptionsSlot)) } returns paymentsClient
+        every { Wallet.getPaymentsClient(any(Context::class), capture(walletOptionsSlot)) } returns
+                paymentsClient
 
         val sut = GooglePayInternalClient()
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest, isReadyToPayCallback)
+        sut.isReadyToPay(context, configuration, isReadyToPayRequest, isReadyToPayCallback)
 
         assertEquals(WalletConstants.ENVIRONMENT_TEST, walletOptionsSlot.captured.environment)
     }
@@ -100,47 +103,42 @@ class GooglePayInternalClientUnitTest {
         every { paymentsClient.isReadyToPay(isReadyToPayRequest) } returns Tasks.forResult(true)
 
         val walletOptionsSlot = slot<Wallet.WalletOptions>()
-        every { Wallet.getPaymentsClient(any(), capture(walletOptionsSlot)) } returns paymentsClient
+        every { Wallet.getPaymentsClient(any(Context::class), capture(walletOptionsSlot)) } returns
+                paymentsClient
 
         val sut = GooglePayInternalClient()
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest, isReadyToPayCallback)
+        sut.isReadyToPay(context, configuration, isReadyToPayRequest, isReadyToPayCallback)
 
         assertEquals(WalletConstants.ENVIRONMENT_PRODUCTION, walletOptionsSlot.captured.environment)
     }
 
     @Test
     fun `isReadyToPay forwards success result to callback`() {
-        val countDownLatch = CountDownLatch(1)
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
-        every { Wallet.getPaymentsClient(any(), any()) } returns paymentsClient
+        every { Wallet.getPaymentsClient(any(Context::class), any()) } returns paymentsClient
 
         every { paymentsClient.isReadyToPay(isReadyToPayRequest) } returns SuccessfulBooleanTask(true)
 
         val sut = GooglePayInternalClient()
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest) { readyToPayResult ->
+        sut.isReadyToPay(context, configuration, isReadyToPayRequest) { readyToPayResult ->
             assertTrue(readyToPayResult is GooglePayReadinessResult.ReadyToPay)
-            countDownLatch.countDown()
         }
-        countDownLatch.await()
     }
 
     @Test
     fun `isReadyToPay forwards failure result to callback`() {
-        val countDownLatch = CountDownLatch(1)
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
-        every { Wallet.getPaymentsClient(any(), any()) } returns paymentsClient
+        every { Wallet.getPaymentsClient(any(Context::class), any()) } returns paymentsClient
 
         val expectedError = ApiException(Status.RESULT_INTERNAL_ERROR)
         val failedTask: Task<Boolean> = FailingBooleanTask(expectedError)
         every { paymentsClient.isReadyToPay(isReadyToPayRequest) } returns failedTask
 
         val sut = GooglePayInternalClient()
-        sut.isReadyToPay(activity, configuration, isReadyToPayRequest) { readyToPayResult ->
+        sut.isReadyToPay(context, configuration, isReadyToPayRequest) { readyToPayResult ->
             assertTrue(readyToPayResult is GooglePayReadinessResult.NotReadyToPay)
             assertSame(expectedError, (readyToPayResult as GooglePayReadinessResult.NotReadyToPay)
                 .error)
-            countDownLatch.countDown()
         }
-        countDownLatch.await()
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Remove references to `FragmentActivity` from `GooglePayClient` and replace with `Context` where possible to make integration more flexible.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
