### PR TITLE
Fix Javadocs Task for AGP 8

### DIFF
--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -54,7 +54,6 @@ afterEvaluate {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     failOnError false
 }
 


### PR DESCRIPTION
### Summary of changes

 - Javadocs task when run with AGP 8 is currently broken - fix by removing invalid classpath

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
@sarahkoop 
