### PR TITLE
Remove Activity from PayPalClient

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -99,7 +99,7 @@ public class PayPalFragment extends BaseFragment {
         } else {
             payPalRequest = createPayPalCheckoutRequest(activity, amount);
         }
-        payPalClient.createPaymentAuthRequest(activity, payPalRequest,
+        payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,
                 (paymentAuthRequest) -> {
                     if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.Failure) {
                         handleError(((PayPalPaymentAuthRequest.Failure) paymentAuthRequest).getError());

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -92,7 +92,6 @@ public class PayPalClient {
                 return;
             }
 
-
             sendPayPalRequest(context, payPalCheckoutRequest, callback);
         });
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -54,25 +54,25 @@ public class PayPalClient {
     }
 
     /**
-     * Starts the PayPal payment flow by creating a {@link PayPalPaymentAuthRequestParams} to be used to
-     * launch the PayPal web authentication flow in
+     * Starts the PayPal payment flow by creating a {@link PayPalPaymentAuthRequestParams} to be
+     * used to launch the PayPal web authentication flow in
      * {@link PayPalLauncher#launch(FragmentActivity, PayPalPaymentAuthRequestParams)}.
      *
-     * @param activity      Android FragmentActivity
+     * @param context       Android Context
      * @param payPalRequest a {@link PayPalRequest} used to customize the request.
      * @param callback      {@link PayPalPaymentAuthCallback}
      */
-    public void createPaymentAuthRequest(@NonNull final FragmentActivity activity,
+    public void createPaymentAuthRequest(@NonNull final Context context,
                                          @NonNull final PayPalRequest payPalRequest,
                                          @NonNull final PayPalPaymentAuthCallback callback) {
         if (payPalRequest instanceof PayPalCheckoutRequest) {
-            sendCheckoutRequest(activity, (PayPalCheckoutRequest) payPalRequest, callback);
+            sendCheckoutRequest(context, (PayPalCheckoutRequest) payPalRequest, callback);
         } else if (payPalRequest instanceof PayPalVaultRequest) {
-            sendVaultRequest(activity, (PayPalVaultRequest) payPalRequest, callback);
+            sendVaultRequest(context, (PayPalVaultRequest) payPalRequest, callback);
         }
     }
 
-    private void sendCheckoutRequest(final FragmentActivity activity,
+    private void sendCheckoutRequest(final Context context,
                                      final PayPalCheckoutRequest payPalCheckoutRequest,
                                      final PayPalPaymentAuthCallback callback) {
         braintreeClient.sendAnalyticsEvent("paypal.single-payment.selected");
@@ -93,12 +93,12 @@ public class PayPalClient {
             }
 
 
-            sendPayPalRequest(activity, payPalCheckoutRequest, callback);
+            sendPayPalRequest(context, payPalCheckoutRequest, callback);
         });
 
     }
 
-    private void sendVaultRequest(final FragmentActivity activity,
+    private void sendVaultRequest(final Context context,
                                   final PayPalVaultRequest payPalVaultRequest,
                                   final PayPalPaymentAuthCallback callback) {
         braintreeClient.sendAnalyticsEvent("paypal.billing-agreement.selected");
@@ -118,23 +118,14 @@ public class PayPalClient {
                 return;
             }
 
-            try {
-                assertCanPerformBrowserSwitch(activity);
-            } catch (BrowserSwitchException browserSwitchException) {
-                braintreeClient.sendAnalyticsEvent("paypal.invalid-manifest");
-                Exception manifestInvalidError =
-                        createBrowserSwitchError(browserSwitchException);
-                callback.onPayPalPaymentAuthRequest(new PayPalPaymentAuthRequest.Failure(manifestInvalidError));
-                return;
-            }
-            sendPayPalRequest(activity, payPalVaultRequest, callback);
+            sendPayPalRequest(context, payPalVaultRequest, callback);
         });
     }
 
