### PR TITLE
Update Venmo Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Venmo
+  * Fix bug where SDK is not sending metadata as expected when creating payment context or constructing App Link URL
+
 ## 4.42.0 (2024-03-12)
 
 * Venmo

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoApi.java
@@ -60,6 +60,14 @@ class VenmoApi {
             JSONObject variables = new JSONObject();
             variables.put("input", input);
             params.put("variables", variables);
+
+            JSONObject braintreeData = new MetadataBuilder()
+                    .sessionId(braintreeClient.getSessionId())
+                    .integration(braintreeClient.getIntegrationType())
+                    .version()
+                    .build();
+
+            params.put("clientSdkMetadata", braintreeData);
         } catch (JSONException e) {
             callback.onResult(null, new BraintreeException("unexpected error"));
         }

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -649,11 +649,14 @@ public class VenmoClient {
 
     @VisibleForTesting
     void startAppLinkFlow(FragmentActivity activity, VenmoIntentData input) throws JSONException, BrowserSwitchException {
-        JSONObject braintreeData = new MetadataBuilder()
+        JSONObject metadata = new MetadataBuilder()
                 .sessionId(input.getSessionId())
                 .integration(input.getIntegrationType())
                 .version()
                 .build();
+
+        JSONObject braintreeData = new JSONObject()
+                .put("_meta", metadata);
 
         String applicationName = "ApplicationNameUnknown";
         Context context = braintreeClient.getApplicationContext();

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Base64;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -672,7 +673,7 @@ public class VenmoClient {
                 .appendQueryParameter("braintree_access_token", input.getConfiguration().getVenmoAccessToken())
                 .appendQueryParameter("braintree_environment", input.getConfiguration().getVenmoEnvironment())
                 .appendQueryParameter("resource_id", input.getPaymentContextId())
-                .appendQueryParameter("braintree_sdk_data", braintreeData.toString())
+                .appendQueryParameter("braintree_sdk_data", Base64.encodeToString(braintreeData.toString().getBytes(), 0))
                 .appendQueryParameter("customerClient", "MOBILE_APP")
                 .build();
 

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoApiUnitTest.java
@@ -68,6 +68,10 @@ public class VenmoApiUnitTest {
         assertEquals("CONTINUE", input.getString("intent"));
         assertEquals("display-name", input.getString("displayName"));
 
+        JSONObject metadata = graphQLJSON.getJSONObject("clientSdkMetadata");
+        assertEquals(BuildConfig.VERSION_NAME, metadata.getString("version"));
+        assertEquals("android", metadata.getString("platform"));
+
         JSONObject paysheetDetails = input.getJSONObject("paysheetDetails");
         assertEquals("true", paysheetDetails.getString("collectCustomerBillingAddress"));
         assertEquals("true", paysheetDetails.getString("collectCustomerShippingAddress"));

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -29,6 +29,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Base64;
 
 import androidx.activity.result.ActivityResultRegistry;
 import androidx.appcompat.app.AppCompatActivity;
@@ -504,13 +505,17 @@ public class VenmoClientUnitTest {
         assertEquals("com.example", browserSwitchOptions.getReturnUrlScheme());
 
         Uri url = browserSwitchOptions.getUrl();
-        // TODO: figure out why null?
         assertEquals("com.example://x-callback-url/vzero/auth/venmo/success", url.getQueryParameter("x-success"));
         assertEquals("com.example://x-callback-url/vzero/auth/venmo/error", url.getQueryParameter("x-error"));
         assertEquals("com.example://x-callback-url/vzero/auth/venmo/cancel", url.getQueryParameter("x-cancel"));
         assertEquals("fake-profile-id", url.getQueryParameter("braintree_merchant_id"));
         assertEquals("fake-payment-context-id", url.getQueryParameter("resource_id"));
         assertEquals("MOBILE_APP", url.getQueryParameter("customerClient"));
+
+        String metadata = url.getQueryParameter("braintree_sdk_data");
+        String metadataString = new String(Base64.decode(metadata, Base64.DEFAULT));
+        String expectedMetadata = String.format("{\"_meta\":{\"platform\":\"android\",\"sessionId\":\"fake-session-id\",\"integration\":\"custom\",\"version\":\"%s\"}}", BuildConfig.VERSION_NAME);
+        assertEquals(expectedMetadata, metadataString);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Send metadata as expected when constructing `CreateVenmoPaymentContext` - verified with Venmo backend team they are seeing this data as expected
 - Base64 encode `braintree_sdk_data` in App Link URL with `_meta` key (this matches the [iOS implementation](https://github.com/braintree/braintree_ios/blob/8775b31e1e003df7a67bf1428b784eec0637364a/Sources/BraintreeVenmo/BTVenmoAppSwitchRedirectURL.swift#L58))

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors

@jaxdesmarais 

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
- [ ] ASAP (let's discuss outside this PR)
- [ ] Soon, here's our target release date: <DD/MM/YYYY>
- [x] Whenever, no rush
