### PR TITLE
Clarify Pull Request urgency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -6,11 +6,18 @@ Thank you for your contribution to Braintree.
 
  - 
 
- ### Checklist
+### Checklist
 
  - [ ] Added a changelog entry
+ - [ ] Relevant test coverage
 
 ### Authors
 > List GitHub usernames for everyone who contributed to this pull request.
 
-- 
+### PayPal and Braintree engineering requirements
+ > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!
+
+**When do these changes need to be released?** 
+[ ] ASAP (let's discuss outside this PR)
+[ ] Soon, here's our target release date: <DD/MM/YYYY>
+[ ] Whenever, no rush


### PR DESCRIPTION
Let's make it a little easier for engineers from other PayPal teams to share with us the priority of getting their changes reviewed and released.

I added a section to the bottom of the PR template that tries to contextualize team deadlines for getting certain changes released without giving away internal business info.

It's very small, but hopefully adopting this can help us help our colleagues deliver code changes on time without needing to ping us outside of the PR review.

Assuming folks are ok with this for Android, I'll go ahead and update iOS and Drop-in repo PR templates, too