### PR TITLE
Add Country Restrictions in DocStrings

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -33,6 +33,9 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      * @param context Android context
      * @param request The [ShopperInsightsRequest] containing information about the shopper.
      * @return A [ShopperInsightsResult] object indicating the recommended payment methods.
+     * - Note: This feature is in beta. Its public API may change or be removed in future releases
+     * Shopper Insights for PayPal payment recommendation is only available in US and AU, FR, DE, ITA, NED, ESP, Switzerland and UK.
+     * Venmo recommendation is only available for US.
      */
     fun getRecommendedPaymentMethods(
         request: ShopperInsightsRequest,

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -34,8 +34,8 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      * @param request The [ShopperInsightsRequest] containing information about the shopper.
      * @return A [ShopperInsightsResult] object indicating the recommended payment methods.
      * Note: This feature is in beta. Its public API may change or be removed in future releases
-     * Shopper Insights for PayPal payment recommendation is only available in US and AU, FR, DE,
-     * ITA, NED, ESP, Switzerland and UK. Venmo recommendation is only available for US.
+     * PayPal recommendation is only available for US, AU, FR, DE, ITA, NED, ESP, Switzerland and
+     * UK merchants. Venmo recommendation is only available for US merchants.
      */
     fun getRecommendedPaymentMethods(
         request: ShopperInsightsRequest,

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsClient.kt
@@ -33,9 +33,9 @@ class ShopperInsightsClient @VisibleForTesting internal constructor(
      * @param context Android context
      * @param request The [ShopperInsightsRequest] containing information about the shopper.
      * @return A [ShopperInsightsResult] object indicating the recommended payment methods.
-     * - Note: This feature is in beta. Its public API may change or be removed in future releases
-     * Shopper Insights for PayPal payment recommendation is only available in US and AU, FR, DE, ITA, NED, ESP, Switzerland and UK.
-     * Venmo recommendation is only available for US.
+     * Note: This feature is in beta. Its public API may change or be removed in future releases
+     * Shopper Insights for PayPal payment recommendation is only available in US and AU, FR, DE,
+     * ITA, NED, ESP, Switzerland and UK. Venmo recommendation is only available for US.
      */
     fun getRecommendedPaymentMethods(
         request: ShopperInsightsRequest,


### PR DESCRIPTION
### Summary of changes

 - Added docStrings for country restrictions on function `getRecommendedPaymentMethods`

### Checklist

 [ ] Added a changelog entry
 [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@KunJeongPark 
### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[x] Whenever, no rush
