### PR TITLE
Venmo Final Amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Venmo
+  * Add `setFinalAmount()` to `VenmoRequest`
+
 ## 4.41.0 (2024-01-18)
 
 * PayPal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Venmo
-  * Add `setFinalAmount()` to `VenmoRequest`
+  * Add `setIsFinalAmount()` to `VenmoRequest`
 
 ## 4.41.0 (2024-01-18)
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
@@ -27,6 +27,7 @@ class VenmoApi {
             input.put("merchantProfileId", venmoProfileId);
             input.put("customerClient", "MOBILE_APP");
             input.put("intent", "CONTINUE");
+            input.put("isFinalAmount", request.getFinalAmountAsString());
             JSONObject paysheetDetails = new JSONObject();
             paysheetDetails.put("collectCustomerShippingAddress", request.getCollectCustomerShippingAddressAsString());
             paysheetDetails.put("collectCustomerBillingAddress", request.getCollectCustomerBillingAddressAsString());

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
@@ -27,7 +27,7 @@ class VenmoApi {
             input.put("merchantProfileId", venmoProfileId);
             input.put("customerClient", "MOBILE_APP");
             input.put("intent", "CONTINUE");
-            input.put("isFinalAmount", request.getFinalAmountAsString());
+            input.put("isFinalAmount", request.getIsFinalAmountAsString());
             JSONObject paysheetDetails = new JSONObject();
             paysheetDetails.put("collectCustomerShippingAddress", request.getCollectCustomerShippingAddressAsString());
             paysheetDetails.put("collectCustomerBillingAddress", request.getCollectCustomerBillingAddressAsString());

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -25,6 +25,7 @@ public class VenmoRequest implements Parcelable {
     private String taxAmount;
     private String shippingAmount;
     private ArrayList<VenmoLineItem> lineItems;
+    private boolean finalAmount;
 
     private final @VenmoPaymentMethodUsage int paymentMethodUsage;
 
@@ -248,6 +249,22 @@ public class VenmoRequest implements Parcelable {
         return lineItems;
     }
 
+    /**
+     * @param finalAmount Optional - Indicates whether the purchase amount is the final amount.
+     *                    Defaults to false.
+     */
+    public void setFinalAmount(boolean finalAmount) {
+        this.finalAmount = finalAmount;
+    }
+
+    /**
+     * @return Whether or not the purchase amount is the final amount.
+     */
+    public boolean getFinalAmount() {
+        return finalAmount;
+    }
+
+
     protected VenmoRequest(Parcel in) {
         shouldVault = in.readByte() != 0;
         collectCustomerBillingAddress = in.readByte() != 0;
@@ -261,6 +278,7 @@ public class VenmoRequest implements Parcelable {
         taxAmount = in.readString();
         totalAmount = in.readString();
         lineItems = in.createTypedArrayList(VenmoLineItem.CREATOR);
+        finalAmount = in.readByte() != 0;
     }
 
     public static final Creator<VenmoRequest> CREATOR = new Creator<VenmoRequest>() {
@@ -294,5 +312,6 @@ public class VenmoRequest implements Parcelable {
         parcel.writeString(taxAmount);
         parcel.writeString(totalAmount);
         parcel.writeTypedList(lineItems);
+        parcel.writeByte((byte) (finalAmount ? 1 : 0));
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -25,7 +25,7 @@ public class VenmoRequest implements Parcelable {
     private String taxAmount;
     private String shippingAmount;
     private ArrayList<VenmoLineItem> lineItems;
-    private boolean finalAmount;
+    private boolean isFinalAmount;
 
     private final @VenmoPaymentMethodUsage int paymentMethodUsage;
 
@@ -250,18 +250,25 @@ public class VenmoRequest implements Parcelable {
     }
 
     /**
-     * @param finalAmount Optional - Indicates whether the purchase amount is the final amount.
+     * @param isFinalAmount Optional - Indicates whether the purchase amount is the final amount.
      *                    Defaults to false.
      */
-    public void setFinalAmount(boolean finalAmount) {
-        this.finalAmount = finalAmount;
+    public void setIsFinalAmount(boolean isFinalAmount) {
+        this.isFinalAmount = isFinalAmount;
+    }
+
+    /**
+     * @return The boolean value of the flag that signifies whether the purchase amount is the final amount.
+     */
+    public boolean getIsFinalAmount() {
+        return isFinalAmount;
     }
 
     /**
      * @return Whether or not the purchase amount is the final amount as a string value.
      */
-    String getFinalAmountAsString() {
-        return String.valueOf(this.finalAmount);
+    String getIsFinalAmountAsString() {
+        return String.valueOf(this.isFinalAmount);
     }
 
 
@@ -278,7 +285,7 @@ public class VenmoRequest implements Parcelable {
         taxAmount = in.readString();
         totalAmount = in.readString();
         lineItems = in.createTypedArrayList(VenmoLineItem.CREATOR);
-        finalAmount = in.readByte() != 0;
+        isFinalAmount = in.readByte() != 0;
     }
 
     public static final Creator<VenmoRequest> CREATOR = new Creator<VenmoRequest>() {
@@ -312,6 +319,6 @@ public class VenmoRequest implements Parcelable {
         parcel.writeString(taxAmount);
         parcel.writeString(totalAmount);
         parcel.writeTypedList(lineItems);
-        parcel.writeByte((byte) (finalAmount ? 1 : 0));
+        parcel.writeByte((byte) (isFinalAmount ? 1 : 0));
     }
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -258,10 +258,10 @@ public class VenmoRequest implements Parcelable {
     }
 
     /**
-     * @return Whether or not the purchase amount is the final amount.
+     * @return Whether or not the purchase amount is the final amount as a string value.
      */
-    public boolean getFinalAmount() {
-        return finalAmount;
+    String getFinalAmountAsString() {
+        return String.valueOf(this.finalAmount);
     }
 
 

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoRequest.java
@@ -271,7 +271,6 @@ public class VenmoRequest implements Parcelable {
         return String.valueOf(this.isFinalAmount);
     }
 
-
     protected VenmoRequest(Parcel in) {
         shouldVault = in.readByte() != 0;
         collectCustomerBillingAddress = in.readByte() != 0;

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
@@ -174,7 +174,7 @@ public class VenmoApiUnitTest {
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
-        request.setFinalAmount(true);
+        request.setIsFinalAmount(true);
         request.setTotalAmount("5.99");
 
         venmoAPI.createPaymentContext(request, request.getProfileId(), mock(VenmoApiCallback.class));
@@ -203,7 +203,7 @@ public class VenmoApiUnitTest {
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
-        request.setFinalAmount(false);
+        request.setIsFinalAmount(false);
         request.setTotalAmount("5.99");
 
         venmoAPI.createPaymentContext(request, request.getProfileId(), mock(VenmoApiCallback.class));

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoRequestUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoRequestUnitTest.java
@@ -48,6 +48,16 @@ public class VenmoRequestUnitTest {
     }
 
     @Test
+    public void getIsFinalAmountAsString_returnsStringEquivalent() {
+        VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.MULTI_USE);
+        request.setIsFinalAmount(true);
+        assertEquals("true", request.getIsFinalAmountAsString());
+
+        request.setIsFinalAmount(false);
+        assertEquals("false", request.getIsFinalAmountAsString());
+    }
+
+    @Test
     public void parcelsCorrectly() {
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.MULTI_USE);
         request.setDisplayName("venmo-user");
@@ -60,6 +70,7 @@ public class VenmoRequestUnitTest {
         request.setDiscountAmount("2.00");
         request.setShippingAmount("1.00");
         request.setTotalAmount("10.00");
+        request.setIsFinalAmount(true);
 
         ArrayList<VenmoLineItem> lineItems = new ArrayList<>();
         lineItems.add(new VenmoLineItem(VenmoLineItem.KIND_DEBIT, "An Item", 1, "10.00"));
@@ -83,5 +94,6 @@ public class VenmoRequestUnitTest {
         assertEquals("10.00", result.getTotalAmount());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+        assertTrue(result.getIsFinalAmount());
     }
 }


### PR DESCRIPTION
### Summary of changes

 -   Add `setIsFinalAmount()` to `VenmoRequest`
     - This removes the text "Subject to change" as seen below

#### Visuals

| Final Amount = false (default) | Final Amount = true |
|-----|-----|
|![Screenshot_20240214-084546](https://github.com/braintree/braintree_android/assets/20733831/d8480eeb-10b7-4102-8431-813973f2435a)|![Screenshot_20240214-084609](https://github.com/braintree/braintree_android/assets/20733831/1264dee0-706c-409d-8fa2-6bbba4544743)|

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors

@jaxdesmarais 