### PR TITLE
Adding imageUrl, upcType, upcCode to PayPalLineItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 # unreleased
 
 * BraintreePayPal
-  * Add following properties to PayPalLineItem
-    * imageUrl
-    * upcCode
-    * upcType
+  * Add imageUrl, upcCode, and upcType to PayPalLineItem
 
 ## 4.40.1 (2023-12-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Braintree Android SDK Release Notes
 
-# unreleased
+## unreleased
 
 * PayPal
   * Add imageUrl, upcCode, and upcType to PayPalLineItem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # unreleased
 
-* BraintreePayPal
+* PayPal
   * Add imageUrl, upcCode, and upcType to PayPalLineItem
 
 ## 4.40.1 (2023-12-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Braintree Android SDK Release Notes
 
+# unreleased
+
+* BraintreePayPal
+  * Add following properties to PayPalLineItem
+    * imageUrl
+    * upcCode
+    * upcType
+
 ## 4.40.1 (2023-12-13)
 
 * BraintreeCore

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -29,6 +29,22 @@ public class PayPalLineItem implements Parcelable {
     public static final String KIND_CREDIT = "credit";
     public static final String KIND_DEBIT = "debit";
 
+    /**
+     * The upc type of PayPal line item.
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({PayPalLineItem.UPC_TYPE_A, PayPalLineItem.UPC_TYPE_B, PayPalLineItem.UPC_TYPE_C, PayPalLineItem.UPC_TYPE_D, PayPalLineItem.UPC_TYPE_E, PayPalLineItem.UPC_TYPE_2, PayPalLineItem.UPC_TYPE_5})
+    @interface PayPalLineItemUpcType {
+    }
+
+    public static final String UPC_TYPE_A = "UPC-A";
+    public static final String UPC_TYPE_B = "UPC-B";
+    public static final String UPC_TYPE_C = "UPC-C";
+    public static final String UPC_TYPE_D = "UPC-D";
+    public static final String UPC_TYPE_E = "UPC-E";
+    public static final String UPC_TYPE_2 = "UPC-2";
+    public static final String UPC_TYPE_5 = "UPC-5";
+
     private static final String DESCRIPTION_KEY = "description";
     private static final String KIND_KEY = "kind";
     private static final String NAME_KEY = "name";
@@ -37,6 +53,9 @@ public class PayPalLineItem implements Parcelable {
     private static final String UNIT_AMOUNT_KEY = "unit_amount";
     private static final String UNIT_TAX_AMOUNT_KEY = "unit_tax_amount";
     private static final String URL_KEY = "url";
+    private static final String IMAGE_URL_KEY = "image_url";
+    private static final String UPC_CODE_KEY = "upc_code";
+    private static final String UPC_TYPE_KEY = "upc_type";
 
     private String description;
     private String kind;
@@ -46,6 +65,9 @@ public class PayPalLineItem implements Parcelable {
     private String unitAmount;
     private String unitTaxAmount;
     private String url;
+    private String imageUrl;
+    private String upcCode;
+    private String upcType;
 
     /**
      * Constructs a line item for PayPal checkout flows. All parameters are required.
@@ -137,6 +159,33 @@ public class PayPalLineItem implements Parcelable {
         this.url = url;
     }
 
+    /**
+     * The image URL to product information.
+     *
+     * @param imageURL The image URL with additional information.
+     */
+    public void setImageUrl(@NonNull String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    /**
+     * UPC code of the item.
+     *
+     * @param upcCode The UPC code.
+     */
+    public void setUpcCode(@NonNull String upcCode) {
+        this.upcCode = upcCode;
+    }
+
+    /**
+     * UPC type of the item.
+     *
+     * @param upcType The UPC type.
+     */
+    public void setUpcType(@NonNull String upcType) {
+        this.upcType = upcType;
+    }
+
     @Nullable
     public String getDescription() {
         return description;
@@ -178,6 +227,21 @@ public class PayPalLineItem implements Parcelable {
         return url;
     }
 
+    @Nullable
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    @Nullable
+    public String getUpcCode() {
+        return upcCode;
+    }
+
+    @Nullable
+    public String getUpcType() {
+        return upcType;
+    }
+
     public JSONObject toJson() {
         try {
             return new JSONObject()
@@ -188,7 +252,10 @@ public class PayPalLineItem implements Parcelable {
                     .putOpt(QUANTITY_KEY, quantity)
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
-                    .putOpt(URL_KEY, url);
+                    .putOpt(URL_KEY, url)
+                    .putOpt(IMAGE_UTL_KRY, imageUrl)
+                    .putOpt(UPC_CODE_KEY, upcCode)
+                    .putOpt(UPC_TYPE_KRY, upcType);
         } catch (JSONException ignored) {
         }
 
@@ -204,6 +271,9 @@ public class PayPalLineItem implements Parcelable {
         unitAmount = in.readString();
         unitTaxAmount = in.readString();
         url = in.readString();
+        imageUrl = in.readString();
+        upcCode = in.readString();
+        upcType = in.readString();
     }
 
     public static final Creator<PayPalLineItem> CREATOR = new Creator<PayPalLineItem>() {
@@ -233,6 +303,9 @@ public class PayPalLineItem implements Parcelable {
         parcel.writeString(unitAmount);
         parcel.writeString(unitTaxAmount);
         parcel.writeString(url);
+        parcel.writeString(imageUrl);
+        parcel.writeString(upcCode);
+        parcel.writeSting(upcType);
     }
 
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -253,9 +253,9 @@ public class PayPalLineItem implements Parcelable {
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
                     .putOpt(URL_KEY, url)
-                    .putOpt(IMAGE_UTL_KRY, imageUrl)
+                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(UPC_CODE_KEY, upcCode)
-                    .putOpt(UPC_TYPE_KRY, upcType);
+                    .putOpt(UPC_TYPE_KEY, upcType);
         } catch (JSONException ignored) {
         }
 
@@ -305,7 +305,7 @@ public class PayPalLineItem implements Parcelable {
         parcel.writeString(url);
         parcel.writeString(imageUrl);
         parcel.writeString(upcCode);
-        parcel.writeSting(upcType);
+        parcel.writeString(upcType);
     }
 
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -191,6 +191,11 @@ public class PayPalLineItem implements Parcelable {
         return description;
     }
 
+    @Nullable
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
     @PayPalLineItemKind
     @Nullable
     public String getKind() {
@@ -223,16 +228,6 @@ public class PayPalLineItem implements Parcelable {
     }
 
     @Nullable
-    public String getUrl() {
-        return url;
-    }
-
-    @Nullable
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    @Nullable
     public String getUpcCode() {
         return upcCode;
     }
@@ -241,6 +236,11 @@ public class PayPalLineItem implements Parcelable {
     @Nullable
     public String getUpcType() {
         return upcType;
+    }
+
+    @Nullable
+    public String getUrl() {
+        return url;
     }
 
     public JSONObject toJson() {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -162,7 +162,7 @@ public class PayPalLineItem implements Parcelable {
     /**
      * The image URL to product information.
      *
-     * @param imageURL The image URL with additional information.
+     * @param imageUrl The image URL with additional information.
      */
     public void setImageUrl(@NonNull String imageUrl) {
         this.imageUrl = imageUrl;

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLineItem.java
@@ -46,28 +46,28 @@ public class PayPalLineItem implements Parcelable {
     public static final String UPC_TYPE_5 = "UPC-5";
 
     private static final String DESCRIPTION_KEY = "description";
+    private static final String IMAGE_URL_KEY = "image_url";
     private static final String KIND_KEY = "kind";
     private static final String NAME_KEY = "name";
     private static final String PRODUCT_CODE_KEY = "product_code";
     private static final String QUANTITY_KEY = "quantity";
     private static final String UNIT_AMOUNT_KEY = "unit_amount";
     private static final String UNIT_TAX_AMOUNT_KEY = "unit_tax_amount";
-    private static final String URL_KEY = "url";
-    private static final String IMAGE_URL_KEY = "image_url";
     private static final String UPC_CODE_KEY = "upc_code";
     private static final String UPC_TYPE_KEY = "upc_type";
+    private static final String URL_KEY = "url";
 
     private String description;
+    private String imageUrl;
     private String kind;
     private String name;
     private String productCode;
     private String quantity;
     private String unitAmount;
     private String unitTaxAmount;
-    private String url;
-    private String imageUrl;
     private String upcCode;
     private String upcType;
+    private String url;
 
     /**
      * Constructs a line item for PayPal checkout flows. All parameters are required.
@@ -94,6 +94,15 @@ public class PayPalLineItem implements Parcelable {
      */
     public void setDescription(@NonNull String description) {
         this.description = description;
+    }
+
+    /**
+     * The image URL to product information.
+     *
+     * @param imageUrl The image URL with additional information.
+     */
+    public void setImageUrl(@Nullable String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     /**
@@ -151,29 +160,11 @@ public class PayPalLineItem implements Parcelable {
     }
 
     /**
-     * The URL to product information.
-     *
-     * @param url The URL with additional information.
-     */
-    public void setUrl(@NonNull String url) {
-        this.url = url;
-    }
-
-    /**
-     * The image URL to product information.
-     *
-     * @param imageUrl The image URL with additional information.
-     */
-    public void setImageUrl(@NonNull String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
-
-    /**
      * UPC code of the item.
      *
      * @param upcCode The UPC code.
      */
-    public void setUpcCode(@NonNull String upcCode) {
+    public void setUpcCode(@Nullable String upcCode) {
         this.upcCode = upcCode;
     }
 
@@ -182,8 +173,17 @@ public class PayPalLineItem implements Parcelable {
      *
      * @param upcType The UPC type.
      */
-    public void setUpcType(@NonNull String upcType) {
+    public void setUpcType(@Nullable @PayPalLineItemUpcType String upcType) {
         this.upcType = upcType;
+    }
+
+    /**
+     * The URL to product information.
+     *
+     * @param url The URL with additional information.
+     */
+    public void setUrl(@NonNull String url) {
+        this.url = url;
     }
 
     @Nullable
@@ -237,6 +237,7 @@ public class PayPalLineItem implements Parcelable {
         return upcCode;
     }
 
+    @PayPalLineItemUpcType
     @Nullable
     public String getUpcType() {
         return upcType;
@@ -246,16 +247,16 @@ public class PayPalLineItem implements Parcelable {
         try {
             return new JSONObject()
                     .putOpt(DESCRIPTION_KEY, description)
+                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(KIND_KEY, kind)
                     .putOpt(NAME_KEY, name)
                     .putOpt(PRODUCT_CODE_KEY, productCode)
                     .putOpt(QUANTITY_KEY, quantity)
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
-                    .putOpt(URL_KEY, url)
-                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(UPC_CODE_KEY, upcCode)
-                    .putOpt(UPC_TYPE_KEY, upcType);
+                    .putOpt(UPC_TYPE_KEY, upcType)
+                    .putOpt(URL_KEY, url);
         } catch (JSONException ignored) {
         }
 
@@ -264,16 +265,16 @@ public class PayPalLineItem implements Parcelable {
 
     PayPalLineItem(Parcel in) {
         description = in.readString();
+        imageUrl = in.readString();
         kind = in.readString();
         name = in.readString();
         productCode = in.readString();
         quantity = in.readString();
         unitAmount = in.readString();
         unitTaxAmount = in.readString();
-        url = in.readString();
-        imageUrl = in.readString();
         upcCode = in.readString();
         upcType = in.readString();
+        url = in.readString();
     }
 
     public static final Creator<PayPalLineItem> CREATOR = new Creator<PayPalLineItem>() {
@@ -296,16 +297,16 @@ public class PayPalLineItem implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeString(description);
+        parcel.writeString(imageUrl);
         parcel.writeString(kind);
         parcel.writeString(name);
         parcel.writeString(productCode);
         parcel.writeString(quantity);
         parcel.writeString(unitAmount);
         parcel.writeString(unitTaxAmount);
-        parcel.writeString(url);
-        parcel.writeString(imageUrl);
         parcel.writeString(upcCode);
         parcel.writeString(upcType);
+        parcel.writeString(url);
     }
 
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
@@ -15,12 +15,12 @@ public class PayPalLineItemUnitTest {
     public void toJson_setsKeysAndValues() throws JSONException {
         PayPalLineItem item = new PayPalLineItem(PayPalLineItem.KIND_DEBIT, "An Item", "1", "2");
         item.setDescription("A new item");
+        item.setImageUrl("http://example.com/image.jpg");
         item.setProductCode("abc-123");
         item.setUnitTaxAmount("1.50");
-        item.setUrl("http://example.com");
-        item.setImageUrl("http://example.com/image.jpg");
         item.setUpcType(PayPalLineItem.UPC_TYPE_2);
         item.setUpcCode("upc-code");
+        item.setUrl("http://example.com");
 
         JSONObject json = item.toJson();
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
@@ -18,6 +18,9 @@ public class PayPalLineItemUnitTest {
         item.setProductCode("abc-123");
         item.setUnitTaxAmount("1.50");
         item.setUrl("http://example.com");
+        item.setImageUrl("http://example.com/image.jpg");
+        item.setUpcType(PayPalLineItem.UPC_TYPE_2);
+        item.setUpcCode("upc-code");
 
         JSONObject json = item.toJson();
 
@@ -29,6 +32,9 @@ public class PayPalLineItemUnitTest {
         assertEquals("abc-123", json.getString("product_code"));
         assertEquals("1.50", json.getString("unit_tax_amount"));
         assertEquals("http://example.com", json.getString("url"));
+        assertEquals("http://example.com/image.jpg", json.getString("image_url"));
+        assertEquals("UPC-2", json.getString("upc_type"));
+        assertEquals("upc-code", json.getString("upc_code"));
     }
 }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
@@ -33,7 +33,7 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
      * The upc type of PayPal line item.
      */
     @Retention(RetentionPolicy.SOURCE)
-    @StringDef({PayPalLineItem.UPC_TYPE_A, PayPalLineItem.UPC_TYPE_B, PayPalLineItem.UPC_TYPE_C, PayPalLineItem.UPC_TYPE_D, PayPalLineItem.UPC_TYPE_E, PayPalLineItem.UPC_TYPE_2, PayPalLineItem.UPC_TYPE_5})
+    @StringDef({PayPalNativeCheckoutLineItem.UPC_TYPE_A, PayPalNativeCheckoutLineItem.UPC_TYPE_B, PayPalNativeCheckoutLineItem.UPC_TYPE_C, PayPalNativeCheckoutLineItem.UPC_TYPE_D, PayPalNativeCheckoutLineItem.UPC_TYPE_E, PayPalNativeCheckoutLineItem.UPC_TYPE_2, PayPalNativeCheckoutLineItem.UPC_TYPE_5})
     @interface PayPalLineItemUpcType {
     }
 
@@ -162,7 +162,7 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     /**
      * The image URL to product information.
      *
-     * @param imageURL The image URL with additional information.
+     * @param imageUrl The image URL with additional information.
      */
     public void setImageUrl(@NonNull String imageUrl) {
         this.imageUrl = imageUrl;
@@ -253,9 +253,9 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
                     .putOpt(URL_KEY, url)
-                    .putOpt(IMAGE_UTL_KRY, imageUrl)
+                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(UPC_CODE_KEY, upcCode)
-                    .putOpt(UPC_TYPE_KRY, upcType);
+                    .putOpt(UPC_TYPE_KEY, upcType);
         } catch (JSONException ignored) {
         }
 
@@ -305,7 +305,7 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
         parcel.writeString(url);
         parcel.writeString(imageUrl);
         parcel.writeString(upcCode);
-        parcel.writeSting(upcType);
+        parcel.writeString(upcType);
     }
 
 }

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
@@ -29,6 +29,22 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     public static final String KIND_CREDIT = "credit";
     public static final String KIND_DEBIT = "debit";
 
+    /**
+     * The upc type of PayPal line item.
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({PayPalLineItem.UPC_TYPE_A, PayPalLineItem.UPC_TYPE_B, PayPalLineItem.UPC_TYPE_C, PayPalLineItem.UPC_TYPE_D, PayPalLineItem.UPC_TYPE_E, PayPalLineItem.UPC_TYPE_2, PayPalLineItem.UPC_TYPE_5})
+    @interface PayPalLineItemUpcType {
+    }
+
+    public static final String UPC_TYPE_A = "UPC-A";
+    public static final String UPC_TYPE_B = "UPC-B";
+    public static final String UPC_TYPE_C = "UPC-C";
+    public static final String UPC_TYPE_D = "UPC-D";
+    public static final String UPC_TYPE_E = "UPC-E";
+    public static final String UPC_TYPE_2 = "UPC-2";
+    public static final String UPC_TYPE_5 = "UPC-5";
+
     private static final String DESCRIPTION_KEY = "description";
     private static final String KIND_KEY = "kind";
     private static final String NAME_KEY = "name";
@@ -37,6 +53,9 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     private static final String UNIT_AMOUNT_KEY = "unit_amount";
     private static final String UNIT_TAX_AMOUNT_KEY = "unit_tax_amount";
     private static final String URL_KEY = "url";
+    private static final String IMAGE_URL_KEY = "image_url";
+    private static final String UPC_CODE_KEY = "upc_code";
+    private static final String UPC_TYPE_KEY = "upc_type";
 
     private String description;
     private String kind;
@@ -46,6 +65,9 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     private String unitAmount;
     private String unitTaxAmount;
     private String url;
+    private String imageUrl;
+    private String upcCode;
+    private String upcType;
 
     /**
      * Constructs a line item for PayPal checkout flows. All parameters are required.
@@ -137,6 +159,33 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
         this.url = url;
     }
 
+    /**
+     * The image URL to product information.
+     *
+     * @param imageURL The image URL with additional information.
+     */
+    public void setImageUrl(@NonNull String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    /**
+     * UPC code of the item.
+     *
+     * @param upcCode The UPC code.
+     */
+    public void setUpcCode(@NonNull String upcCode) {
+        this.upcCode = upcCode;
+    }
+
+    /**
+     * UPC type of the item.
+     *
+     * @param upcType The UPC type.
+     */
+    public void setUpcType(@NonNull String upcType) {
+        this.upcType = upcType;
+    }
+
     @Nullable
     public String getDescription() {
         return description;
@@ -178,6 +227,21 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
         return url;
     }
 
+    @Nullable
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    @Nullable
+    public String getUpcCode() {
+        return upcCode;
+    }
+
+    @Nullable
+    public String getUpcType() {
+        return upcType;
+    }
+
     public JSONObject toJson() {
         try {
             return new JSONObject()
@@ -188,7 +252,10 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
                     .putOpt(QUANTITY_KEY, quantity)
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
-                    .putOpt(URL_KEY, url);
+                    .putOpt(URL_KEY, url)
+                    .putOpt(IMAGE_UTL_KRY, imageUrl)
+                    .putOpt(UPC_CODE_KEY, upcCode)
+                    .putOpt(UPC_TYPE_KRY, upcType);
         } catch (JSONException ignored) {
         }
 
@@ -204,6 +271,9 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
         unitAmount = in.readString();
         unitTaxAmount = in.readString();
         url = in.readString();
+        imageUrl = in.readString();
+        upcCode = in.readString();
+        upcType = in.readString();
     }
 
     public static final Creator<PayPalNativeCheckoutLineItem> CREATOR = new Creator<PayPalNativeCheckoutLineItem>() {
@@ -233,6 +303,9 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
         parcel.writeString(unitAmount);
         parcel.writeString(unitTaxAmount);
         parcel.writeString(url);
+        parcel.writeString(imageUrl);
+        parcel.writeString(upcCode);
+        parcel.writeSting(upcType);
     }
 
 }

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutLineItem.java
@@ -46,28 +46,28 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     public static final String UPC_TYPE_5 = "UPC-5";
 
     private static final String DESCRIPTION_KEY = "description";
+    private static final String IMAGE_URL_KEY = "image_url";
     private static final String KIND_KEY = "kind";
     private static final String NAME_KEY = "name";
     private static final String PRODUCT_CODE_KEY = "product_code";
     private static final String QUANTITY_KEY = "quantity";
     private static final String UNIT_AMOUNT_KEY = "unit_amount";
     private static final String UNIT_TAX_AMOUNT_KEY = "unit_tax_amount";
-    private static final String URL_KEY = "url";
-    private static final String IMAGE_URL_KEY = "image_url";
     private static final String UPC_CODE_KEY = "upc_code";
     private static final String UPC_TYPE_KEY = "upc_type";
+    private static final String URL_KEY = "url";
 
     private String description;
+    private String imageUrl;
     private String kind;
     private String name;
     private String productCode;
     private String quantity;
     private String unitAmount;
     private String unitTaxAmount;
-    private String url;
-    private String imageUrl;
     private String upcCode;
     private String upcType;
+    private String url;
 
     /**
      * Constructs a line item for PayPal checkout flows. All parameters are required.
@@ -94,6 +94,15 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
      */
     public void setDescription(@NonNull String description) {
         this.description = description;
+    }
+
+    /**
+     * The image URL to product information.
+     *
+     * @param imageUrl The image URL with additional information.
+     */
+    public void setImageUrl(@Nullable String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     /**
@@ -151,29 +160,11 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     }
 
     /**
-     * The URL to product information.
-     *
-     * @param url The URL with additional information.
-     */
-    public void setUrl(@NonNull String url) {
-        this.url = url;
-    }
-
-    /**
-     * The image URL to product information.
-     *
-     * @param imageUrl The image URL with additional information.
-     */
-    public void setImageUrl(@NonNull String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
-
-    /**
      * UPC code of the item.
      *
      * @param upcCode The UPC code.
      */
-    public void setUpcCode(@NonNull String upcCode) {
+    public void setUpcCode(@Nullable String upcCode) {
         this.upcCode = upcCode;
     }
 
@@ -182,13 +173,27 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
      *
      * @param upcType The UPC type.
      */
-    public void setUpcType(@NonNull String upcType) {
+    public void setUpcType(@Nullable @PayPalLineItemUpcType String upcType) {
         this.upcType = upcType;
+    }
+
+    /**
+     * The URL to product information.
+     *
+     * @param url The URL with additional information.
+     */
+    public void setUrl(@NonNull String url) {
+        this.url = url;
     }
 
     @Nullable
     public String getDescription() {
         return description;
+    }
+
+    @Nullable
+    public String getImageUrl() {
+        return imageUrl;
     }
 
     @PayPalLineItemKind
@@ -223,39 +228,35 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     }
 
     @Nullable
-    public String getUrl() {
-        return url;
-    }
-
-    @Nullable
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    @Nullable
     public String getUpcCode() {
         return upcCode;
     }
 
+    @PayPalLineItemUpcType
     @Nullable
     public String getUpcType() {
         return upcType;
+    }
+
+    @Nullable
+    public String getUrl() {
+        return url;
     }
 
     public JSONObject toJson() {
         try {
             return new JSONObject()
                     .putOpt(DESCRIPTION_KEY, description)
+                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(KIND_KEY, kind)
                     .putOpt(NAME_KEY, name)
                     .putOpt(PRODUCT_CODE_KEY, productCode)
                     .putOpt(QUANTITY_KEY, quantity)
                     .putOpt(UNIT_AMOUNT_KEY, unitAmount)
                     .putOpt(UNIT_TAX_AMOUNT_KEY, unitTaxAmount)
-                    .putOpt(URL_KEY, url)
-                    .putOpt(IMAGE_URL_KEY, imageUrl)
                     .putOpt(UPC_CODE_KEY, upcCode)
-                    .putOpt(UPC_TYPE_KEY, upcType);
+                    .putOpt(UPC_TYPE_KEY, upcType)
+                    .putOpt(URL_KEY, url);
         } catch (JSONException ignored) {
         }
 
@@ -264,16 +265,16 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
 
     PayPalNativeCheckoutLineItem(Parcel in) {
         description = in.readString();
+        imageUrl = in.readString();
         kind = in.readString();
         name = in.readString();
         productCode = in.readString();
         quantity = in.readString();
         unitAmount = in.readString();
         unitTaxAmount = in.readString();
-        url = in.readString();
-        imageUrl = in.readString();
         upcCode = in.readString();
         upcType = in.readString();
+        url = in.readString();
     }
 
     public static final Creator<PayPalNativeCheckoutLineItem> CREATOR = new Creator<PayPalNativeCheckoutLineItem>() {
@@ -296,16 +297,16 @@ public class PayPalNativeCheckoutLineItem implements Parcelable {
     @Override
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeString(description);
+        parcel.writeString(imageUrl);
         parcel.writeString(kind);
         parcel.writeString(name);
         parcel.writeString(productCode);
         parcel.writeString(quantity);
         parcel.writeString(unitAmount);
         parcel.writeString(unitTaxAmount);
-        parcel.writeString(url);
-        parcel.writeString(imageUrl);
         parcel.writeString(upcCode);
         parcel.writeString(upcType);
+        parcel.writeString(url);
     }
 
 }

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
@@ -18,6 +18,9 @@ public class PayPalLineItemUnitTest {
         item.setProductCode("abc-123");
         item.setUnitTaxAmount("1.50");
         item.setUrl("http://example.com");
+        item.setImageUrl("http://example.com/image.jpg");
+        item.setUpcType(PayPalLineItem.UPC_TYPE_2);
+        item.setUpcCode("upc-code");
 
         JSONObject json = item.toJson();
 
@@ -29,6 +32,10 @@ public class PayPalLineItemUnitTest {
         assertEquals("abc-123", json.getString("product_code"));
         assertEquals("1.50", json.getString("unit_tax_amount"));
         assertEquals("http://example.com", json.getString("url"));
+        assertEquals("http://example.com/image.jpg", json.getString("image_url"));
+        assertEquals("UPC-2", json.getString("upc_type"));
+        assertEquals("upc-code", json.getString("upc_code"));
     }
+
 }
 

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
@@ -15,12 +15,12 @@ public class PayPalLineItemUnitTest {
     public void toJson_setsKeysAndValues() throws JSONException {
         PayPalNativeCheckoutLineItem item = new PayPalNativeCheckoutLineItem(PayPalNativeCheckoutLineItem.KIND_DEBIT, "An Item", "1", "2");
         item.setDescription("A new item");
+        item.setImageUrl("http://example.com/image.jpg");
         item.setProductCode("abc-123");
         item.setUnitTaxAmount("1.50");
-        item.setUrl("http://example.com");
-        item.setImageUrl("http://example.com/image.jpg");
         item.setUpcType(PayPalNativeCheckoutLineItem.UPC_TYPE_2);
         item.setUpcCode("upc-code");
+        item.setUrl("http://example.com");
 
         JSONObject json = item.toJson();
 

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalLineItemUnitTest.java
@@ -19,7 +19,7 @@ public class PayPalLineItemUnitTest {
         item.setUnitTaxAmount("1.50");
         item.setUrl("http://example.com");
         item.setImageUrl("http://example.com/image.jpg");
-        item.setUpcType(PayPalLineItem.UPC_TYPE_2);
+        item.setUpcType(PayPalNativeCheckoutLineItem.UPC_TYPE_2);
         item.setUpcCode("upc-code");
 
         JSONObject json = item.toJson();


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Added the ability for merchants to pass imageUrl, upcCode, upcType in PayPalLineItem.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @vankads 
