### PR TITLE
Send FPTI Analytics Events in American Express

### DIFF
--- a/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressAnalytics.kt
+++ b/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressAnalytics.kt
@@ -1,8 +1,8 @@
 package com.braintreepayments.api
 
-internal enum class AmericanExpressAnalytics(@JvmField val event: String) {
+internal object AmericanExpressAnalytics {
 
-    REWARDS_BALANCE_STARTED("amex:rewards-balance:started"),
-    REWARDS_BALANCE_FAILED("amex:rewards-balance:failed"),
-    REWARDS_BALANCE_SUCCEEDED("amex:rewards-balance:succeeded")
+    const val REWARDS_BALANCE_STARTED = "amex:rewards-balance:started"
+    const val REWARDS_BALANCE_FAILED = "amex:rewards-balance:failed"
+    const val REWARDS_BALANCE_SUCCEEDED = "amex:rewards-balance:succeeded"
 }

--- a/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressClient.java
+++ b/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressClient.java
@@ -55,16 +55,23 @@ public class AmericanExpressClient {
                 try {
                     AmericanExpressRewardsBalance rewardsBalance =
                             AmericanExpressRewardsBalance.fromJson(responseBody);
-                    callback.onAmericanExpressResult(new AmericanExpressResult.Success(rewardsBalance));
-                    braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED);
+                    callbackSuccess(new AmericanExpressResult.Success(rewardsBalance), callback);
                 } catch (JSONException e) {
-                    braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
-                    callback.onAmericanExpressResult(new AmericanExpressResult.Failure(e));
+                    callbackFailure(new AmericanExpressResult.Failure(e), callback);
                 }
             } else if (httpError != null) {
-                callback.onAmericanExpressResult(new AmericanExpressResult.Failure(httpError));
-                braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
+                callbackFailure(new AmericanExpressResult.Failure(httpError), callback);
             }
         });
+    }
+
+    private void callbackSuccess(AmericanExpressResult.Success result, AmericanExpressGetRewardsBalanceCallback callback) {
+        callback.onAmericanExpressResult(result);
+        braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED);
+    }
+
+    private void callbackFailure(AmericanExpressResult.Failure result, AmericanExpressGetRewardsBalanceCallback callback) {
+        callback.onAmericanExpressResult(result);
+        braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
     }
 }

--- a/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressClient.java
+++ b/AmericanExpress/src/main/java/com/braintreepayments/api/AmericanExpressClient.java
@@ -49,21 +49,21 @@ public class AmericanExpressClient {
                 .build()
                 .toString();
 
-        braintreeClient.sendAnalyticsEvent("amex.rewards-balance.start");
+        braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_STARTED);
         braintreeClient.sendGET(getRewardsBalanceUrl, (responseBody, httpError) -> {
             if (responseBody != null) {
-                braintreeClient.sendAnalyticsEvent("amex.rewards-balance.success");
                 try {
                     AmericanExpressRewardsBalance rewardsBalance =
                             AmericanExpressRewardsBalance.fromJson(responseBody);
                     callback.onAmericanExpressResult(new AmericanExpressResult.Success(rewardsBalance));
+                    braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED);
                 } catch (JSONException e) {
-                    braintreeClient.sendAnalyticsEvent("amex.rewards-balance.parse.failed");
+                    braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
                     callback.onAmericanExpressResult(new AmericanExpressResult.Failure(e));
                 }
             } else if (httpError != null) {
                 callback.onAmericanExpressResult(new AmericanExpressResult.Failure(httpError));
-                braintreeClient.sendAnalyticsEvent("amex.rewards-balance.error");
+                braintreeClient.sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
             }
         });
     }

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressAnalyticsUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressAnalyticsUnitTest.kt
@@ -9,15 +9,15 @@ class AmericanExpressAnalyticsUnitTest {
     fun testAnalyticsEvents_sendsExpectedEventNames() {
         assertEquals(
             "amex:rewards-balance:started",
-            AmericanExpressAnalytics.REWARDS_BALANCE_STARTED.event
+            AmericanExpressAnalytics.REWARDS_BALANCE_STARTED
         )
         assertEquals(
             "amex:rewards-balance:failed",
-            AmericanExpressAnalytics.REWARDS_BALANCE_FAILED.event
+            AmericanExpressAnalytics.REWARDS_BALANCE_FAILED
         )
         assertEquals(
             "amex:rewards-balance:succeeded",
-            AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED.event
+            AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED
         )
     }
 }

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressClientUnitTest.java
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressClientUnitTest.java
@@ -152,8 +152,8 @@ public class AmericanExpressClientUnitTest {
         AmericanExpressClient sut = new AmericanExpressClient(braintreeClient);
         sut.getRewardsBalance("fake-nonce", "USD", amexRewardsCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.start");
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.success");
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_STARTED);
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_SUCCEEDED);
     }
 
     @Test
@@ -165,8 +165,8 @@ public class AmericanExpressClientUnitTest {
         AmericanExpressClient sut = new AmericanExpressClient(braintreeClient);
         sut.getRewardsBalance("fake-nonce", "USD", amexRewardsCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.start");
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.error");
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_STARTED);
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
     }
 
     @Test
@@ -177,7 +177,7 @@ public class AmericanExpressClientUnitTest {
         AmericanExpressClient sut = new AmericanExpressClient(braintreeClient);
         sut.getRewardsBalance("fake-nonce", "USD", amexRewardsCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.start");
-        verify(braintreeClient).sendAnalyticsEvent("amex.rewards-balance.parse.failed");
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_STARTED);
+        verify(braintreeClient).sendAnalyticsEvent(AmericanExpressAnalytics.REWARDS_BALANCE_FAILED);
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Update `AmericanExpressClient` to send FPTI analytics events
 - Update `AmericanExpressAnalytics` to be a simple object rather than enum

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
