### PR TITLE
Update Venmo demo to send MULTI_USE when vault is enabled

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VenmoFragment.java
@@ -58,9 +58,12 @@ public class VenmoFragment extends BaseFragment implements VenmoListener {
         boolean shouldVault =
                 Settings.vaultVenmo(activity) && !TextUtils.isEmpty(Settings.getCustomerId(activity));
 
+        int venmoPaymentMethodUsage = shouldVault ?
+            VenmoPaymentMethodUsage.MULTI_USE : VenmoPaymentMethodUsage.SINGLE_USE;
+
         braintreeClient.getConfiguration((configuration, error) -> {
             if (venmoClient.isVenmoAppSwitchAvailable(activity)) {
-                VenmoRequest venmoRequest = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
+                VenmoRequest venmoRequest = new VenmoRequest(venmoPaymentMethodUsage);
                 venmoRequest.setProfileId(null);
                 venmoRequest.setShouldVault(shouldVault);
                 venmoRequest.setCollectCustomerBillingAddress(true);

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -42,6 +42,10 @@ public class VenmoRequest implements Parcelable {
      * @param shouldVault Optional - Whether or not to automatically vault the Venmo Account.
      *                    Vaulting will only occur if a client token with a customer ID is being used.
      *                    Defaults to false.
+     *
+     *                    Also when shouldVault is true, {@link VenmoPaymentMethodUsage} on the
+     *                    {@link VenmoRequest} must be set to
+     *                    {@link VenmoPaymentMethodUsage.MULTI_USE}.
      */
     public void setShouldVault(boolean shouldVault) {
         this.shouldVault = shouldVault;


### PR DESCRIPTION
### Summary of changes

 - Send `MULTI_USE` instead of `SINGLE_USE` to the `VenmoPaymentMethodUsage` param in the Venmo request when vault is enabled

### Checklist

~- [ ] Added a changelog entry~
~- [ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
