### PR TITLE
Cardinal Cleanup Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Venmo
   * Add `setIsFinalAmount()` to `VenmoRequest`
+* ThreeDSecure
+  * Call cleanup method to resolve `Cardinal.getInstance` memory leak (fixes #898)
 
 ## 4.41.0 (2024-01-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Venmo
   * Add `setIsFinalAmount()` to `VenmoRequest`
 * ThreeDSecure
-  * Call cleanup method to resolve `Cardinal.getInstance` memory leak (fixes #898)
+  * Call cleanup method to resolve `Cardinal.getInstance` memory leak
 
 ## 4.41.0 (2024-01-18)
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
@@ -58,6 +58,8 @@ class CardinalClient {
         } catch (RuntimeException e) {
             throw new BraintreeException("Cardinal SDK cca_continue Error.", e);
         }
+
+        Cardinal.getInstance().cleanup();
     }
 
     private void configureCardinal(Context context, Configuration configuration, ThreeDSecureRequest request) throws BraintreeException {

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.kt
@@ -243,6 +243,8 @@ class CardinalClientUnitTest {
                 cardinalChallengeObserver
             )
         }
+
+        verify { cardinalInstance.cleanup() }
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Call Cardinal cleanup method to resolve memory leak from `Cardinal.getInstance`
     - Verified via Leak Canary that the `getInstance` memory leak is gone
     - Note: there is still a memory leak on `Cardinal.cca_continue` that will be resolve in a future Cardinal release

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors

@jaxdesmarais 