### PR TITLE
Remove payee and merchant id from eligible payments API request

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApiRequest.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/EligiblePaymentsApiRequest.kt
@@ -45,9 +45,6 @@ internal data class EligiblePaymentsApiRequest(
                 })
                 put(KEY_PURCHASE_UNITS, JSONArray().apply {
                     put(JSONObject().apply {
-                        put(KEY_PAYEE, JSONObject().apply {
-                            put(KEY_MERCHANT_ID, merchantId)
-                        })
                         put(KEY_AMOUNT, JSONObject().apply {
                             put(KEY_CURRENCY_CODE, currencyCode)
                         })
@@ -69,9 +66,7 @@ internal data class EligiblePaymentsApiRequest(
         internal const val KEY_EMAIL = "email"
         internal const val KEY_PHONE = "phone"
         internal const val KEY_PURCHASE_UNITS = "purchase_units"
-        internal const val KEY_PAYEE = "payee"
         internal const val KEY_AMOUNT = "amount"
-        internal const val KEY_MERCHANT_ID = "merchant_id"
         internal const val KEY_CURRENCY_CODE = "currency_code"
         internal const val KEY_PREFERENCES = "preferences"
         internal const val KEY_INCLUDE_ACCOUNT_DETAILS = "include_account_details"

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiRequestUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/EligiblePaymentsApiRequestUnitTest.kt
@@ -40,9 +40,6 @@ class EligiblePaymentsApiRequestUnitTest {
                 },
                 "purchase_units": [
                     {
-                        "payee": {
-                            "merchant_id": "MXSJ4F5BADVNS"
-                        },
                         "amount": {
                             "currency_code": "USD"
                         }


### PR DESCRIPTION
### Summary of changes

 - Remove `payee` and `merchant_id` from the EligiblePaymentsApi request

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
