### PR TITLE
[Shopper Insights] Demo App Parity

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -21,6 +21,8 @@ class ShopperInsightsFragment : BaseFragment() {
 
     private lateinit var responseTextView: TextView
     private lateinit var actionButton: Button
+    private lateinit var paypalVaultButton: Button
+    private lateinit var venmoButton: Button
     private lateinit var emailInput: TextInputLayout
     private lateinit var countryCodeInput: TextInputLayout
     private lateinit var nationalNumberInput: TextInputLayout
@@ -53,6 +55,10 @@ class ShopperInsightsFragment : BaseFragment() {
         nationalNumberInput = view.findViewById(R.id.nationalNumberInput)
         emailNullSwitch = view.findViewById(R.id.emailNullSwitch)
         phoneNullSwitch = view.findViewById(R.id.phoneNullSwitch)
+
+        emailInput.editText?.setText("PR1_merchantname@personal.example.com")
+        nationalNumberInput.editText?.setText("408-232-1001")
+        countryCodeInput.editText?.setText("1")
     }
 
     private fun setupActionButton() {
@@ -73,12 +79,16 @@ class ShopperInsightsFragment : BaseFragment() {
                 requireContext(),
                 request
             ) { result ->
-                responseTextView.text = when (result) {
+                when (result) {
                     is ShopperInsightsResult.Success -> {
-                        "PayPal Recommended ${result.response.isPayPalRecommended} " +
-                                "\n Venmo Recommended ${result.response.isVenmoRecommended}"
+                        paypalVaultButton.isEnabled = result.response.isPayPalRecommended
+                        paypalVaultButton.isEnabled = result.response.isVenmoRecommended
+
+                        responseTextView.text = "PayPal Recommended ${result.response.isPayPalRecommended} " + "\n Venmo Recommended ${result.response.isVenmoRecommended}"
                     }
-                    is ShopperInsightsResult.Failure -> result.error.toString()
+                    is ShopperInsightsResult.Failure -> {
+                        responseTextView.text = result.error.toString()
+                    }
                 }
             }
         }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
 import com.braintreepayments.api.BraintreeClient
 import com.braintreepayments.api.PayPalAccountNonce
@@ -51,8 +50,9 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
     ): View? {
         braintreeClient = getBraintreeClient()
         shopperInsightsClient = ShopperInsightsClient(braintreeClient)
-        payPalClient = PayPalClient(braintreeClient)
+
         venmoClient = VenmoClient(this, braintreeClient)
+        venmoClient.setListener(this)
 
         val useManualBrowserSwitch = Settings.isManualBrowserSwitchingEnabled(requireActivity())
         if (useManualBrowserSwitch) {
@@ -131,7 +131,12 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
 
     private fun launchVenmo() {
         val venmoRequest = VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE)
+        venmoRequest.profileId = null
+        venmoRequest.collectCustomerBillingAddress = true
+        venmoRequest.collectCustomerShippingAddress = true
         venmoRequest.totalAmount = "20"
+        venmoRequest.subTotalAmount = "18"
+        venmoRequest.taxAmount = "1"
 
         venmoClient.tokenizeVenmoAccount(requireActivity(), venmoRequest)
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -7,10 +7,14 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import com.braintreepayments.api.BraintreeClient
+import com.braintreepayments.api.PayPalClient
 import com.braintreepayments.api.ShopperInsightsBuyerPhone
 import com.braintreepayments.api.ShopperInsightsClient
 import com.braintreepayments.api.ShopperInsightsRequest
 import com.braintreepayments.api.ShopperInsightsResult
+import com.braintreepayments.api.VenmoClient
+import com.braintreepayments.api.VenmoPaymentMethodUsage
+import com.braintreepayments.api.VenmoRequest
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
 
@@ -21,15 +25,18 @@ class ShopperInsightsFragment : BaseFragment() {
 
     private lateinit var responseTextView: TextView
     private lateinit var actionButton: Button
-    private lateinit var paypalVaultButton: Button
+    private lateinit var payPalVaultButton: Button
     private lateinit var venmoButton: Button
     private lateinit var emailInput: TextInputLayout
     private lateinit var countryCodeInput: TextInputLayout
     private lateinit var nationalNumberInput: TextInputLayout
     private lateinit var emailNullSwitch: SwitchMaterial
     private lateinit var phoneNullSwitch: SwitchMaterial
+
     private lateinit var braintreeClient: BraintreeClient
     private lateinit var shopperInsightsClient: ShopperInsightsClient
+    private lateinit var payPalClient: PayPalClient
+    private lateinit var venmoClient: VenmoClient
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,18 +45,25 @@ class ShopperInsightsFragment : BaseFragment() {
     ): View? {
         braintreeClient = getBraintreeClient()
         shopperInsightsClient = ShopperInsightsClient(braintreeClient)
+        payPalClient = PayPalClient(braintreeClient)
+        venmoClient = VenmoClient(this, braintreeClient)
         return inflater.inflate(R.layout.fragment_shopping_insights, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initializeViews(view)
-        setupActionButton()
+
+        actionButton.setOnClickListener { fetchShopperInsights() }
+        venmoButton.setOnClickListener { launchVenmo() }
+        payPalVaultButton.setOnClickListener{ launchPayPalVault() }
     }
 
     private fun initializeViews(view: View) {
         responseTextView = view.findViewById(R.id.responseTextView)
         actionButton = view.findViewById(R.id.actionButton)
+        payPalVaultButton = view.findViewById(R.id.payPalVaultButton)
+        venmoButton = view.findViewById(R.id.venmoButton)
         emailInput = view.findViewById(R.id.emailInput)
         countryCodeInput = view.findViewById(R.id.countryCodeInput)
         nationalNumberInput = view.findViewById(R.id.nationalNumberInput)
@@ -61,36 +75,50 @@ class ShopperInsightsFragment : BaseFragment() {
         countryCodeInput.editText?.setText("1")
     }
 
-    private fun setupActionButton() {
-        actionButton.setOnClickListener {
-            val email =
-                if (emailNullSwitch.isChecked) null else emailInput.editText?.text.toString()
-            val countryCode =
-                if (phoneNullSwitch.isChecked) null else countryCodeInput.editText?.text.toString()
-            val nationalNumber =
-                if (phoneNullSwitch.isChecked) null else nationalNumberInput.editText?.text.toString()
+    private fun fetchShopperInsights() {
+        val email =
+            if (emailNullSwitch.isChecked) null else emailInput.editText?.text.toString()
+        val countryCode =
+            if (phoneNullSwitch.isChecked) null else countryCodeInput.editText?.text.toString()
+        val nationalNumber =
+            if (phoneNullSwitch.isChecked) null else nationalNumberInput.editText?.text.toString()
 
-            val request = if (countryCode != null && nationalNumber != null) {
-                ShopperInsightsRequest(email, ShopperInsightsBuyerPhone(countryCode, nationalNumber))
-            } else {
-                ShopperInsightsRequest(email, null)
-            }
-            shopperInsightsClient.getRecommendedPaymentMethods(
-                requireContext(),
-                request
-            ) { result ->
-                when (result) {
-                    is ShopperInsightsResult.Success -> {
-                        paypalVaultButton.isEnabled = result.response.isPayPalRecommended
-                        paypalVaultButton.isEnabled = result.response.isVenmoRecommended
+        val request = if (countryCode != null && nationalNumber != null) {
+            ShopperInsightsRequest(email, ShopperInsightsBuyerPhone(countryCode, nationalNumber))
+        } else {
+            ShopperInsightsRequest(email, null)
+        }
+        shopperInsightsClient.getRecommendedPaymentMethods(
+            requireContext(),
+            request
+        ) { result ->
+            when (result) {
+                is ShopperInsightsResult.Success -> {
+                    payPalVaultButton.isEnabled = result.response.isPayPalRecommended
+                    venmoButton.isEnabled = result.response.isVenmoRecommended
 
-                        responseTextView.text = "PayPal Recommended ${result.response.isPayPalRecommended} " + "\n Venmo Recommended ${result.response.isVenmoRecommended}"
-                    }
-                    is ShopperInsightsResult.Failure -> {
-                        responseTextView.text = result.error.toString()
-                    }
+                    responseTextView.text =
+                        "PayPal Recommended ${result.response.isPayPalRecommended} " + "\n Venmo Recommended ${result.response.isVenmoRecommended}"
+                }
+
+                is ShopperInsightsResult.Failure -> {
+                    responseTextView.text = result.error.toString()
                 }
             }
         }
     }
+    private fun launchPayPalVault() {
+        payPalClient.tokenizePayPalAccount(
+            requireActivity(),
+            PayPalRequestFactory.createPayPalVaultRequest(activity)
+        )
+    }
+
+    private fun launchVenmo() {
+        val venmoRequest = VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE)
+        venmoRequest.totalAmount = "20"
+
+        venmoClient.tokenizeVenmoAccount(requireActivity(), venmoRequest)
+    }
+
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -71,7 +71,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
 
         actionButton.setOnClickListener { fetchShopperInsights() }
         venmoButton.setOnClickListener { launchVenmo() }
-        payPalVaultButton.setOnClickListener{ launchPayPalVault() }
+        payPalVaultButton.setOnClickListener { launchPayPalVault() }
     }
 
     private fun initializeViews(view: View) {
@@ -112,7 +112,10 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
                     venmoButton.isEnabled = result.response.isVenmoRecommended
 
                     responseTextView.text =
-                        "PayPal Recommended ${result.response.isPayPalRecommended} " + "\n Venmo Recommended ${result.response.isVenmoRecommended}"
+                        """
+                            PayPal Recommended: ${result.response.isPayPalRecommended}
+                            Venmo Recommended: ${result.response.isVenmoRecommended}
+                        """.trimIndent()
                 }
 
                 is ShopperInsightsResult.Failure -> {

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -54,7 +54,13 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         payPalClient = PayPalClient(braintreeClient)
         venmoClient = VenmoClient(this, braintreeClient)
 
-        payPalClient.setListener(this)
+        val useManualBrowserSwitch = Settings.isManualBrowserSwitchingEnabled(requireActivity())
+        if (useManualBrowserSwitch) {
+            payPalClient = PayPalClient(braintreeClient)
+        } else {
+            payPalClient = PayPalClient(this, braintreeClient)
+            payPalClient.setListener(this)
+        }
 
         return inflater.inflate(R.layout.fragment_shopping_insights, container, false)
     }
@@ -80,7 +86,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         phoneNullSwitch = view.findViewById(R.id.phoneNullSwitch)
 
         emailInput.editText?.setText("PR1_merchantname@personal.example.com")
-        nationalNumberInput.editText?.setText("408-232-1001")
+        nationalNumberInput.editText?.setText("4082321001")
         countryCodeInput.editText?.setText("1")
     }
 
@@ -132,7 +138,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
 
     override fun onPayPalSuccess(payPalAccountNonce: PayPalAccountNonce) {
         super.onPaymentMethodNonceCreated(payPalAccountNonce)
-        val action = PayPalFragmentDirections.actionPayPalFragmentToDisplayNonceFragment(
+        val action = ShopperInsightsFragmentDirections.actionShopperInsightsFragmentToDisplayNonceFragment(
             payPalAccountNonce
         )
         NavHostFragment.findNavController(this).navigate(action)
@@ -145,8 +151,9 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
     override fun onVenmoSuccess(venmoAccountNonce: VenmoAccountNonce) {
         super.onPaymentMethodNonceCreated(venmoAccountNonce)
 
-        val action: NavDirections =
-            VenmoFragmentDirections.actionVenmoFragmentToDisplayNonceFragment(venmoAccountNonce)
+        val action = ShopperInsightsFragmentDirections.actionShopperInsightsFragmentToDisplayNonceFragment(
+            venmoAccountNonce
+        )
         NavHostFragment.findNavController(this).navigate(action)
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -103,6 +103,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         } else {
             ShopperInsightsRequest(email, null)
         }
+
         shopperInsightsClient.getRecommendedPaymentMethods(
             request
         ) { result ->
@@ -124,6 +125,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
             }
         }
     }
+    
     private fun launchPayPalVault() {
         payPalClient.tokenizePayPalAccount(
             requireActivity(),

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -125,7 +125,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
             }
         }
     }
-    
+
     private fun launchPayPalVault() {
         payPalClient.tokenizePayPalAccount(
             requireActivity(),

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context=".ShopperInsightsFragment">
 
     <View
         android:id="@+id/view2"
@@ -110,6 +111,7 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_paypal_vault_button"
+        android:enabled="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/actionButton" />
@@ -122,6 +124,7 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_venmo_button"
+        android:enabled="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -25,7 +25,7 @@
         android:text="@string/insights_response_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/actionButton" />
+        app:layout_constraintTop_toBottomOf="@+id/venmoButton" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/countryCodeInput"
@@ -101,6 +101,32 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/countryCodeInput" />
+
+    <Button
+        android:id="@+id/paypalVaultButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/insights_paypal_vault_button"
+        android:enabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/actionButton" />
+
+    <Button
+        android:id="@+id/venmoButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/insights_venmo_button"
+        android:enabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/paypalVaultButton" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/emailNullSwitch"

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -103,7 +103,7 @@
         app:layout_constraintTop_toBottomOf="@+id/countryCodeInput" />
 
     <Button
-        android:id="@+id/paypalVaultButton"
+        android:id="@+id/payPalVaultButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -126,7 +126,7 @@
         android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/paypalVaultButton" />
+        app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/emailNullSwitch"

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -110,7 +110,6 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_paypal_vault_button"
-        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/actionButton" />
@@ -123,7 +122,6 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_venmo_button"
-        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -111,7 +111,7 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_paypal_vault_button"
-        android:enabled="true"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/actionButton" />
@@ -124,7 +124,7 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
         android:text="@string/insights_venmo_button"
-        android:enabled="true"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -35,11 +35,14 @@
             android:id="@+id/action_mainFragment_to_sepaDirectDebitFragment"
             app:destination="@id/SEPADirectDebitFragment" />
         <action
+            android:id="@+id/action_mainFragment_to_shopperInsightsFragment"
+            app:destination="@id/shopperInsightsFragment" />
+        <action
             android:id="@+id/action_mainFragment_to_payPalNativeCheckoutFragment"
             app:destination="@id/payPalNativeCheckoutFragment" />
         <action
             android:id="@+id/action_mainFragment_to_shoppingInsightsFragment"
-            app:destination="@id/shoppingInsightsFragment" />
+            app:destination="@id/shopperInsightsFragment" />
     </fragment>
     <fragment
         android:id="@+id/cardFragment"
@@ -183,8 +186,13 @@
             app:popUpToInclusive="false" />
     </fragment>
     <fragment
-        android:id="@+id/shoppingInsightsFragment"
+        android:id="@+id/shopperInsightsFragment"
         android:name="com.braintreepayments.demo.ShopperInsightsFragment"
-        tools:layout="@layout/fragment_shopping_insights">
+        tools:layout="@layout/fragment_shopping_insights" >
+        <action
+            android:id="@+id/action_shopperInsightsFragment_to_displayNonceFragment"
+            app:destination="@id/displayNonceFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
 </navigation>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -129,7 +129,9 @@
     <string name="insights_text_input_email">Email</string>
     <string name="insights_text_input_country_code">Country Code</string>
     <string name="insights_text_input_national_number">National Number</string>
-    <string name="insights_action_button">Submit</string>
+    <string name="insights_action_button">Fetch Shopper Insights</string>
+    <string name="insights_venmo_button">Venmo</string>
+    <string name="insights_paypal_vault_button">PayPal Vault</string>
     <string name="insights_response_label">Response:</string>
     <string name="insights_null_switch">Null </string>
 </resources>


### PR DESCRIPTION
See similar [iOS PR](https://github.com/braintree/braintree_ios/pull/1185). The goal is to align our Demo app's functionality for QA testers to easily use.

### Summary of changes

 - Add Venmo & PayPal Vault buttons to ShopperInsights demo for use after `getRecommendedPaymentMethods()` returns a result
    - Add Venmo & PP listeners
    - Add navigation logic to nonce creation & transaction.sale() screen
    - Disable Venmo & PP buttons until `getRecommendedPaymentMethods()` returns `isRecommended` booleans
 - Add default email & phone test values to trigger mocked API response

### Notes

- This demo requires that Settings select "Client Token" as the auth type
    - We should consider returning an error to the merchant if they attempt to use a tokenization key in follow up PRs
- There's a mixed use of "shopper" and "shopping" terminology throughout the demo app. Let's stay consistent and use "shopper" only in a follow-up PR

### Compare iOS & Android Demos

| iOS      | Android |
| ----------- | ----------- |
|  ![ScreenRecording2024-02-07at5 58 07PM-ezgif com-video-to-gif-converter](https://github.com/braintree/braintree_android/assets/35243507/2f42dac2-2108-4fe9-a1a5-7b540cbdce98) | ![ScreenRecording2024-02-07at5 56 38PM-ezgif com-video-to-gif-converter](https://github.com/braintree/braintree_android/assets/35243507/1f20fc57-a300-4186-8a10-9236a6a0127c)       |


### Checklist

 - ~Added a changelog entry~
 - ~Relevant test coverage~

### Authors
@scannillo 