-    private void sendPayPalRequest(final FragmentActivity activity,
+    private void sendPayPalRequest(final Context context,
                                    final PayPalRequest payPalRequest,
                                    final PayPalPaymentAuthCallback callback) {
-        internalPayPalClient.sendRequest(activity, payPalRequest,
+        internalPayPalClient.sendRequest(context, payPalRequest,
                 (payPalResponse, error) -> {
                     if (payPalResponse != null) {
                         String analyticsPrefix = getAnalyticsEventPrefix(payPalRequest);

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -47,23 +47,10 @@ public class PayPalClient {
         return (configuration == null || !configuration.isPayPalEnabled());
     }
 
-    private void assertCanPerformBrowserSwitch(FragmentActivity activity)
-            throws BrowserSwitchException {
-        braintreeClient.assertCanPerformBrowserSwitch(activity, BraintreeRequestCodes.PAYPAL);
-    }
-
     private static Exception createPayPalError() {
         return new BraintreeException("PayPal is not enabled. " +
                 "See https://developer.paypal.com/braintree/docs/guides/paypal/overview/android/v4 " +
                 "for more information.");
-    }
-
-    private static Exception createBrowserSwitchError(BrowserSwitchException exception) {
-        return new BraintreeException(
-                "AndroidManifest.xml is incorrectly configured or another app " +
-                        "defines the same browser switch url as this app. See " +
-                        "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                        "for the correct configuration: " + exception.getMessage());
     }
 
     /**
@@ -105,15 +92,7 @@ public class PayPalClient {
                 return;
             }
 
-            try {
-                assertCanPerformBrowserSwitch(activity);
-            } catch (BrowserSwitchException browserSwitchException) {
-                braintreeClient.sendAnalyticsEvent("paypal.invalid-manifest");
-                Exception manifestInvalidError =
-                        createBrowserSwitchError(browserSwitchException);
-                callback.onPayPalPaymentAuthRequest(new PayPalPaymentAuthRequest.Failure(manifestInvalidError));
-                return;
-            }
+
             sendPayPalRequest(activity, payPalCheckoutRequest, callback);
         });
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalLauncher.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalLauncher.java
@@ -41,8 +41,7 @@ public class PayPalLauncher {
      *
      * @param activity       an Android {@link FragmentActivity}
      * @param paymentAuthRequest a request to launch the PayPal web flow created in
-     *                       {@link PayPalClient#createPaymentAuthRequest(FragmentActivity,
-     *                       PayPalRequest, PayPalPaymentAuthCallback)}
+     *                       {@link PayPalClient#createPaymentAuthRequest(Context, PayPalRequest, PayPalPaymentAuthCallback)}
      */
     public void launch(@NonNull FragmentActivity activity,
                        @NonNull PayPalPaymentAuthRequestParams paymentAuthRequest) {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalPaymentAuthCallback.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalPaymentAuthCallback.java
@@ -1,10 +1,8 @@
 package com.braintreepayments.api;
 
-import androidx.fragment.app.FragmentActivity;
-
 /**
  * Callback for receiving result of
- * {@link PayPalClient#createPaymentAuthRequest(FragmentActivity, PayPalRequest, PayPalPaymentAuthCallback)}.
+ * {@link PayPalClient#createPaymentAuthRequest(android.content.Context, PayPalRequest, PayPalPaymentAuthCallback)}.
  */
 public interface PayPalPaymentAuthCallback {
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -214,31 +214,7 @@ public class PayPalClientUnitTest {
         assertEquals(authError, ((PayPalPaymentAuthRequest.Failure) request).getError());
     }
 
-    @Test
-    public void requestOneTimePayment_whenDeviceCantPerformBrowserSwitch_returnsError() {
-        PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder().build();
 
-        BraintreeClient braintreeClient =
-                new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
-                        .browserSwitchAssertionError(
-                                new BrowserSwitchException("browser switch error")).build();
-
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
-        sut.createPaymentAuthRequest(activity, new PayPalCheckoutRequest("1.00"),
-                paymentAuthCallback);
-
-        ArgumentCaptor<PayPalPaymentAuthRequest> captor =
-                ArgumentCaptor.forClass(PayPalPaymentAuthRequest.class);
-        verify(paymentAuthCallback).onPayPalPaymentAuthRequest(captor.capture());
-
-        PayPalPaymentAuthRequest request = captor.getValue();
-        assertTrue(request instanceof PayPalPaymentAuthRequest.Failure);
-        assertEquals("AndroidManifest.xml is incorrectly configured or another app " +
-                        "defines the same browser switch url as this app. See " +
-                        "https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/android/v4#browser-switch-setup " +
-                        "for the correct configuration: browser switch error",
-                ((PayPalPaymentAuthRequest.Failure) request).getError().getMessage());
-    }
 
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Remove `FragmentActivity` parameter from `PayPalClient` methods in favor of `Context`
 - Move `assertCanPerformBrowserSwitch` from `PayPalClient` to `PayPalLauncher` since the launcher handles starting the browser switch now
 
 ### Checklist

 - ~[ ] Added a changelog entry~ 

### Authors

- @sarahkoop 
