### PR TITLE
Rename `PayPalMessagingClient` to `PayPalMessagingView`

### DIFF
--- a/PayPalMessaging/src/main/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingView.kt
+++ b/PayPalMessaging/src/main/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingView.kt
@@ -1,4 +1,4 @@
 package com.braintreepayments.api.paypalmessaging
-class PayPalMessagingClient {
+class PayPalMessagingView {
     // TODO: Add functionality in a future PR
 }

--- a/PayPalMessaging/src/test/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingViewUnitTest.kt
+++ b/PayPalMessaging/src/test/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingViewUnitTest.kt
@@ -1,4 +1,4 @@
 package com.braintreepayments.api.paypalmessaging
-class PayPalMessagingClientUnitTest {
+class PayPalMessagingViewUnitTest {
     // TODO: Add unit tests in a future PR
 }


### PR DESCRIPTION
### Summary of changes

 - Rename `PayPalMessagingClient` to `PayPalMessagingView`
     - [iOS conversation where this decision was made](https://github.com/braintree/braintree_ios/pull/1153#discussion_r1431811348)
     - tl;dr: when implementing the feature in a demo app it became apparent that adding a view called a client seemed a bit odd. Since this is the first module we have that just contains UI we will establish this as our pattern moving forward.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
