### PR TITLE
Add optional param, payerEmail, to PayPalVaultRequest 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.42.0 (2024-03-12)
 
+* PayPal
+  * Add optional property `PayPalVaultRequest.setUserAuthenticationEmail()`
 * Venmo
   * Add `setIsFinalAmount()` to `VenmoRequest`
   * Add `setFallbackToWeb()` to `VenmoRequest`

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -26,6 +26,7 @@ public abstract class PayPalRequest implements Parcelable {
     static final String REQUEST_BILLING_AGREEMENT_KEY = "request_billing_agreement";
     static final String BILLING_AGREEMENT_DETAILS_KEY = "billing_agreement_details";
     static final String DESCRIPTION_KEY = "description";
+    static final String PAYER_EMAIL_KEY = "payer_email";
     static final String AUTHORIZATION_FINGERPRINT_KEY = "authorization_fingerprint";
     static final String TOKENIZATION_KEY = "client_key";
     static final String RETURN_URL_KEY = "return_url";

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -38,10 +38,11 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
      *
      * @param userAuthenticationEmail - email address of the payer
      */
-    public void setUserAuthenticationEmail(String userAuthenticationEmail) {
+    public void setUserAuthenticationEmail(@Nullable String userAuthenticationEmail) {
         this.userAuthenticationEmail = userAuthenticationEmail;
     }
 
+    @Nullable
     public String getUserAuthenticationEmail() {
         return this.userAuthenticationEmail;
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -4,6 +4,8 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -63,9 +63,7 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
             parameters.put(DESCRIPTION_KEY, billingAgreementDescription);
         }
 
-        if (userAuthenticationEmail != null) {
-            parameters.put(PAYER_EMAIL_KEY, userAuthenticationEmail);
-        }
+        parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail);
 
         JSONObject experienceProfile = new JSONObject();
         experienceProfile.put(NO_SHIPPING_KEY, !isShippingAddressRequired());

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -14,6 +14,8 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     private boolean shouldOfferCredit;
 
+    private String userAuthenticationEmail;
+
     public PayPalVaultRequest() {
     }
 
@@ -28,6 +30,20 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     public boolean getShouldOfferCredit() {
         return shouldOfferCredit;
+    }
+
+    /**
+     * Optional: User email to initiate a quicker authentication flow in cases where the user has a
+     * PayPal Account with the same email.
+     *
+     * @param userAuthenticationEmail - email address of the payer
+     */
+    public void setUserAuthenticationEmail(String userAuthenticationEmail) {
+        this.userAuthenticationEmail = userAuthenticationEmail;
+    }
+
+    public String getUserAuthenticationEmail() {
+        return this.userAuthenticationEmail;
     }
 
     String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException {
@@ -45,6 +61,10 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
         String billingAgreementDescription = getBillingAgreementDescription();
         if (!TextUtils.isEmpty(billingAgreementDescription)) {
             parameters.put(DESCRIPTION_KEY, billingAgreementDescription);
+        }
+
+        if (userAuthenticationEmail != null) {
+            parameters.put(PAYER_EMAIL_KEY, userAuthenticationEmail);
         }
 
         JSONObject experienceProfile = new JSONObject();

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -1,9 +1,12 @@
 package com.braintreepayments.api;
 
+import android.content.pm.Signature;
 import android.os.Parcel;
 
+import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
@@ -12,6 +15,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 public class PayPalVaultRequestUnitTest {
@@ -80,17 +84,33 @@ public class PayPalVaultRequestUnitTest {
 
         assertEquals("en-US", result.getLocaleCode());
         assertEquals("Billing Agreement Description",
-                result.getBillingAgreementDescription());
+            result.getBillingAgreementDescription());
         assertTrue(result.getShouldOfferCredit());
         assertTrue(result.isShippingAddressRequired());
         assertTrue(result.isShippingAddressEditable());
         assertEquals("Postal Address", result.getShippingAddressOverride()
-                .getRecipientName());
+            .getRecipientName());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, result.getLandingPageType());
         assertEquals("Display Name", result.getDisplayName());
         assertEquals("123-correlation", result.getRiskCorrelationId());
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+    }
+
+    @Test
+    public void createRequestBody_sets_userAuthenticationEmail_when_not_null() throws JSONException {
+        String payerEmail = "payer_email@example.com";
+        PayPalVaultRequest request = new PayPalVaultRequest();
+
+        request.setUserAuthenticationEmail(payerEmail);
+        String requestBody = request.createRequestBody(
+            mock(Configuration.class),
+            mock(Authorization.class),
+            "success_url",
+            "cancel_url"
+        );
+
+        assertTrue(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Separating out adding `payerEmail` to `PayPalVaultRequest` from the rest of the shopper insights feature branch 
 - This work was previously merged into feature branch in #918 

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
@tdchow 

