### PR TITLE
Add PayPal Messaging Dependency

### DIFF
--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         // required to be out of sync with other modules due to messaging SDK min version
-        minSdkVersion 23
+        minSdkVersion rootProject.minSdkVersionPayPalMessaging
         targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation deps.coreKtx
     implementation deps.kotlinStdLib
     implementation deps.appCompat
+    implementation('com.paypal.messages:paypal-messages:1.0.0-alpha.0-SNAPSHOT')
 
     testImplementation deps.junitTest
 }

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -7,7 +7,8 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
+        // required to be out of sync with other modules due to messaging SDK min version
+        minSdkVersion 23
         targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -40,9 +41,17 @@ dependencies {
     implementation deps.coreKtx
     implementation deps.kotlinStdLib
     implementation deps.appCompat
-    implementation('com.paypal.messages:paypal-messages:1.0.0-alpha.0-SNAPSHOT')
+    implementation('com.paypal.messages:paypal-messages:1.0.0-alpha.00-SNAPSHOT')
 
     testImplementation deps.junitTest
+}
+
+allprojects {
+    repositories {
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
 }
 
 // region signing and publishing

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation deps.junitTest
 }
 
+// TODO: remove importing snapshot repositories before feature is merged
 allprojects {
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ group 'com.braintreepayments'
 ext {
     compileSdkVersion = 34
     minSdkVersion = 21
+    minSdkVersionPayPalMessaging = 23
     versionCode = 185
     targetSdkVersion = 34
     versionName = version


### PR DESCRIPTION
This work is going into the `paypal-messaging-feature` branch

### Summary of changes

 - Now that a version of the SDK has been released we can add it as a dependency and pick back up on wrapping this feature

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors

@jaxdesmarais 