### PR TITLE
Remove App Check From Shopper Insights and Analytics Updates

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -69,10 +69,7 @@ class ShopperInsightsFragment : BaseFragment() {
             } else {
                 ShopperInsightsRequest(email, null)
             }
-            shopperInsightsClient.getRecommendedPaymentMethods(
-                requireContext(),
-                request
-            ) { result ->
+            shopperInsightsClient.getRecommendedPaymentMethods(request) { result ->
                 responseTextView.text = when (result) {
                     is ShopperInsightsResult.Success -> {
                         "PayPal Recommended ${result.response.isPayPalRecommended} " +

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -90,18 +90,10 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
             }
 
             else -> {
-                braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
-                callback.onResult(
-                    ShopperInsightsResult.Success(
-                        ShopperInsightsInfo(
-                            isPayPalRecommended = isPaymentRecommended(
-                                result.eligibleMethods.paypal
-                            ),
-                            isVenmoRecommended = isPaymentRecommended(
-                                result.eligibleMethods.venmo
-                            )
-                        )
-                    )
+                callbackSuccess(
+                    callback = callback,
+                    isPayPalRecommended = isPaymentRecommended(result.eligibleMethods.paypal),
+                    isVenmoRecommended = isPaymentRecommended(result.eligibleMethods.venmo)
                 )
             }
         }
@@ -113,6 +105,19 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
     ) {
         braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED)
         callback.onResult(ShopperInsightsResult.Failure(error))
+    }
+
+    private fun callbackSuccess(
+        callback: ShopperInsightsCallback,
+        isPayPalRecommended: Boolean,
+        isVenmoRecommended: Boolean,
+    ) {
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
+        callback.onResult(
+            ShopperInsightsResult.Success(
+                ShopperInsightsInfo(isPayPalRecommended, isVenmoRecommended)
+            )
+        )
     }
 
     private fun isPaymentRecommended(paymentDetail: EligiblePaymentMethodDetails?): Boolean {

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -1,6 +1,5 @@
 package com.braintreepayments.api
 
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.braintreepayments.api.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_FAILED
 import com.braintreepayments.api.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_STARTED
@@ -21,13 +20,11 @@ import java.lang.Exception
  */
 class ShopperInsightsClient @VisibleForTesting internal constructor(
     private val api: ShopperInsightsApi,
-    private val braintreeClient: BraintreeClient,
-    private val deviceInspector: DeviceInspector
+    private val braintreeClient: BraintreeClient
 ) {
     constructor(braintreeClient: BraintreeClient) : this(
         ShopperInsightsApi(EligiblePaymentsApi(braintreeClient)),
         braintreeClient,
-        DeviceInspector()
     )
 
     /**
@@ -38,38 +35,19 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      * @return A [ShopperInsightsResult] object indicating the recommended payment methods.
      */
     fun getRecommendedPaymentMethods(
-        context: Context,
         request: ShopperInsightsRequest,
         callback: ShopperInsightsCallback
     ) {
         braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_STARTED)
+
         if (request.email == null && request.phone == null) {
-            callback.onResult(
-                ShopperInsightsResult.Failure(
-                    IllegalArgumentException(
-                        "One of ShopperInsightsRequest.email or " +
-                                "ShopperInsightsRequest.phone must be non-null."
-                    )
+            callbackFailure(
+                callback = callback,
+                error = IllegalArgumentException(
+                    "One of ShopperInsightsRequest.email or ShopperInsightsRequest.phone must be " +
+                            "non-null."
                 )
             )
-            braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED)
-            return
-        }
-
-        val applicationContext = context.applicationContext
-        val isVenmoAppInstalled = deviceInspector.isVenmoInstalled(applicationContext)
-        val isPayPalAppInstalled = deviceInspector.isPayPalInstalled(applicationContext)
-
-        if (isVenmoAppInstalled && isPayPalAppInstalled) {
-            callback.onResult(
-                ShopperInsightsResult.Success(
-                    ShopperInsightsInfo(
-                        isPayPalRecommended = true,
-                        isVenmoRecommended = true
-                    )
-                )
-            )
-            braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
             return
         }
 
@@ -94,7 +72,6 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
                 )
             }
         )
-        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
     }
 
     private fun handleFindEligiblePaymentsResult(
@@ -103,16 +80,17 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
         callback: ShopperInsightsCallback
     ) {
         when {
-            error != null -> callback.onResult(ShopperInsightsResult.Failure(error))
-            result?.eligibleMethods?.paypal == null &&
-                    result?.eligibleMethods?.venmo == null -> {
-                callback.onResult(
-                    ShopperInsightsResult.Failure(
-                        BraintreeException("Required fields missing from API response body")
-                    )
+            error != null -> callbackFailure(callback, error)
+
+            result?.eligibleMethods?.paypal == null && result?.eligibleMethods?.venmo == null -> {
+                callbackFailure(
+                    callback = callback,
+                    error = BraintreeException("Required fields missing from API response body")
                 )
             }
+
             else -> {
+                braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
                 callback.onResult(
                     ShopperInsightsResult.Success(
                         ShopperInsightsInfo(
@@ -127,6 +105,14 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
                 )
             }
         }
+    }
+
+    private fun callbackFailure(
+        callback: ShopperInsightsCallback,
+        error: Exception
+    ) {
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED)
+        callback.onResult(ShopperInsightsResult.Failure(error))
     }
 
     private fun isPaymentRecommended(paymentDetail: EligiblePaymentMethodDetails?): Boolean {

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -39,7 +39,7 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `when getRecommendedPaymentMethods is called, succeeded event is sent`() {
+    fun `when getRecommendedPaymentMethods is called, failed event is sent`() {
         val request = ShopperInsightsRequest(null, null)
 
         sut.getRecommendedPaymentMethods(request, mockk(relaxed = true))
@@ -244,7 +244,7 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `when getRecommendedPaymentMethods is called with null request, failed event is sent`() {
+    fun `when getRecommendedPaymentMethods is called with null request, succeeded event is sent`() {
         val result = EligiblePaymentsApiResult(
             EligiblePaymentMethods(
                 paypal = EligiblePaymentMethodDetails(

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -1,19 +1,15 @@
 package com.braintreepayments.api
 
-import android.content.Context
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for BraintreeShopperInsightsClient.
@@ -24,91 +20,30 @@ import org.junit.Test
  */
 class ShopperInsightsClientUnitTest {
 
-    private val context: Context = mockk(relaxed = true)
-    private val applicationContext: Context = mockk(relaxed = true)
     private lateinit var sut: ShopperInsightsClient
     private lateinit var api: ShopperInsightsApi
     private lateinit var braintreeClient: BraintreeClient
-    private lateinit var deviceInspector: DeviceInspector
 
     @Before
     fun beforeEach() {
         api = mockk(relaxed = true)
         braintreeClient = mockk(relaxed = true)
-        deviceInspector = mockk(relaxed = true)
-        every { context.applicationContext } returns applicationContext
-        sut = ShopperInsightsClient(api, braintreeClient, deviceInspector)
+        sut = ShopperInsightsClient(api, braintreeClient)
     }
 
-    /**
-     * Tests if the getRecommendedPaymentMethods method returns paypal and venmo recommendations
-     * when providing a shopping insight request.
-     */
     @Test
-    fun testGetRecommendedPaymentMethods_noInstalledApps_returnsDefaultRecommendations() {
-        every { deviceInspector.isVenmoInstalled(applicationContext) } returns false
-        every { deviceInspector.isPayPalInstalled(applicationContext) } returns false
+    fun `when getRecommendedPaymentMethods is called, started event is sent`() {
+        sut.getRecommendedPaymentMethods(mockk(relaxed = true), mockk(relaxed = true))
 
-        val request = ShopperInsightsRequest("fake-email", null)
-        sut.getRecommendedPaymentMethods(context, request) { result ->
-            assertNotNull(result)
-            val successResult = assertIs<ShopperInsightsResult.Success>(result)
-            assertFalse(successResult.response.isPayPalRecommended)
-            assertFalse(successResult.response.isVenmoRecommended)
-        }
         verifyStartedAnalyticsEvent()
-        verifySuccessAnalyticsEvent()
     }
 
     @Test
-    fun testGetRecommendedPaymentMethods_oneInstalledApp_returnsDefaultRecommendations() {
-        every { deviceInspector.isVenmoInstalled(applicationContext) } returns true
-        every { deviceInspector.isPayPalInstalled(applicationContext) } returns false
-
-        val request = ShopperInsightsRequest("fake-email", null)
-        sut.getRecommendedPaymentMethods(context, request) { result ->
-            assertNotNull(result)
-            val successResult = assertIs<ShopperInsightsResult.Success>(result)
-            assertFalse(successResult.response.isPayPalRecommended)
-            assertFalse(successResult.response.isVenmoRecommended)
-        }
-        verifyStartedAnalyticsEvent()
-        verifySuccessAnalyticsEvent()
-    }
-
-    @Test
-    fun testGetRecommendedPaymentMethods_hasBothAppsInstalled_returnsSuccessResult() {
-        every { deviceInspector.isVenmoInstalled(applicationContext) } returns true
-        every { deviceInspector.isPayPalInstalled(applicationContext) } returns true
-
-        val request = ShopperInsightsRequest("some-email", null)
-        sut.getRecommendedPaymentMethods(context, request) { result ->
-            assertNotNull(result)
-            val successResult = assertIs<ShopperInsightsResult.Success>(result)
-            assertTrue(successResult.response.isPayPalRecommended)
-            assertTrue(successResult.response.isVenmoRecommended)
-        }
-        verifyStartedAnalyticsEvent()
-        verifySuccessAnalyticsEvent()
-    }
-
-    @Test
-    fun `testGetRecommendedPaymentMethods - request object has null properties`() {
-        every { deviceInspector.isVenmoInstalled(applicationContext) } returns false
-        every { deviceInspector.isPayPalInstalled(applicationContext) } returns true
-
+    fun `when getRecommendedPaymentMethods is called, succeeded event is sent`() {
         val request = ShopperInsightsRequest(null, null)
-        sut.getRecommendedPaymentMethods(context, request) { result ->
-            assertNotNull(result)
-            val error = assertIs<ShopperInsightsResult.Failure>(result)
-            val iae = assertIs<IllegalArgumentException>(error.error)
-            assertEquals(
-                "One of ShopperInsightsRequest.email or " +
-                        "ShopperInsightsRequest.phone must be non-null.",
-                iae.message
-            )
-        }
-        verifyStartedAnalyticsEvent()
+
+        sut.getRecommendedPaymentMethods(request, mockk(relaxed = true))
+
         verifyFailedAnalyticsEvent()
     }
 
@@ -309,6 +244,29 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
+    fun `when getRecommendedPaymentMethods is called with null request, failed event is sent`() {
+        val result = EligiblePaymentsApiResult(
+            EligiblePaymentMethods(
+                paypal = EligiblePaymentMethodDetails(
+                    canBeVaulted = true,
+                    eligibleInPayPalNetwork = true,
+                    recommended = false,
+                    recommendedPriority = 1
+                ),
+                venmo = null
+            )
+        )
+
+        executeTestForFindEligiblePaymentsApi(
+            callback = mockk<ShopperInsightsCallback>(relaxed = true),
+            result = result,
+            error = null
+        )
+
+        verifySuccessAnalyticsEvent()
+    }
+
+    @Test
     fun `test paypal presented analytics event`() {
         sut.sendPayPalPresentedEvent()
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-presented") }
@@ -338,13 +296,10 @@ class ShopperInsightsClientUnitTest {
         result: EligiblePaymentsApiResult?,
         error: Exception?
     ) {
-        every { deviceInspector.isVenmoInstalled(applicationContext) } returns false
-        every { deviceInspector.isPayPalInstalled(applicationContext) } returns false
-
         val apiCallbackSlot = slot<EligiblePaymentsCallback>()
         every { api.findEligiblePayments(any(), capture(apiCallbackSlot)) } just runs
 
-        sut.getRecommendedPaymentMethods(context, request, callback)
+        sut.getRecommendedPaymentMethods(request, callback)
 
         apiCallbackSlot.captured.onResult(result = result, error = error)
     }


### PR DESCRIPTION
### Summary of changes

 - Removed the PayPal and Venmo app installed checks from the Shopper Insights module - the API call is now always executed.
 - Rearrange a few analytics calls to match iOS

### Checklist

 ~- [ ] Added a changelog entry~
~- [ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
