### PR TITLE
Use Browser Switch Snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
             // kotlin libraries. Make sure to keep this dependency in line with the kotlin version used.
             "kotlinCoroutinesCore"       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1",
 
-            "browserSwitch"              : "com.braintreepayments.api:browser-switch:2.6.1",
+            "browserSwitch"              : "com.braintreepayments.api:browser-switch:3.0.0-beta1-SNAPSHOT",
             "cardinal"                   : "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.7-5",
             "samsungPay"                 : "com.samsung.android.spay:sdk:2.5.01",
             "playServicesWallet"         : "com.google.android.gms:play-services-wallet:${versions.playServices}",
@@ -77,6 +77,9 @@ allprojects {
     repositories {
         mavenCentral()
         google()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 }
 


### PR DESCRIPTION
### Summary of changes

 - Update browser switch dependency to use snaphots while developing browser switch v3 (to be updated to full release major version before v5 release)

 ### Checklist

 - ~[] Added a changelog entry~

### Authors

- @sarahkoop 
