### PR TITLE
Remove Venmo from the Shopper Insight Response

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -18,8 +18,6 @@ import com.braintreepayments.api.ShopperInsightsResult
 import com.braintreepayments.api.VenmoAccountNonce
 import com.braintreepayments.api.VenmoClient
 import com.braintreepayments.api.VenmoListener
-import com.braintreepayments.api.VenmoPaymentMethodUsage
-import com.braintreepayments.api.VenmoRequest
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -31,7 +31,6 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
     private lateinit var responseTextView: TextView
     private lateinit var actionButton: Button
     private lateinit var payPalVaultButton: Button
-    private lateinit var venmoButton: Button
     private lateinit var emailInput: TextInputLayout
     private lateinit var countryCodeInput: TextInputLayout
     private lateinit var nationalNumberInput: TextInputLayout
@@ -70,7 +69,6 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         initializeViews(view)
 
         actionButton.setOnClickListener { fetchShopperInsights() }
-        venmoButton.setOnClickListener { launchVenmo() }
         payPalVaultButton.setOnClickListener { launchPayPalVault() }
     }
 
@@ -78,7 +76,6 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         responseTextView = view.findViewById(R.id.responseTextView)
         actionButton = view.findViewById(R.id.actionButton)
         payPalVaultButton = view.findViewById(R.id.payPalVaultButton)
-        venmoButton = view.findViewById(R.id.venmoButton)
         emailInput = view.findViewById(R.id.emailInput)
         countryCodeInput = view.findViewById(R.id.countryCodeInput)
         nationalNumberInput = view.findViewById(R.id.nationalNumberInput)
@@ -110,12 +107,10 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
             when (result) {
                 is ShopperInsightsResult.Success -> {
                     payPalVaultButton.isEnabled = result.response.isPayPalRecommended
-                    venmoButton.isEnabled = result.response.isVenmoRecommended
 
                     responseTextView.text =
                         """
                             PayPal Recommended: ${result.response.isPayPalRecommended}
-                            Venmo Recommended: ${result.response.isVenmoRecommended}
                         """.trimIndent()
                 }
 
@@ -131,18 +126,6 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
             requireActivity(),
             PayPalRequestFactory.createPayPalVaultRequest(activity)
         )
