### PR TITLE
Add PayPal-Client-Metadata-Id to Shopper Insights API Call

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.kt
@@ -164,11 +164,11 @@ internal class AnalyticsClient @VisibleForTesting constructor(
             val analyticsRequest = serializeEvents(authorization, events, metadata)
             lastKnownAnalyticsUrl?.let { analyticsUrl ->
                 httpClient.post(
-                    analyticsUrl,
-                    analyticsRequest.toString(),
-                    null,
-                    authorization,
-                    HttpNoResponse()
+                    path = analyticsUrl,
+                    data = analyticsRequest.toString(),
+                    configuration = null,
+                    authorization = authorization,
+                    callback = HttpNoResponse()
                 )
             }
         } catch (e: JSONException) { /* ignored */

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ApiClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ApiClient.kt
@@ -35,7 +35,6 @@ class ApiClient(private val braintreeClient: BraintreeClient) {
             sendPOST(
                 url = url,
                 data = paymentMethod.buildJSON().toString(),
-                additionalHeaders = emptyMap(),
             ) { responseBody, httpError ->
                 parseResponseToJSON(responseBody)?.let { json ->
                     sendAnalyticsEvent("card.rest.tokenization.success")

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/ApiClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/ApiClient.kt
@@ -32,17 +32,19 @@ class ApiClient(private val braintreeClient: BraintreeClient) {
             paymentMethod.setSessionId(braintreeClient.sessionId)
 
             sendAnalyticsEvent("card.rest.tokenization.started")
-            sendPOST(url, paymentMethod.buildJSON().toString(), object : HttpResponseCallback {
-                override fun onResult(responseBody: String?, httpError: Exception?) {
-                    parseResponseToJSON(responseBody)?.let { json ->
-                        sendAnalyticsEvent("card.rest.tokenization.success")
-                        callback.onResult(json, null)
-                    } ?: httpError?.let { error ->
-                        sendAnalyticsEvent("card.rest.tokenization.failure")
-                        callback.onResult(null, error)
-                    }
+            sendPOST(
+                url = url,
+                data = paymentMethod.buildJSON().toString(),
+                additionalHeaders = emptyMap(),
+            ) { responseBody, httpError ->
+                parseResponseToJSON(responseBody)?.let { json ->
+                    sendAnalyticsEvent("card.rest.tokenization.success")
+                    callback.onResult(json, null)
+                } ?: httpError?.let { error ->
+                    sendAnalyticsEvent("card.rest.tokenization.failure")
+                    callback.onResult(null, error)
                 }
-            })
+            }
         }
 
     private fun parseResponseToJSON(responseBody: String?): JSONObject? =

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -260,17 +260,24 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @suppress
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun sendPOST(url: String, data: String, responseCallback: HttpResponseCallback) {
+    @JvmOverloads
+    fun sendPOST(
+        url: String,
+        data: String,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        responseCallback: HttpResponseCallback,
+    ) {
         getAuthorization { authorization, authError ->
             if (authorization != null) {
                 getConfiguration { configuration, configError ->
                     if (configuration != null) {
                         httpClient.post(
-                            url,
-                            data,
-                            configuration,
-                            authorization,
-                            responseCallback
+                            path = url,
+                            data = data,
+                            configuration = configuration,
+                            authorization = authorization,
+                            additionalHeaders = additionalHeaders,
+                            callback = responseCallback
                         )
                     } else {
                         responseCallback.onResult(null, configError)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeHttpClient.kt
@@ -89,6 +89,7 @@ internal class BraintreeHttpClient(
         data: String,
         configuration: Configuration?,
         authorization: Authorization?,
+        additionalHeaders: Map<String, String> = emptyMap(),
         callback: HttpResponseCallback
     ) {
         if (authorization is InvalidAuthorization) {
@@ -126,6 +127,7 @@ internal class BraintreeHttpClient(
             request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
         authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token") }
+        additionalHeaders.forEach { (name, value) -> request.addHeader(name, value) }
         httpClient.sendRequest(request, callback)
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/AnalyticsClientUnitTest.kt
@@ -351,11 +351,11 @@ class AnalyticsClientUnitTest {
         val analyticsJSONSlot = slot<String>()
         every {
             httpClient.post(
-                "analytics_url",
-                capture(analyticsJSONSlot),
-                isNull(),
-                authorization,
-                any()
+                path = "analytics_url",
+                data = capture(analyticsJSONSlot),
+                configuration = isNull(),
+                authorization = authorization,
+                callback = any()
             )
         } returns Unit
 
@@ -412,20 +412,20 @@ class AnalyticsClientUnitTest {
 
     companion object {
         private fun createSampleDeviceMetadata() = DeviceMetadata(
-                integration = "sample-integration",
-                sessionId = "sample-session-id",
-                platform = "platform",
-                sdkVersion = "sdk-version",
-                deviceManufacturer = "device-manufacturer",
-                deviceModel = "device-model",
-                platformVersion = "platform-version",
-                merchantAppName = "merchant-app-name",
-                devicePersistentUUID = "persistent-uuid",
-                merchantAppId = "merchant-app-name",
-                userOrientation = "user-orientation",
-                isPayPalInstalled = true,
-                isVenmoInstalled = true,
-                isSimulator = false
-            )
+            integration = "sample-integration",
+            sessionId = "sample-session-id",
+            platform = "platform",
+            sdkVersion = "sdk-version",
+            deviceManufacturer = "device-manufacturer",
+            deviceModel = "device-model",
+            platformVersion = "platform-version",
+            merchantAppName = "merchant-app-name",
+            devicePersistentUUID = "persistent-uuid",
+            merchantAppId = "merchant-app-name",
+            userOrientation = "user-orientation",
+            isPayPalInstalled = true,
+            isVenmoInstalled = true,
+            isSimulator = false
+        )
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
@@ -221,15 +221,15 @@ class BraintreeClientUnitTest {
         val sut = BraintreeClient(params)
 
         val httpResponseCallback = mockk<HttpResponseCallback>(relaxed = true)
-        sut.sendPOST("sample-url", "{}", httpResponseCallback)
+        sut.sendPOST("sample-url", "{}", emptyMap(), httpResponseCallback)
 
         verify {
             braintreeHttpClient.post(
-                "sample-url",
-                "{}",
-                configuration,
-                authorization,
-                httpResponseCallback
+                path = "sample-url",
+                data = "{}",
+                configuration = configuration,
+                authorization = authorization,
+                callback = httpResponseCallback
             )
         }
     }
@@ -246,7 +246,7 @@ class BraintreeClientUnitTest {
 
         val sut = BraintreeClient(params)
         val httpResponseCallback = mockk<HttpResponseCallback>(relaxed = true)
-        sut.sendPOST("sample-url", "{}", httpResponseCallback)
+        sut.sendPOST("sample-url", "{}", emptyMap(), httpResponseCallback)
 
         verify { httpResponseCallback.onResult(null, authError) }
     }
@@ -266,8 +266,68 @@ class BraintreeClientUnitTest {
         val sut = BraintreeClient(params)
         val httpResponseCallback = mockk<HttpResponseCallback>(relaxed = true)
 
-        sut.sendPOST("sample-url", "{}", httpResponseCallback)
+        sut.sendPOST("sample-url", "{}", emptyMap(), httpResponseCallback)
         verify { httpResponseCallback.onResult(null, exception) }
+    }
+
+    @Test
+    fun `sendPOST defaults additionalHeaders to an empty map`() {
+        val authorizationLoader = MockkAuthorizationLoaderBuilder()
+            .authorization(authorization)
+            .build()
+        val configurationLoader = MockkConfigurationLoaderBuilder()
+            .configuration(mockk<Configuration>(relaxed = true))
+            .build()
+        val params = createDefaultParams(configurationLoader, authorizationLoader)
+        val sut = BraintreeClient(params)
+
+        sut.sendPOST(
+            url = "sample-url",
+            data = "{}",
+            responseCallback = mockk(relaxed = true)
+        )
+
+        verify {
+            braintreeHttpClient.post(
+                path = any(),
+                data = any(),
+                configuration = any(),
+                authorization = any(),
+                additionalHeaders = emptyMap(),
+                callback = any()
+            )
+        }
+    }
+
+    @Test
+    fun `sendPOST sends additionalHeaders to httpClient post`() {
+        val authorizationLoader = MockkAuthorizationLoaderBuilder()
+            .authorization(authorization)
+            .build()
+        val configurationLoader = MockkConfigurationLoaderBuilder()
+            .configuration(mockk<Configuration>(relaxed = true))
+            .build()
+        val params = createDefaultParams(configurationLoader, authorizationLoader)
+        val sut = BraintreeClient(params)
+        val headers = mapOf("name" to "value")
+
+        sut.sendPOST(
+            url = "sample-url",
+            data = "{}",
+            additionalHeaders = headers,
+            responseCallback = mockk(relaxed = true)
+        )
+
+        verify {
+            braintreeHttpClient.post(
+                path = any(),
+                data = any(),
+                configuration = any(),
+                authorization = any(),
+                additionalHeaders = headers,
+                callback = any()
+            )
+        }
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.kt
@@ -472,6 +472,5 @@ class BraintreeHttpClientUnitTest {
                 assertEquals(it.headers["name2"], "value2")
             }, callback)
         }
-
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeHttpClientUnitTest.kt
@@ -5,6 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.verify
 import org.json.JSONException
 import org.junit.Assert.*
 import org.junit.Before
@@ -26,7 +27,7 @@ class BraintreeHttpClientUnitTest {
 
     @Before
     fun beforeEach() {
-        httpClient = mockk()
+        httpClient = mockk(relaxed = true)
         httpResponseCallback = mockk()
     }
 
@@ -255,7 +256,13 @@ class BraintreeHttpClientUnitTest {
         every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("sample/path", "{}", configuration, tokenizationKey, callback)
+        sut.post(
+            path = "sample/path",
+            data = "{}",
+            configuration = configuration,
+            authorization = tokenizationKey,
+            callback = callback
+        )
 
         val httpRequest = httpRequestSlot.captured
         val headers = httpRequest.headers
@@ -281,7 +288,13 @@ class BraintreeHttpClientUnitTest {
         every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("sample/path", "{}", configuration, clientToken, callback)
+        sut.post(
+            path = "sample/path",
+            data = "{}",
+            configuration = configuration,
+            authorization = clientToken,
+            callback = callback
+        )
 
         val httpRequest = httpRequestSlot.captured
         val headers = httpRequest.headers
@@ -305,7 +318,13 @@ class BraintreeHttpClientUnitTest {
         every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("sample/path", "{}", null, clientToken, callback)
+        sut.post(
+            path = "sample/path",
+            data = "{}",
+            configuration = null,
+            authorization = clientToken,
+            callback = callback
+        )
 
         val exception = exceptionSlot.captured
         assertEquals(
@@ -326,7 +345,13 @@ class BraintreeHttpClientUnitTest {
         every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("https://example.com/sample/path", "{}", null, clientToken, callback)
+        sut.post(
+            path = "https://example.com/sample/path",
+            data = "{}",
+            configuration = null,
+            authorization = clientToken,
+            callback = callback
+        )
 
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
@@ -345,7 +370,13 @@ class BraintreeHttpClientUnitTest {
         every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("sample/path", "not json", configuration, clientToken, callback)
+        sut.post(
+            path = "sample/path",
+            data = "not json",
+            configuration = configuration,
+            authorization = clientToken,
+            callback = callback
+        )
 
         val exception = exceptionSlot.captured
         assertEquals(
@@ -365,7 +396,13 @@ class BraintreeHttpClientUnitTest {
         every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post("sample/path", "{}", configuration, authorization, callback)
+        sut.post(
+            path = "sample/path",
+            data = "{}",
+            configuration = configuration,
+            authorization = authorization,
+            callback = callback
+        )
 
         val exception = exceptionSlot.captured
         assertEquals("token invalid", exception.message)
@@ -412,5 +449,29 @@ class BraintreeHttpClientUnitTest {
 
         val headers = httpRequestSlot.captured.headers
         assertNull(headers["Authorization"])
+    }
+
+    @Test
+    fun `when post is called with additional headers, headers are added to the request`() {
+        val headers = mapOf("name1" to "value1", "name2" to "value2")
+        val callback = mockk<HttpResponseCallback>()
+        val sut = BraintreeHttpClient(httpClient)
+
+        sut.post(
+            path = "sample/path",
+            data = "{}",
+            configuration = mockk(relaxed = true),
+            authorization = mockk(relaxed = true),
+            additionalHeaders = headers,
+            callback = callback
+        )
+
+        verify {
+            httpClient.sendRequest(withArg {
+                assertEquals(it.headers["name1"], "value1")
+                assertEquals(it.headers["name2"], "value2")
+            }, callback)
+        }
+
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/HttpResponseCallback.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/HttpResponseCallback.kt
@@ -7,7 +7,7 @@ import androidx.annotation.RestrictTo
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface HttpResponseCallback {
+fun interface HttpResponseCallback {
 
     @MainThread
     fun onResult(responseBody: String?, httpError: Exception?)


### PR DESCRIPTION
### Summary of changes

 - Add the `PayPal-Client-Metadata-Id` header to the Shopper Insights API call
 - Pass `addtionalHeaders` all the way down to `BraintreeHttpClient` to be added to the request
 - Added named parameters to certain call sites to utilize the empty map default value while keeping the callback param the last in the list

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
