### PR TITLE
Update American Express Package Name

### DIFF
--- a/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressAnalytics.kt
+++ b/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressAnalytics.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.americanexpress
 
 internal object AmericanExpressAnalytics {
 

--- a/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressClient.java
+++ b/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressClient.java
@@ -1,10 +1,13 @@
-package com.braintreepayments.api;
+package com.braintreepayments.americanexpress;
 
 import android.content.Context;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+
+import com.braintreepayments.api.ApiClient;
+import com.braintreepayments.api.BraintreeClient;
 
 import org.json.JSONException;
 

--- a/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressGetRewardsBalanceCallback.kt
+++ b/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressGetRewardsBalanceCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.americanexpress
 
 /**
  * Callback for receiving result of

--- a/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressResult.kt
+++ b/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.americanexpress
 
 /**
  * Result of fetching American Express rewards balance

--- a/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressRewardsBalance.java
+++ b/AmericanExpress/src/main/java/com/braintreepayments/americanexpress/AmericanExpressRewardsBalance.java
@@ -1,8 +1,10 @@
-package com.braintreepayments.api;
+package com.braintreepayments.americanexpress;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.Nullable;
+
+import com.braintreepayments.api.Json;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressAnalyticsUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressAnalyticsUnitTest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api
 
+import com.braintreepayments.americanexpress.AmericanExpressAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressClientUnitTest.java
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressClientUnitTest.java
@@ -9,6 +9,12 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.braintreepayments.americanexpress.AmericanExpressAnalytics;
+import com.braintreepayments.americanexpress.AmericanExpressClient;
+import com.braintreepayments.americanexpress.AmericanExpressGetRewardsBalanceCallback;
+import com.braintreepayments.americanexpress.AmericanExpressResult;
+import com.braintreepayments.americanexpress.AmericanExpressRewardsBalance;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressRewardsBalanceUnitTest.java
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/AmericanExpressRewardsBalanceUnitTest.java
@@ -10,6 +10,8 @@ import org.robolectric.RobolectricTestRunner;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 
+import com.braintreepayments.americanexpress.AmericanExpressRewardsBalance;
+
 @RunWith(RobolectricTestRunner.class)
 public class AmericanExpressRewardsBalanceUnitTest {
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
   * American Express
     * Change parameters of `AmericanExpressGetRewardsBalanceCallback`
     * Add `AmericanExpressResult`
+    * Update package name to `com.braintreepayments.americanexpress`
   * Samsung Pay
     * Remove entire Samsung Pay module
   * PayPal Native Checkout

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -15,9 +15,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.braintreepayments.api.AmericanExpressClient;
-import com.braintreepayments.api.AmericanExpressResult;
-import com.braintreepayments.api.AmericanExpressRewardsBalance;
+import com.braintreepayments.americanexpress.AmericanExpressClient;
+import com.braintreepayments.americanexpress.AmericanExpressResult;
+import com.braintreepayments.americanexpress.AmericanExpressRewardsBalance;
 import com.braintreepayments.api.Card;
 import com.braintreepayments.api.CardClient;
 import com.braintreepayments.api.CardNonce;

--- a/SharedUtils/src/main/java/com/braintreepayments/api/Json.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/Json.java
@@ -1,7 +1,10 @@
 package com.braintreepayments.api;
 
+import androidx.annotation.RestrictTo;
+
 import org.json.JSONObject;
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class Json {
 
     /**
@@ -15,6 +18,7 @@ public class Json {
      * @param fallback
      * @return {@link String}
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public static String optString(JSONObject json, String name, String fallback) {
         if (json == null || json.isNull(name)) {
             return fallback;
@@ -23,7 +27,8 @@ public class Json {
         }
     }
 
-    static Boolean optBoolean(JSONObject json, String name, Boolean fallback) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static Boolean optBoolean(JSONObject json, String name, Boolean fallback) {
         if (json == null || json.isNull(name)) {
             return fallback;
         } else {

--- a/SharedUtils/src/main/java/com/braintreepayments/api/Json.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/Json.java
@@ -2,7 +2,7 @@ package com.braintreepayments.api;
 
 import org.json.JSONObject;
 
-class Json {
+public class Json {
 
     /**
      * Returns the value mapped by name if it exists, coercing it if necessary, or fallback if no such mapping exists.
@@ -15,7 +15,7 @@ class Json {
      * @param fallback
      * @return {@link String}
      */
-    static String optString(JSONObject json, String name, String fallback) {
+    public static String optString(JSONObject json, String name, String fallback) {
         if (json == null || json.isNull(name)) {
             return fallback;
         } else {


### PR DESCRIPTION
### Summary of changes

 - Rename American Express package name from `com.braintreepayments.api` to `com.braintreepayments.americanexpress`
 - Add `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` annotation to the Json class

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