-    }
-
-    private fun launchVenmo() {
-        val venmoRequest = VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE)
-        venmoRequest.profileId = null
-        venmoRequest.collectCustomerBillingAddress = true
-        venmoRequest.collectCustomerShippingAddress = true
-        venmoRequest.totalAmount = "20"
-        venmoRequest.subTotalAmount = "18"
-        venmoRequest.taxAmount = "1"
-
-        venmoClient.tokenizeVenmoAccount(requireActivity(), venmoRequest)
     }
 
     override fun onPayPalSuccess(payPalAccountNonce: PayPalAccountNonce) {

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -26,7 +26,7 @@
         android:text="@string/insights_response_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/venmoButton" />
+        app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/countryCodeInput"
@@ -115,19 +115,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/actionButton" />
-
-    <Button
-        android:id="@+id/venmoButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
-        android:text="@string/insights_venmo_button"
-        android:enabled="false"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/payPalVaultButton" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/emailNullSwitch"

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentMethods.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentMethods.kt
@@ -6,21 +6,16 @@ import org.json.JSONObject
  * Contains details about the available payment methods.
  *
  * @property paypal Details about the PayPal payment method.
- * @property venmo Details about the Venmo payment method.
  */
 internal data class EligiblePaymentMethods(
-    val paypal: EligiblePaymentMethodDetails?,
-    val venmo: EligiblePaymentMethodDetails?
+    val paypal: EligiblePaymentMethodDetails?
 ) {
     companion object {
         fun fromJson(jsonObject: JSONObject): EligiblePaymentMethods {
             val paypal = jsonObject.optJSONObject("paypal")?.let {
                 EligiblePaymentMethodDetails.fromJson(it)
             }
-            val venmo = jsonObject.optJSONObject("venmo")?.let {
-                EligiblePaymentMethodDetails.fromJson(it)
-            }
-            return EligiblePaymentMethods(paypal, venmo)
+            return EligiblePaymentMethods(paypal)
         }
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsAnalytics.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsAnalytics.kt
@@ -3,8 +3,6 @@ package com.braintreepayments.api
 internal object ShopperInsightsAnalytics {
     const val PAYPAL_PRESENTED = "shopper-insights:paypal-presented"
     const val PAYPAL_SELECTED = "shopper-insights:paypal-selected"
-    const val VENMO_PRESENTED = "shopper-insights:venmo-presented"
-    const val VENMO_SELECTED = "shopper-insights:venmo-selected"
 
     const val GET_RECOMMENDED_PAYMENTS_FAILED = "shopper-insights:get-recommended-payments:failed"
     const val GET_RECOMMENDED_PAYMENTS_STARTED = "shopper-insights:get-recommended-payments:started"

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -6,9 +6,6 @@ import com.braintreepayments.api.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMEN
 import com.braintreepayments.api.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_SUCCEEDED
 import com.braintreepayments.api.ShopperInsightsAnalytics.PAYPAL_PRESENTED
 import com.braintreepayments.api.ShopperInsightsAnalytics.PAYPAL_SELECTED
-import com.braintreepayments.api.ShopperInsightsAnalytics.VENMO_PRESENTED
-import com.braintreepayments.api.ShopperInsightsAnalytics.VENMO_SELECTED
-import java.lang.Exception
 
 /**
  * Use [ShopperInsightsClient] to optimize your checkout experience
@@ -82,7 +79,7 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
         when {
             error != null -> callbackFailure(callback, error)
 
-            result?.eligibleMethods?.paypal == null && result?.eligibleMethods?.venmo == null -> {
+            result?.eligibleMethods?.paypal == null -> {
                 callbackFailure(
                     callback = callback,
                     error = BraintreeException("Required fields missing from API response body")
@@ -92,8 +89,7 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
             else -> {
                 callbackSuccess(
                     callback = callback,
-                    isPayPalRecommended = isPaymentRecommended(result.eligibleMethods.paypal),
-                    isVenmoRecommended = isPaymentRecommended(result.eligibleMethods.venmo)
+                    isPayPalRecommended = isPaymentRecommended(result.eligibleMethods.paypal)
                 )
             }
         }
@@ -109,13 +105,12 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
 
     private fun callbackSuccess(
         callback: ShopperInsightsCallback,
-        isPayPalRecommended: Boolean,
-        isVenmoRecommended: Boolean,
+        isPayPalRecommended: Boolean
     ) {
         braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
         callback.onResult(
             ShopperInsightsResult.Success(
-                ShopperInsightsInfo(isPayPalRecommended, isVenmoRecommended)
+                ShopperInsightsInfo(isPayPalRecommended)
             )
         )
     }
@@ -140,28 +135,12 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
         braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED)
     }
 
-    /**
-     * Call this method when the Venmo button has been successfully displayed to the buyer.
-     * This method sends analytics to help improve the Shopper Insights feature experience.
-     */
-    fun sendVenmoPresentedEvent() {
-        braintreeClient.sendAnalyticsEvent(VENMO_PRESENTED)
-    }
-
-    /**
-     * Call this method when the Venmo button has been selected/tapped by the buyer.
-     * This method sends analytics to help improve the Shopper Insights feature experience.
-     */
-    fun sendVenmoSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED)
-    }
-
     companion object {
         // Default values
         private const val countryCode = "US"
         private const val currencyCode = "USD"
         private const val constraintType = "INCLUDE"
-        private val paymentSources = listOf("PAYPAL", "VENMO")
+        private val paymentSources = listOf("PAYPAL")
         private const val includeAccountDetails = true
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
@@ -3,18 +3,15 @@ package com.braintreepayments.api
 /**
  * Data class encapsulating the result of a shopper insight api request.
  *
- * This class holds information about the recommended payment methods for a shopper
- * The recommendations include flags for whether payment methods like PayPal or Venmo
- * should be displayed with high priority in the user interface.
+ * This class holds information about the recommended payment methods for a shopper. The
+ * recommendations include flags for whether payment methods like PayPal should be displayed with
+ * high priority in the user interface.
  *
  * @property isPayPalRecommended If true, indicates that the PayPal payment option
- * should be given high priority in the checkout UI.
- * @property isVenmoRecommended If true, indicates that the Venmo payment option
  * should be given high priority in the checkout UI.
  *
  * Note: **This feature is in beta. It's public API may change in future releases.**
  */
 data class ShopperInsightsInfo(
-    val isPayPalRecommended: Boolean,
-    val isVenmoRecommended: Boolean
+    val isPayPalRecommended: Boolean
 )

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiResultUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiResultUnitTest.kt
@@ -6,33 +6,6 @@ import org.junit.Test
 class EligiblePaymentsApiResultUnitTest {
 
     @Test
-    fun testVenmoFromJson() {
-        // Sample JSON string
-        val jsonString = """
-            {
-                "eligible_methods": {
-                    "venmo": {
-                        "can_be_vaulted": false,
-                        "eligible_in_paypal_network": true,
-                        "recommended": false
-                    }
-                }
-            }
-        """.trimIndent()
-
-        // Convert JSON string to ShopperInsightApiResult object
-        val result = EligiblePaymentsApiResult.fromJson(jsonString)
-
-        // Assertions for Venmo
-        val venmo = result.eligibleMethods.venmo
-        assertNotNull(venmo)
-        assertFalse(venmo!!.canBeVaulted)
-        assertTrue(venmo.eligibleInPayPalNetwork)
-        assertFalse(venmo.recommended)
-        assertEquals(0, venmo.recommendedPriority)
-    }
-
-    @Test
     fun testPayPalFromJson() {
         // Sample JSON string
         val jsonString = """

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiUnitTest.kt
@@ -99,8 +99,7 @@ class EligiblePaymentsApiUnitTest {
                             eligibleInPayPalNetwork = false,
                             recommended = true,
                             recommendedPriority = 1
-                        ),
-                        venmo = null
+                        )
                     )
                 ), error = null
             )

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -68,7 +68,7 @@ class ShopperInsightsClientUnitTest {
                     countryCode = "US",
                     accountDetails = true,
                     constraintType = "INCLUDE",
-                    paymentSources = listOf("PAYPAL", "VENMO")
+                    paymentSources = listOf("PAYPAL")
                 ),
                 callback = any()
             )
@@ -123,11 +123,11 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `testGetRecommendedPaymentMethods - all methods are null`() {
+    fun `testGetRecommendedPaymentMethods - methods is null`() {
         val callback = mockk<ShopperInsightsCallback>(relaxed = true)
 
         executeTestForFindEligiblePaymentsApi(
-            result = EligiblePaymentsApiResult(EligiblePaymentMethods(paypal = null, venmo = null)),
+            result = EligiblePaymentsApiResult(EligiblePaymentMethods(paypal = null)),
             error = null,
             callback = callback
         )
@@ -149,7 +149,7 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `testGetRecommendedPaymentMethods - both paypal and venmo recommended`() {
+    fun `testGetRecommendedPaymentMethods - paypal recommended`() {
         val callback = mockk<ShopperInsightsCallback>(relaxed = true)
         val eligiblePaymentMethodDetails = EligiblePaymentMethodDetails(
             canBeVaulted = true,
@@ -161,8 +161,7 @@ class ShopperInsightsClientUnitTest {
         executeTestForFindEligiblePaymentsApi(
             result = EligiblePaymentsApiResult(
                 EligiblePaymentMethods(
-                    paypal = eligiblePaymentMethodDetails,
-                    venmo = eligiblePaymentMethodDetails
+                    paypal = eligiblePaymentMethodDetails
                 )
             ),
             error = null,
@@ -175,38 +174,6 @@ class ShopperInsightsClientUnitTest {
                     assertTrue { result is ShopperInsightsResult.Success }
                     val success = result as ShopperInsightsResult.Success
                     assertEquals(true, success.response.isPayPalRecommended)
-                    assertEquals(true, success.response.isVenmoRecommended)
-                }
-            )
-        }
-    }
-
-    @Test
-    fun `testGetRecommendedPaymentMethods - paymentDetail null`() {
-        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
-
-        executeTestForFindEligiblePaymentsApi(
-            result = EligiblePaymentsApiResult(
-                EligiblePaymentMethods(
-                    paypal = null,
-                    venmo = EligiblePaymentMethodDetails(
-                        canBeVaulted = true,
-                        eligibleInPayPalNetwork = true,
-                        recommended = true,
-                        recommendedPriority = 1
-                    )
-                )
-            ),
-            error = null,
-            callback = callback
-        )
-
-        verify {
-            callback.onResult(
-                withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
-                    val success = result as ShopperInsightsResult.Success
-                    assertEquals(false, success.response.isPayPalRecommended)
                 }
             )
         }
@@ -224,8 +191,7 @@ class ShopperInsightsClientUnitTest {
                         eligibleInPayPalNetwork = true,
                         recommended = false,
                         recommendedPriority = 1
-                    ),
-                    venmo = null
+                    )
                 )
             ),
             error = null,
@@ -252,8 +218,7 @@ class ShopperInsightsClientUnitTest {
                     eligibleInPayPalNetwork = true,
                     recommended = false,
                     recommendedPriority = 1
-                ),
-                venmo = null
+                )
             )
         )
 
@@ -276,18 +241,6 @@ class ShopperInsightsClientUnitTest {
     fun `test paypal selected analytics event`() {
         sut.sendPayPalSelectedEvent()
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-selected") }
-    }
-
-    @Test
-    fun `test venmo presented analytics event`() {
-        sut.sendVenmoPresentedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-presented") }
-    }
-
-    @Test
-    fun `test venmo selected analytics event`() {
-        sut.sendVenmoSelectedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected") }
     }
 
     private fun executeTestForFindEligiblePaymentsApi(


### PR DESCRIPTION
### Summary of changes

 - Remove `isVenmoRecommended` from the `ShopperInsightsInfo` response object
 - Remove merchant-facing analytics functions on `ShopperInsightsClient`
 - Remove Venmo button on the Shopper Insights demo screen

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
