### PR TITLE
Add network call for shopper insights

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -124,7 +124,7 @@ internal class BraintreeHttpClient(
         if (authorization is TokenizationKey) {
             request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
-        request.addHeader("Authorization", "Bearer " + authorization?.bearer)
+        authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token")
         httpClient.sendRequest(request, callback)
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -83,6 +83,7 @@ internal class BraintreeHttpClient(
      * @param authorization
      * @param callback [HttpResponseCallback]
      */
+    @Suppress("CyclomaticComplexMethod")
     fun post(
         path: String,
         data: String,

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -124,6 +124,9 @@ internal class BraintreeHttpClient(
         if (authorization is TokenizationKey) {
             request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
+        if (authorization is ClientToken) {
+            request.addHeader("Authorization", "Bearer " + authorization.authorizationFingerprint)
+        }
         httpClient.sendRequest(request, callback)
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -124,9 +124,7 @@ internal class BraintreeHttpClient(
         if (authorization is TokenizationKey) {
             request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
-        if (authorization is ClientToken) {
-            request.addHeader("Authorization", "Bearer " + authorization.authorizationFingerprint)
-        }
+        request.addHeader("Authorization", "Bearer " + authorization?.bearer)
         httpClient.sendRequest(request, callback)
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -125,7 +125,7 @@ internal class BraintreeHttpClient(
         if (authorization is TokenizationKey) {
             request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
-        authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token")
+        authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token") }
         httpClient.sendRequest(request, callback)
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -10,6 +10,7 @@ import com.braintreepayments.api.BraintreeClient
 import com.braintreepayments.api.ShopperInsightsBuyerPhone
 import com.braintreepayments.api.ShopperInsightsClient
 import com.braintreepayments.api.ShopperInsightsRequest
+import com.braintreepayments.api.ShopperInsightsResult
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
 
@@ -72,7 +73,12 @@ class ShopperInsightsFragment : BaseFragment() {
                 requireContext(),
                 request
             ) { result ->
-                responseTextView.text = result.toString()
+                responseTextView.text = when (result) {
+                    is ShopperInsightsResult.Success -> {
+                        "PayPal Recommended ${result.response.isPayPalRecommended} \n Venmo Recommended ${result.response.isVenmoRecommended}"
+                    }
+                    is ShopperInsightsResult.Failure -> result.error.toString()
+                }
             }
         }
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -75,7 +75,8 @@ class ShopperInsightsFragment : BaseFragment() {
             ) { result ->
                 responseTextView.text = when (result) {
                     is ShopperInsightsResult.Success -> {
-                        "PayPal Recommended ${result.response.isPayPalRecommended} \n Venmo Recommended ${result.response.isVenmoRecommended}"
+                        "PayPal Recommended ${result.response.isPayPalRecommended} " +
+                                "\n Venmo Recommended ${result.response.isVenmoRecommended}"
                     }
                     is ShopperInsightsResult.Failure -> result.error.toString()
                 }

--- a/PayPalDataCollector/src/main/java/com/braintreepayments/api/MagnesInternalClient.java
+++ b/PayPalDataCollector/src/main/java/com/braintreepayments/api/MagnesInternalClient.java
@@ -45,7 +45,6 @@ class MagnesInternalClient {
                     .setAppGuid(request.getApplicationGuid());
 
             magnesSDK.setUp(magnesSettingsBuilder.build());
-
             MagnesResult result = magnesSDK.collectAndSubmit(context.getApplicationContext(), request.getClientMetadataId(), request.getAdditionalData());
             return result.getPaypalClientMetaDataId();
         } catch (InvalidInputException e) {

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -15,9 +15,7 @@ internal class EligiblePaymentsApi(
             jsonBody,
             object : HttpResponseCallback {
                 override fun onResult(responseBody: String?, httpError: Exception?) {
-                    if (httpError != null) {
-                        callback.onResult(null, httpError)
-                    } else if (responseBody != null) {
+                    if (responseBody != null) {
                         try {
                             callback.onResult(
                                 EligiblePaymentsApiResult.fromJson(responseBody),
@@ -27,7 +25,7 @@ internal class EligiblePaymentsApi(
                             callback.onResult(null, e)
                         }
                     } else {
-                        callback.onResult(null, Exception("null body"))
+                        callback.onResult(null, httpError)
                     }
                 }
             }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -17,23 +17,10 @@ internal class EligiblePaymentsApi(
                 override fun onResult(responseBody: String?, httpError: Exception?) {
                     if (responseBody != null) {
                         try {
-                            val responseJson = JSONObject(responseBody)
-                            callback.onResult(EligiblePaymentsApiResult(
-                                eligibleMethods = EligiblePaymentMethods(
-                                    paypal = EligiblePaymentMethodDetails(
-                                        canBeVaulted = true,
-                                        eligibleInPayPalNetwork = true,
-                                        recommended = true,
-                                        recommendedPriority = 1
-                                    ),
-                                    venmo = EligiblePaymentMethodDetails(
-                                        canBeVaulted = true,
-                                        eligibleInPayPalNetwork = true,
-                                        recommended = true,
-                                        recommendedPriority = 1
-                                    )
-                                )
-                            ), null)
+                            callback.onResult(
+                                EligiblePaymentsApiResult.fromJson(responseBody),
+                                null
+                            )
                         } catch (e: JSONException) {
                             callback.onResult(null, e)
                         }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -8,27 +8,33 @@ internal class EligiblePaymentsApi(
 ) {
     fun execute(request: EligiblePaymentsApiRequest, callback: EligiblePaymentsCallback) {
         val jsonBody = request.toJson()
-        // TODO: Move url to PaypalHttpClient class when it is created
-        val url = "https://api.sandbox.paypal.com/v2/payments/find-eligible-methods"
-        braintreeClient.sendPOST(
-            url,
-            jsonBody,
-            object : HttpResponseCallback {
-                override fun onResult(responseBody: String?, httpError: Exception?) {
-                    if (responseBody != null) {
-                        try {
-                            callback.onResult(
-                                EligiblePaymentsApiResult.fromJson(responseBody),
-                                null
-                            )
-                        } catch (e: JSONException) {
-                            callback.onResult(null, e)
+        braintreeClient.getConfiguration { configuration, configError ->
+            // TODO: Move url to PaypalHttpClient class when it is created
+            val baseUrl = when (configuration?.environment) {
+                "production" -> "https://api.paypal.com"
+                else -> "https://api.sandbox.paypal.com"
+            }
+            val url = "$baseUrl/v2/payments/find-eligible-methods"
+            braintreeClient.sendPOST(
+                url,
+                jsonBody,
+                object : HttpResponseCallback {
+                    override fun onResult(responseBody: String?, httpError: Exception?) {
+                        if (responseBody != null) {
+                            try {
+                                callback.onResult(
+                                    EligiblePaymentsApiResult.fromJson(responseBody),
+                                    null
+                                )
+                            } catch (e: JSONException) {
+                                callback.onResult(null, e)
+                            }
+                        } else {
+                            callback.onResult(null, httpError)
                         }
-                    } else {
-                        callback.onResult(null, httpError)
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -8,7 +8,7 @@ internal class EligiblePaymentsApi(
 ) {
     fun execute(request: EligiblePaymentsApiRequest, callback: EligiblePaymentsCallback) {
         val jsonBody = request.toJson()
-        //TODO: Move url to PaypalHttpClient class when it is created
+        // TODO: Move url to PaypalHttpClient class when it is created
         val url = "https://api.sandbox.paypal.com/v2/payments/find-eligible-methods"
         braintreeClient.sendPOST(
             url,

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -1,28 +1,47 @@
 package com.braintreepayments.api
 
 import com.braintreepayments.api.EligiblePaymentsApiRequest.Companion.toJson
+import org.json.JSONException
+import org.json.JSONObject
 
-internal class EligiblePaymentsApi {
-    fun execute(request: EligiblePaymentsApiRequest): EligiblePaymentsApiResult {
-        request.toJson()
-        // TODO: Network call
-
-        // Hardcoded result
-        return EligiblePaymentsApiResult(
-            eligibleMethods = EligiblePaymentMethods(
-                paypal = EligiblePaymentMethodDetails(
-                    canBeVaulted = true,
-                    eligibleInPayPalNetwork = true,
-                    recommended = true,
-                    recommendedPriority = 1
-                ),
-                venmo = EligiblePaymentMethodDetails(
-                    canBeVaulted = true,
-                    eligibleInPayPalNetwork = true,
-                    recommended = true,
-                    recommendedPriority = 1
-                )
-            )
+internal class EligiblePaymentsApi(
+    private val braintreeClient: BraintreeClient
+) {
+    fun execute(request: EligiblePaymentsApiRequest, callback: EligiblePaymentsCallback) {
+        val jsonBody = request.toJson()
+        val url = "https://api.sandbox.paypal.com/v2/payments/find-eligible-methods"
+        braintreeClient.sendPOST(
+            url,
+            jsonBody,
+            object : HttpResponseCallback {
+                override fun onResult(responseBody: String?, httpError: Exception?) {
+                    if (responseBody != null) {
+                        try {
+                            val responseJson = JSONObject(responseBody)
+                            callback.onResult(EligiblePaymentsApiResult(
+                                eligibleMethods = EligiblePaymentMethods(
+                                    paypal = EligiblePaymentMethodDetails(
+                                        canBeVaulted = true,
+                                        eligibleInPayPalNetwork = true,
+                                        recommended = true,
+                                        recommendedPriority = 1
+                                    ),
+                                    venmo = EligiblePaymentMethodDetails(
+                                        canBeVaulted = true,
+                                        eligibleInPayPalNetwork = true,
+                                        recommended = true,
+                                        recommendedPriority = 1
+                                    )
+                                )
+                            ), null)
+                        } catch (e: JSONException) {
+                            callback.onResult(null, e)
+                        }
+                    } else {
+                        callback.onResult(null, Exception("null body"))
+                    }
+                }
+            }
         )
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -15,7 +15,9 @@ internal class EligiblePaymentsApi(
             jsonBody,
             object : HttpResponseCallback {
                 override fun onResult(responseBody: String?, httpError: Exception?) {
-                    if (responseBody != null) {
+                    if (httpError != null) {
+                        callback.onResult(null, httpError)
+                    } else if (responseBody != null) {
                         try {
                             callback.onResult(
                                 EligiblePaymentsApiResult.fromJson(responseBody),

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -8,6 +8,7 @@ internal class EligiblePaymentsApi(
 ) {
     fun execute(request: EligiblePaymentsApiRequest, callback: EligiblePaymentsCallback) {
         val jsonBody = request.toJson()
+        //TODO: Move url to PaypalHttpClient class when it is created
         val url = "https://api.sandbox.paypal.com/v2/payments/find-eligible-methods"
         braintreeClient.sendPOST(
             url,

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApi.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api
 
 import com.braintreepayments.api.EligiblePaymentsApiRequest.Companion.toJson
 import org.json.JSONException
-import org.json.JSONObject
 
 internal class EligiblePaymentsApi(
     private val braintreeClient: BraintreeClient

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsCallback.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsCallback.kt
@@ -1,0 +1,10 @@
+package com.braintreepayments.api
+
+import java.lang.Exception
+
+/**
+ * A callback that returns information on whether someone is a PayPal or a Venmo shopper.
+ */
+internal fun interface EligiblePaymentsCallback {
+    fun onResult(result: EligiblePaymentsApiResult?, error: Exception?)
+}

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsApi.kt
@@ -8,7 +8,7 @@ internal class ShopperInsightsApi(
     private val eligiblePaymentsApi: EligiblePaymentsApi
 ) {
 
-    fun findEligiblePayments(request: EligiblePaymentsApiRequest): EligiblePaymentsApiResult {
-        return eligiblePaymentsApi.execute(request)
+    fun findEligiblePayments(request: EligiblePaymentsApiRequest, callback: EligiblePaymentsCallback) {
+        eligiblePaymentsApi.execute(request, callback)
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -108,7 +108,7 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
                     result?.eligibleMethods?.venmo == null -> {
                 callback.onResult(
                     ShopperInsightsResult.Failure(
-                        NullPointerException("Missing data in API response")
+                        BraintreeException("Required fields missing from API response body")
                     )
                 )
             }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -36,6 +36,7 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      * @param request The [ShopperInsightsRequest] containing information about the shopper.
      * @return A [ShopperInsightsResult] object indicating the recommended payment methods.
      */
+    @Suppress("LongMethod")
     fun getRecommendedPaymentMethods(
         context: Context,
         request: ShopperInsightsRequest,
@@ -74,13 +75,6 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
 
         // TODO: get correct merchant ID from SDK
         val merchantId = "MXSJ4F5BADVNS"
-
-        // Default values
-        val countryCode = "US"
-        val currencyCode = "USD"
-        val constraintType = "INCLUDE"
-        val paymentSources = listOf("PAYPAL", "VENMO")
-        val includeAccountDetails = true
 
         api.findEligiblePayments(
             EligiblePaymentsApiRequest(
@@ -148,5 +142,14 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      */
     fun sendVenmoSelectedEvent() {
         braintreeClient.sendAnalyticsEvent(VENMO_SELECTED)
+    }
+
+    companion object {
+        // Default values
+        private const val countryCode = "US"
+        private const val currencyCode = "USD"
+        private const val constraintType = "INCLUDE"
+        private val paymentSources = listOf("PAYPAL", "VENMO")
+        private const val includeAccountDetails = true
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
@@ -1,0 +1,123 @@
+package com.braintreepayments.api
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class EligiblePaymentsApiUnitTest {
+
+    private lateinit var sut: EligiblePaymentsApi
+    private lateinit var callback: EligiblePaymentsCallback
+    private lateinit var braintreeClient: BraintreeClient
+    private val configuration: Configuration = createMockConfiguration()
+
+    @Before
+    fun setup() {
+        callback = mockk(relaxed = true)
+        braintreeClient = mockk(relaxed = true)
+        setupBraintreeClientToReturnConfiguration()
+        sut = EligiblePaymentsApi(braintreeClient)
+    }
+
+    @Test
+    fun test_sendPOST_Error() {
+        val error = Exception("error")
+
+        mockBraintreeClientToSendPOSTWithError(error)
+
+        sut.execute(createEmptyRequest(), callback)
+
+        verify {
+            callback.onResult(result = null, error = error)
+        }
+    }
+
+    @Test
+    fun test_sendPOST_Success() {
+
+        val responseBody = """
+            {
+                "eligible_methods": {
+                    "paypal": {
+                        "can_be_vaulted": true,
+                        "eligible_in_paypal_network": false,
+                        "recommended": true,
+                        "recommended_priority": 1
+                    }
+                }
+            }
+        """.trimIndent()
+
+        mockBraintreeClientToSendPOSTWithResponse(responseBody)
+
+        sut.execute(createEmptyRequest(), callback)
+
+        verify {
+            callback.onResult(result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = false,
+                        recommended = true,
+                        recommendedPriority = 1
+                    ),
+                    venmo = null
+                )
+            ), error = null)
+        }
+    }
+
+    private fun setupBraintreeClientToReturnConfiguration() {
+        val callbackSlot = slot<ConfigurationCallback>()
+        every {
+            braintreeClient.getConfiguration(capture(callbackSlot))
+        } answers {
+            val callback = callbackSlot.captured
+            callback.onResult(configuration, error = null)
+        }
+    }
+
+    private fun createMockConfiguration(): Configuration {
+        return mockk(relaxed = true) {
+            every { environment } answers { "sandbox" }
+        }
+    }
+
+    private fun mockBraintreeClientToSendPOSTWithError(error: Exception) {
+        val callbackSlot = slot<HttpResponseCallback>()
+        every {
+            braintreeClient.sendPOST(any(), any(), capture(callbackSlot))
+        } answers {
+            val callback = callbackSlot.captured
+            callback.onResult(null, error)
+        }
+    }
+
+    private fun mockBraintreeClientToSendPOSTWithResponse(responseBody: String) {
+        val callbackSlot = slot<HttpResponseCallback>()
+        every {
+            braintreeClient.sendPOST(any(), any(), capture(callbackSlot))
+        } answers {
+            val callback = callbackSlot.captured
+            callback.onResult(responseBody, null)
+        }
+    }
+
+    private fun createEmptyRequest(): EligiblePaymentsApiRequest {
+       return EligiblePaymentsApiRequest(
+            ShopperInsightsRequest(
+                "",
+                ShopperInsightsBuyerPhone("", "")
+            ),
+            "",
+            "",
+            "",
+            true,
+            "",
+            emptyList()
+        )
+    }
+}

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
@@ -23,7 +23,27 @@ class EligiblePaymentsApiUnitTest {
     }
 
     @Test
-    fun test_sendPOST_Error() {
+    fun `when environment is production, braintreeClient sendPOST is called with the correct url`() {
+        val expectedUrl = "https://api.paypal.com/v2/payments/find-eligible-methods"
+        every { configuration.environment } returns "production"
+
+        sut.execute(createEmptyRequest(), callback)
+
+        verify { braintreeClient.sendPOST(expectedUrl, any(), any()) }
+    }
+
+    @Test
+    fun `when environment is sandbox, braintreeClient sendPOST is called with the correct url`() {
+        val expectedUrl = "https://api.sandbox.paypal.com/v2/payments/find-eligible-methods"
+        every { configuration.environment } returns "sandbox"
+
+        sut.execute(createEmptyRequest(), callback)
+
+        verify { braintreeClient.sendPOST(expectedUrl, any(), any()) }
+    }
+
+    @Test
+    fun `when sendPost is called and an error occurs, callback onResult is invoked with the error`() {
         val error = Exception("error")
 
         mockBraintreeClientToSendPOSTWithError(error)
@@ -36,7 +56,7 @@ class EligiblePaymentsApiUnitTest {
     }
 
     @Test
-    fun test_sendPOST_Success() {
+    fun `when sendPost is called, callback onResult is invoked with a result`() {
 
         val responseBody = """
             {
@@ -107,7 +127,7 @@ class EligiblePaymentsApiUnitTest {
     }
 
     private fun createEmptyRequest(): EligiblePaymentsApiRequest {
-       return EligiblePaymentsApiRequest(
+        return EligiblePaymentsApiRequest(
             ShopperInsightsRequest(
                 "",
                 ShopperInsightsBuyerPhone("", "")

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -2,7 +2,10 @@ package com.braintreepayments.api
 
 import android.content.Context
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -11,6 +14,7 @@ import kotlin.test.assertTrue
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import java.lang.NullPointerException
 
 /**
  * Unit tests for BraintreeShopperInsightsClient.
@@ -101,12 +105,208 @@ class ShopperInsightsClientUnitTest {
             val iae = assertIs<IllegalArgumentException>(error.error)
             assertEquals(
                 "One of ShopperInsightsRequest.email or " +
-                    "ShopperInsightsRequest.phone must be non-null.",
+                        "ShopperInsightsRequest.phone must be non-null.",
                 iae.message
             )
         }
         verifyStartedAnalyticsEvent()
         verifyFailedAnalyticsEvent()
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - findEligiblePayments is called with request`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+        val request = ShopperInsightsRequest("some-email", null)
+
+        executeTestForFindEligiblePaymentsApi(
+            request = request,
+            result = null,
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            api.findEligiblePayments(
+                request = EligiblePaymentsApiRequest(
+                    request,
+                    merchantId = "MXSJ4F5BADVNS",
+                    currencyCode = "USD",
+                    countryCode = "US",
+                    accountDetails = true,
+                    constraintType = "INCLUDE",
+                    paymentSources = listOf("PAYPAL", "VENMO")
+                ),
+                callback = any()
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - findEligiblePayments returns an error`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+        val expectedError = Exception("Expected Exception")
+
+        executeTestForFindEligiblePaymentsApi(
+            result = null,
+            error = expectedError,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertEquals((result as ShopperInsightsResult.Failure).error, expectedError)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - result is null`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = null,
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertTrue {
+                        (result as ShopperInsightsResult.Failure).error is NullPointerException
+                    }
+                    assertEquals(
+                        "Missing data in API response",
+                        (result as ShopperInsightsResult.Failure).error.message
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - all methods are null`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(EligiblePaymentMethods(paypal = null, venmo = null)),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertTrue {
+                        (result as ShopperInsightsResult.Failure).error is NullPointerException
+                    }
+                    assertEquals(
+                        "Missing data in API response",
+                        (result as ShopperInsightsResult.Failure).error.message
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - both paypal and venmo recommended`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+        val eligiblePaymentMethodDetails = EligiblePaymentMethodDetails(
+            canBeVaulted = true,
+            eligibleInPayPalNetwork = true,
+            recommended = true,
+            recommendedPriority = 1
+        )
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = eligiblePaymentMethodDetails,
+                    venmo = eligiblePaymentMethodDetails
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertEquals(true, success.response.isPayPalRecommended)
+                    assertEquals(true, success.response.isVenmoRecommended)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - paymentDetail null`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = null,
+                    venmo = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = true,
+                        recommended = true,
+                        recommendedPriority = 1
+                    )
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertEquals(false, success.response.isPayPalRecommended)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `testGetRecommendedPaymentMethods - recommended is false`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = true,
+                        recommended = false,
+                        recommendedPriority = 1
+                    ),
+                    venmo = null
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertEquals(false, success.response.isPayPalRecommended)
+                }
+            )
+        }
     }
 
     @Test
@@ -131,6 +331,23 @@ class ShopperInsightsClientUnitTest {
     fun `test venmo selected analytics event`() {
         sut.sendVenmoSelectedEvent()
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected") }
+    }
+
+    private fun executeTestForFindEligiblePaymentsApi(
+        callback: ShopperInsightsCallback,
+        request: ShopperInsightsRequest = ShopperInsightsRequest("some-email", null),
+        result: EligiblePaymentsApiResult?,
+        error: Exception?
+    ) {
+        every { deviceInspector.isVenmoInstalled(applicationContext) } returns false
+        every { deviceInspector.isPayPalInstalled(applicationContext) } returns false
+
+        val apiCallbackSlot = slot<EligiblePaymentsCallback>()
+        every { api.findEligiblePayments(any(), capture(apiCallbackSlot)) } just runs
+
+        sut.getRecommendedPaymentMethods(context, request, callback)
+
+        apiCallbackSlot.captured.onResult(result = result, error = error)
     }
 
     private fun verifyStartedAnalyticsEvent() {

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -14,7 +14,6 @@ import kotlin.test.assertTrue
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import java.lang.NullPointerException
 
 /**
  * Unit tests for BraintreeShopperInsightsClient.
@@ -177,10 +176,10 @@ class ShopperInsightsClientUnitTest {
                 withArg { result ->
                     assertTrue { result is ShopperInsightsResult.Failure }
                     assertTrue {
-                        (result as ShopperInsightsResult.Failure).error is NullPointerException
+                        (result as ShopperInsightsResult.Failure).error is BraintreeException
                     }
                     assertEquals(
-                        "Missing data in API response",
+                        "Required fields missing from API response body",
                         (result as ShopperInsightsResult.Failure).error.message
                     )
                 }
@@ -203,10 +202,10 @@ class ShopperInsightsClientUnitTest {
                 withArg { result ->
                     assertTrue { result is ShopperInsightsResult.Failure }
                     assertTrue {
-                        (result as ShopperInsightsResult.Failure).error is NullPointerException
+                        (result as ShopperInsightsResult.Failure).error is BraintreeException
                     }
                     assertEquals(
-                        "Missing data in API response",
+                        "Required fields missing from API response body",
                         (result as ShopperInsightsResult.Failure).error.message
                     )
                 }


### PR DESCRIPTION
### Summary of changes

 - Added network call for eligible payments api
 - Updated demo app to show response

### Screenshots

<img width="417" alt="Screenshot 2024-01-23 at 11 57 30 AM" src="https://github.com/braintree/braintree_android/assets/128730898/bb6a00a5-a4b0-4d15-8bce-bb5b4c86320a">


### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
@MaxHastingsPP 
