### PR TITLE
skip signinig on publishing local builds

### DIFF
--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -46,9 +46,14 @@ afterEvaluate {
         }
     }
 
+    def isCiEnvironment = System.getenv('CI')
+
     signing {
-        sign publishing.publications
-        sign configurations.archives
+        required { isCiEnvironment }
+        if(isCiEnvironment) {
+            sign publishing.publications
+            sign configurations.archives
+        }
     }
 }
 


### PR DESCRIPTION
### Summary of changes

 - Making signing required only for builds run on CI. This is to make sure that `publishToMavenLocal` works without signing.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
