### PR TITLE
Add `paypal_context_id` 

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -47,6 +47,10 @@ open class BraintreeClient @VisibleForTesting internal constructor(
     private val crashReporter: CrashReporter
     private var launchesBrowserSwitchAsNewTask: Boolean = false
 
+    // Used for linking events from the client to server side request
+    // This value will be PayPal Order ID, Payment Token, EC token or Billing Agreement depending on the flow
+    var payPalContextID: String? = null
+
     // NOTE: this constructor is used to make dependency injection easy
     internal constructor(params: BraintreeClientParams) : this(
         applicationContext = params.applicationContext,
@@ -231,7 +235,8 @@ open class BraintreeClient @VisibleForTesting internal constructor(
                 eventName,
                 sessionId,
                 integrationType,
-                authorization
+                authorization,
+                payPalContextID
             )
         }
     }

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -126,6 +126,7 @@ public class LocalPaymentClient {
                             @Override
                             public void onResult(@Nullable LocalPaymentResult localPaymentResult, @Nullable Exception error) {
                                 if (localPaymentResult != null) {
+                                    braintreeClient.setPayPalContextID(localPaymentResult.getPaymentId());
                                     sendAnalyticsEvent(request.getPaymentType(), "local-payment.create.succeeded");
                                 } else if (error != null) {
                                     sendAnalyticsEvent(request.getPaymentType(), "local-payment.webswitch.initiate.failed");

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -382,6 +382,9 @@ public class PayPalClient {
         String tokenKey = isBillingAgreement ? "ba_token" : "token";
         String analyticsPrefix = isBillingAgreement ? "paypal.billing-agreement" : "paypal.single-payment";
 
+        String pairingID = Uri.parse(approvalUrl).getQueryParameter(tokenKey);
+        braintreeClient.setPayPalContextID(pairingID);
+
         int result = browserSwitchResult.getStatus();
         switch (result) {
             case BrowserSwitchStatus.CANCELED:

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -147,6 +147,7 @@ public class PayPalNativeCheckoutClient {
             final PayPalNativeRequest payPalRequest,
             final Configuration configuration
     ) {
+        braintreeClient.setPayPalContextID(configuration.getPayPalClientId());
         internalPayPalClient.sendRequest(activity, payPalRequest, (payPalResponse, error) -> {
             if (payPalResponse != null) {
                 String analyticsPrefix = payPalRequest instanceof PayPalNativeCheckoutVaultRequest ? "billing-agreement" : "single-payment";


### PR DESCRIPTION
### Summary of changes

- Pass `paypal_context_id` when available:
    - PayPal Web: passing either the `token` (checkout) or `ba_token` (vault) as the `paypal_context_id`
    - PayPal Native: passing the `orderID` as the `paypal_context_id`
    - Local Payments: passing the `paymentToken` (which is an order ID) as the `paypal_context_id`
    - If we get an empty string back we will not pass an empty string to FPTI
 
### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors

- @richherrera   

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
