### PR TITLE
Add PayPal Messaging Feature to Demo App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * PayPalMessaging (BETA)
   * Add `PayPalMessagingRequest`, `PayPalMessagingColor`, `PayPalMessagingLogoType`, `PayPalMessagingOfferType`, `PayPalMessagingPlacement`, `PayPalMessagingTextAlignment`, and `PayPalMessagingListener`
-  * Add `PayPalMessagingView` to display PayPal messages to promote offers such as Pay Later and PayPal Credit to customers.
-    * To get started call `PayPalMessagingView#start(Context)` with an optional `PayPalMessagingRequest`
+  * Add `PayPalMessagingView(BraintreeClient, Context)` to display PayPal messages to promote offers such as Pay Later and PayPal Credit to customers.
+    * To get started call `PayPalMessagingView#start()` with an optional `PayPalMessagingRequest`
 
 ## 4.41.0 (2024-01-18)
 

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'androidx.navigation.safeargs'
+    id 'kotlin-android'
 }
 
 android {
@@ -75,6 +76,7 @@ android {
 
 dependencies {
     implementation 'androidx.preference:preference:1.1.1'
+    implementation deps.kotlinStdLib
 
     implementation('com.squareup.retrofit:retrofit:1.9.0') {
         exclude module: 'com.google.gson'
@@ -86,6 +88,7 @@ dependencies {
     implementation project(':GooglePay')
     implementation project(':LocalPayment')
     implementation project(':PayPal')
+    implementation project(':PayPalMessaging')
     implementation project(':PayPalNativeCheckout')
     implementation project(':SamsungPay')
     implementation project(':SEPADirectDebit')

--- a/Demo/src/main/java/com/braintreepayments/demo/MainFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainFragment.java
@@ -37,6 +37,7 @@ public class MainFragment extends BaseFragment {
         Button samsungButton = view.findViewById(R.id.samsung_pay);
         Button sepaDirectDebitButton = view.findViewById(R.id.sepa_debit);
         Button payPalNativeCheckoutButton = view.findViewById(R.id.paypal_native_checkout);
+        Button payPalMessagingButton = view.findViewById(R.id.paypal_messaging);
 
         cardsButton.setOnClickListener(this::launchCards);
         payPalButton.setOnClickListener(this::launchPayPal);
@@ -47,6 +48,7 @@ public class MainFragment extends BaseFragment {
         samsungButton.setOnClickListener(this::launchSamsungPay);
         payPalNativeCheckoutButton.setOnClickListener(this::launchPayPalNativeCheckout);
         sepaDirectDebitButton.setOnClickListener(this::launchSEPADirectDebit);
+        payPalMessagingButton.setOnClickListener(this::launchPayPalMessaging);
 
         return view;
     }
@@ -124,6 +126,12 @@ public class MainFragment extends BaseFragment {
 
     public void launchSEPADirectDebit(View v) {
         NavDirections action = MainFragmentDirections.actionMainFragmentToSepaDirectDebitFragment();
+        Navigation.findNavController(v).navigate(action);
+    }
+
+    public void launchPayPalMessaging(View v) {
+        NavDirections action =
+                MainFragmentDirections.actionMainFragmentToPayPalMessagingFragment();
         Navigation.findNavController(v).navigate(action);
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
@@ -1,0 +1,58 @@
+package com.braintreepayments.demo
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.braintreepayments.api.PayPalMessagingListener
+import com.braintreepayments.api.PayPalMessagingLogoType
+import com.braintreepayments.api.PayPalMessagingOfferType
+import com.braintreepayments.api.PayPalMessagingRequest
+import com.braintreepayments.api.PayPalMessagingTextAlignment
+import com.braintreepayments.api.PayPalMessagingView
+
+class PayPalMessagingFragment: BaseFragment(), PayPalMessagingListener {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_paypal_messaging, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val payPalMessagingRequest = PayPalMessagingRequest(
+            2.0,
+            null,
+            PayPalMessagingOfferType.PAY_LATER_LONG_TERM,
+            "US",
+            PayPalMessagingLogoType.PRIMARY,
+            PayPalMessagingTextAlignment.CENTER,
+            null
+        )
+
+        var payPalMessagingView = PayPalMessagingView(braintreeClient)
+        payPalMessagingView.payPalMessagingListener = this
+        payPalMessagingView.start(requireActivity(), payPalMessagingRequest)
+    }
+    override fun onPayPalMessagingClick() {
+        print("User clicked on the PayPalMessagingView")
+    }
+
+    override fun onPayPalMessagingApply() {
+        print("User is attempting to apply for PayPal Credit")
+    }
+
+    override fun onPayPalMessagingLoading() {
+        print("Loading PayPalMessagingView")
+    }
+
+    override fun onPayPalMessagingSuccess() {
+        print("PayPalMessagingView displayed to user")
+    }
+
+    override fun onPayPalMessagingFailure(error: Exception) {
+        print("PayPalMessagingView returned the error:" + error.message)
+    }
+}

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.core.view.isVisible
 import com.braintreepayments.api.PayPalMessagingListener
 import com.braintreepayments.api.PayPalMessagingLogoType
 import com.braintreepayments.api.PayPalMessagingOfferType
@@ -22,6 +24,7 @@ class PayPalMessagingFragment: BaseFragment(), PayPalMessagingListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         val payPalMessagingRequest = PayPalMessagingRequest(
             2.0,
             null,
@@ -32,10 +35,18 @@ class PayPalMessagingFragment: BaseFragment(), PayPalMessagingListener {
             null
         )
 
-        var payPalMessagingView = PayPalMessagingView(braintreeClient)
+        var payPalMessagingView = PayPalMessagingView(braintreeClient, requireActivity())
         payPalMessagingView.payPalMessagingListener = this
-        payPalMessagingView.start(requireActivity(), payPalMessagingRequest)
+        payPalMessagingView.start(payPalMessagingRequest)
+        payPalMessagingView.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
+
+        val messagingView: LinearLayout = view.findViewById(R.id.content)
+        messagingView.addView(payPalMessagingView)
     }
+
     override fun onPayPalMessagingClick() {
         print("User clicked on the PayPalMessagingView")
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalMessagingFragment.kt
@@ -26,13 +26,13 @@ class PayPalMessagingFragment: BaseFragment(), PayPalMessagingListener {
         super.onViewCreated(view, savedInstanceState)
 
         val payPalMessagingRequest = PayPalMessagingRequest(
-            2.0,
-            null,
-            PayPalMessagingOfferType.PAY_LATER_LONG_TERM,
-            "US",
-            PayPalMessagingLogoType.PRIMARY,
-            PayPalMessagingTextAlignment.CENTER,
-            null
+            amount = 2.0,
+            placement = null,
+            offerType = PayPalMessagingOfferType.PAY_LATER_LONG_TERM,
+            buyerCountry = "US",
+            logoType = PayPalMessagingLogoType.PRIMARY,
+            textAlignment = PayPalMessagingTextAlignment.CENTER,
+            color = null
         )
 
         var payPalMessagingView = PayPalMessagingView(braintreeClient, requireActivity())

--- a/Demo/src/main/res/layout/fragment_main.xml
+++ b/Demo/src/main/res/layout/fragment_main.xml
@@ -23,6 +23,14 @@
             android:text="@string/cards"
             android:textSize="12sp" />
 
+        <Button
+            android:id="@+id/paypal_messaging"
+            style="?android:attr/buttonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/paypal_messaging_button"
+            android:textSize="12sp" />
     </TableRow>
 
     <TableRow

--- a/Demo/src/main/res/layout/fragment_paypal_messaging.xml
+++ b/Demo/src/main/res/layout/fragment_paypal_messaging.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:context=".PayPalMessagingFragment"/>

--- a/Demo/src/main/res/layout/fragment_paypal_messaging.xml
+++ b/Demo/src/main/res/layout/fragment_paypal_messaging.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/content"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:context=".PayPalMessagingFragment"/>
+    android:layout_height="100dp"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:padding="10dp"
+    tools:context=".PayPalMessagingFragment" />

--- a/Demo/src/main/res/layout/fragment_paypal_messaging.xml
+++ b/Demo/src/main/res/layout/fragment_paypal_messaging.xml
@@ -3,8 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/content"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
-    android:gravity="center"
-    android:orientation="horizontal"
+    android:layout_height="80dp"
+    android:orientation="vertical"
+    android:layout_gravity="center_vertical"
     android:padding="10dp"
     tools:context=".PayPalMessagingFragment" />

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -37,6 +37,9 @@
         <action
             android:id="@+id/action_mainFragment_to_payPalNativeCheckoutFragment"
             app:destination="@id/payPalNativeCheckoutFragment" />
+        <action
+            android:id="@+id/action_mainFragment_to_payPalMessagingFragment"
+            app:destination="@id/payPalMessagingFragment" />
     </fragment>
     <fragment
         android:id="@+id/cardFragment"
@@ -178,6 +181,11 @@
             app:destination="@id/displayNonceFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
+    </fragment>
+    <fragment
+        android:id="@+id/payPalMessagingFragment"
+        android:name="com.braintreepayments.demo.PayPalMessagingFragment"
+        tools:layout="fragment_paypal_messaging">
     </fragment>
 
 </navigation>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="local_payment_button">Local Payment</string>
     <string name="sepa_direct_debit_button">SEPA Direct Debit</string>
     <string name="cards">Credit or Debit Cards</string>
+    <string name="paypal_messaging_button">PayPal Messaging</string>
     <string name="paypal_native_checkout">PayPal Native Checkout</string>
     <string name="samsung_pay">Samsung Pay</string>
     <string name="create_transaction">Create a Transaction</string>

--- a/PayPalMessaging/src/main/java/com/braintreepayments/api/PayPalMessagingView.kt
+++ b/PayPalMessaging/src/main/java/com/braintreepayments/api/PayPalMessagingView.kt
@@ -26,7 +26,6 @@ class PayPalMessagingView(
 
     /**
      * Creates a view to be displayed to promote offers such as Pay Later and PayPal Credit to customers.
-     * @property context the Android Context
      * @property request An optional [PayPalMessagingRequest]
      * Note: **This module is in beta. It's public API may change or be removed in future releases.**
      */

--- a/PayPalMessaging/src/main/java/com/braintreepayments/api/PayPalMessagingView.kt
+++ b/PayPalMessaging/src/main/java/com/braintreepayments/api/PayPalMessagingView.kt
@@ -1,7 +1,9 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import com.paypal.messages.PayPalMessageView
 import com.paypal.messages.config.message.PayPalMessageData
 import com.paypal.messages.config.PayPalEnvironment
@@ -16,7 +18,10 @@ import com.paypal.messages.config.message.PayPalMessageViewStateCallbacks
  * Note: **This module is in beta. It's public API may change or be removed in future releases.**
  * @property braintreeClient a {@link BraintreeClient}
  */
-class PayPalMessagingView(private val braintreeClient: BraintreeClient) {
+class PayPalMessagingView(
+    private val braintreeClient: BraintreeClient,
+    context: Context
+) : FrameLayout(context) {
     var payPalMessagingListener: PayPalMessagingListener? = null
 
     /**
@@ -25,7 +30,7 @@ class PayPalMessagingView(private val braintreeClient: BraintreeClient) {
      * @property request An optional [PayPalMessagingRequest]
      * Note: **This module is in beta. It's public API may change or be removed in future releases.**
      */
-    fun start(context: Context, request: PayPalMessagingRequest = PayPalMessagingRequest()) {
+    fun start(request: PayPalMessagingRequest = PayPalMessagingRequest()) {
         braintreeClient.getConfiguration { configuration, configError ->
             if (configError != null) {
                 payPalMessagingListener?.onPayPalMessagingFailure(configError)
@@ -42,6 +47,8 @@ class PayPalMessagingView(private val braintreeClient: BraintreeClient) {
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
+
+                    addView(payPalMessageView)
                 }
             } else {
                 val exception = BraintreeException(


### PR DESCRIPTION
This work is going into the `paypal-messaging-feature` branch

### Summary of changes

 - Add `PayPalMessagingFragment` to Demo app
     - Add button to demo app to select this feature
     - Implement `PayPalMessagingView`
- Update `PayPalMessagingView` method and subclass `FrameLayout` so the class is a view type
    - Move context to constructor vs in start method as it is needed for `FrameLayout` subclass
    - Update CHANGELOG with these changes

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~

### Authors

@jaxdesmarais 