### PR TITLE
Update the Card Module Package Name

### DIFF
--- a/BraintreeCore/src/test/java/com/braintreepayments/api/ApiClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/ApiClientUnitTest.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.braintreepayments.api.card.Card
 import io.mockk.*
 import org.json.JSONException
 import org.json.JSONObject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
     * Move `ThreeDSecureInfo` to `three-d-secure` module
     * Add `CardResult` object
     * Change `CardTokenizeCallback` parameters
+    * Update package name to `com.braintreepayments.api.card`
   * SEPA Direct Debit
     * Remove `SEPADirectDebitLifecycleObserver` and `SEPADirectDebitListener`
     * Add `SEPADirectDebitLauncher`, `SEPADirectDebitPendingRequest`, 
@@ -121,7 +122,7 @@
   * American Express
     * Change parameters of `AmericanExpressGetRewardsBalanceCallback`
     * Add `AmericanExpressResult`
-    * Update package name to `com.braintreepayments.americanexpress`
+    * Update package name to `com.braintreepayments.api.americanexpress`
   * Samsung Pay
     * Remove entire Samsung Pay module
   * PayPal Native Checkout

--- a/Card/src/androidTest/java/com/braintreepayments/api/CardClientTest.java
+++ b/Card/src/androidTest/java/com/braintreepayments/api/CardClientTest.java
@@ -11,6 +11,8 @@ import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.braintreepayments.api.card.CardResult;
+
 import org.json.JSONException;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/Card/src/androidTest/java/com/braintreepayments/api/card/CardClientTest.java
+++ b/Card/src/androidTest/java/com/braintreepayments/api/card/CardClientTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import static com.braintreepayments.api.CardNumber.VISA;
 import static com.braintreepayments.api.Fixtures.TOKENIZATION_KEY;
@@ -11,7 +11,16 @@ import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.braintreepayments.api.card.CardResult;
+import com.braintreepayments.api.Authorization;
+import com.braintreepayments.api.AuthorizationException;
+import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.Configuration;
+import com.braintreepayments.api.ErrorWithResponse;
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.SharedPreferencesHelper;
+import com.braintreepayments.api.TestClientTokenBuilder;
+
+import junit.framework.Assert;
 
 import org.json.JSONException;
 import org.junit.Ignore;
@@ -199,7 +208,7 @@ public class CardClientTest {
         sut.tokenize(card, (cardResult) -> {
             assertTrue(cardResult instanceof CardResult.Failure);
             Exception error = ((CardResult.Failure) cardResult).getError();
-            assertEquals("CVV verification failed",
+            Assert.assertEquals("CVV verification failed",
                     ((ErrorWithResponse) error).errorFor("creditCard").getFieldErrors().get(0).getMessage());
             countDownLatch.countDown();
         });

--- a/Card/src/androidTest/java/com/braintreepayments/api/card/CardClientTest.java
+++ b/Card/src/androidTest/java/com/braintreepayments/api/card/CardClientTest.java
@@ -208,7 +208,7 @@ public class CardClientTest {
         sut.tokenize(card, (cardResult) -> {
             assertTrue(cardResult instanceof CardResult.Failure);
             Exception error = ((CardResult.Failure) cardResult).getError();
-            Assert.assertEquals("CVV verification failed",
+           assertEquals("CVV verification failed",
                     ((ErrorWithResponse) error).errorFor("creditCard").getFieldErrors().get(0).getMessage());
             countDownLatch.countDown();
         });

--- a/Card/src/main/java/com/braintreepayments/api/card/AuthenticationInsight.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/AuthenticationInsight.java
@@ -1,9 +1,11 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
+
+import com.braintreepayments.api.Json;
 
 import org.json.JSONObject;
 

--- a/Card/src/main/java/com/braintreepayments/api/card/BaseCard.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/BaseCard.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -6,6 +6,8 @@ import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+
+import com.braintreepayments.api.PaymentMethod;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Card/src/main/java/com/braintreepayments/api/card/BinData.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/BinData.java
@@ -1,10 +1,13 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.annotation.StringDef;
+
+import com.braintreepayments.api.Json;
 
 import org.json.JSONObject;
 
@@ -45,7 +48,8 @@ public class BinData implements Parcelable {
     private String countryOfIssuance;
     private String productId;
 
-    protected static BinData fromJson(JSONObject json) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static BinData fromJson(JSONObject json) {
         if (json == null) {
             json = new JSONObject();
         }

--- a/Card/src/main/java/com/braintreepayments/api/card/Card.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/Card.java
@@ -29,7 +29,8 @@ public class Card extends BaseCard implements Parcelable {
 
     private boolean shouldValidate;
 
-    JSONObject buildJSONForGraphQL() throws BraintreeException, JSONException {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public JSONObject buildJSONForGraphQL() throws BraintreeException, JSONException {
         JSONObject base = new JSONObject();
         JSONObject input = new JSONObject();
         JSONObject variables = new JSONObject();

--- a/Card/src/main/java/com/braintreepayments/api/card/Card.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/Card.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 
+import com.braintreepayments.api.BraintreeException;
 import com.braintreepayments.api.GraphQLConstants.Keys;
 
 import org.json.JSONException;

--- a/Card/src/main/java/com/braintreepayments/api/card/CardAnalytics.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardAnalytics.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.card
 
 internal object CardAnalytics {
 

--- a/Card/src/main/java/com/braintreepayments/api/card/CardClient.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardClient.java
@@ -1,9 +1,15 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+
+import com.braintreepayments.api.ApiClient;
+import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.BraintreeException;
+import com.braintreepayments.api.ErrorWithResponse;
+import com.braintreepayments.api.GraphQLConstants;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Card/src/main/java/com/braintreepayments/api/card/CardNonce.java
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardNonce.java
@@ -1,26 +1,30 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
+
+import static com.braintreepayments.api.card.BinData.BIN_DATA_KEY;
 
 import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import static com.braintreepayments.api.BinData.BIN_DATA_KEY;
+import com.braintreepayments.api.Json;
+import com.braintreepayments.api.PaymentMethodNonce;
 
 /**
  * {@link PaymentMethodNonce} representing a credit or debit card.
  */
 public class CardNonce extends PaymentMethodNonce {
 
-    static final String API_RESOURCE_KEY = "creditCards";
+    protected static final String API_RESOURCE_KEY = "creditCards";
 
     private static final String PAYMENT_METHOD_NONCE_KEY = "nonce";
     private static final String PAYMENT_METHOD_DEFAULT_KEY = "default";
 
-    static final String DATA_KEY = "data";
+    protected static final String DATA_KEY = "data";
     private static final String TOKEN_KEY = "token";
 
     private static final String GRAPHQL_TOKENIZE_CREDIT_CARD_KEY = "tokenizeCreditCard";
@@ -53,8 +57,9 @@ public class CardNonce extends PaymentMethodNonce {
      * @return {@link CardNonce}
      * @throws JSONException if nonce could not be parsed successfully
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @NonNull
-    static CardNonce fromJSON(JSONObject inputJson) throws JSONException {
+    public static CardNonce fromJSON(JSONObject inputJson) throws JSONException {
         if (isGraphQLTokenizationResponse(inputJson)) {
             return CardNonce.fromGraphQLJSON(inputJson);
         } else if (isRESTfulTokenizationResponse(inputJson)) {
@@ -141,7 +146,8 @@ public class CardNonce extends PaymentMethodNonce {
         }
     }
 
-    CardNonce(String cardType, String lastTwo, String lastFour, String bin, BinData binData,
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public CardNonce(String cardType, String lastTwo, String lastFour, String bin, BinData binData,
               AuthenticationInsight authenticationInsight, String expirationMonth,
               String expirationYear, String cardholderName, String nonce, boolean isDefault) {
         super(nonce, isDefault);

--- a/Card/src/main/java/com/braintreepayments/api/card/CardResult.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.card
 
 /**
  * Result of tokenizing a [Card]

--- a/Card/src/main/java/com/braintreepayments/api/card/CardTokenizeCallback.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardTokenizeCallback.kt
@@ -1,4 +1,6 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.card
+
+import com.braintreepayments.api.card.CardResult
 
 /**
  * Callback for receiving result of [CardClient.tokenize].

--- a/Card/src/main/java/com/braintreepayments/api/card/CardTokenizeCallback.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardTokenizeCallback.kt
@@ -1,7 +1,5 @@
 package com.braintreepayments.api.card
 
-import com.braintreepayments.api.card.CardResult
-
 /**
  * Callback for receiving result of [CardClient.tokenize].
  */

--- a/Card/src/test/java/com/braintreepayments/api/CardAnalyticsUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/CardAnalyticsUnitTest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api
 
+import com.braintreepayments.api.card.CardAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/Card/src/test/java/com/braintreepayments/api/CardClientUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/CardClientUnitTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import android.content.Context;
+import com.braintreepayments.api.card.CardAnalytics;
+import com.braintreepayments.api.card.CardResult;
+import com.braintreepayments.api.card.CardTokenizeCallback;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Card/src/test/java/com/braintreepayments/api/card/AuthenticationInsightUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/card/AuthenticationInsightUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import android.os.Parcel;
 

--- a/Card/src/test/java/com/braintreepayments/api/card/BinDataUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/card/BinDataUnitTest.java
@@ -1,17 +1,19 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
+
+import static com.braintreepayments.api.Assertions.assertBinDataEqual;
+import static com.braintreepayments.api.card.BinData.UNKNOWN;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 
 import android.os.Parcel;
+
+import com.braintreepayments.api.Fixtures;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
-import static com.braintreepayments.api.BinData.UNKNOWN;
-import static com.braintreepayments.api.Assertions.assertBinDataEqual;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class BinDataUnitTest {

--- a/Card/src/test/java/com/braintreepayments/api/card/CardAnalyticsUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardAnalyticsUnitTest.kt
@@ -1,6 +1,5 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.card
 
-import com.braintreepayments.api.card.CardAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -9,6 +9,13 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.braintreepayments.api.ApiClient;
+import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.Configuration;
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.MockApiClientBuilder;
+import com.braintreepayments.api.MockBraintreeClientBuilder;
+import com.braintreepayments.api.TokenizeCallback;
 import com.braintreepayments.api.card.CardAnalytics;
 import com.braintreepayments.api.card.CardResult;
 import com.braintreepayments.api.card.CardTokenizeCallback;

--- a/Card/src/test/java/com/braintreepayments/api/card/CardNonceUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardNonceUnitTest.java
@@ -1,22 +1,24 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
+
+import static com.braintreepayments.api.Assertions.assertBinDataEqual;
+import static com.braintreepayments.api.card.BinData.NO;
+import static com.braintreepayments.api.card.BinData.UNKNOWN;
+import static com.braintreepayments.api.card.BinData.YES;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import android.os.Parcel;
+
+import com.braintreepayments.api.Fixtures;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
-import static com.braintreepayments.api.BinData.NO;
-import static com.braintreepayments.api.BinData.UNKNOWN;
-import static com.braintreepayments.api.BinData.YES;
-import static com.braintreepayments.api.Assertions.assertBinDataEqual;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class CardNonceUnitTest {

--- a/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
@@ -1,7 +1,11 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.card
 
 import android.os.Parcel
+import com.braintreepayments.api.BraintreeException
 import com.braintreepayments.api.CardNumber.VISA
+import com.braintreepayments.api.GraphQLConstants
+import com.braintreepayments.api.MetadataBuilder
+import com.braintreepayments.api.PaymentMethod
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNull

--- a/Card/src/test/java/com/braintreepayments/api/card/ThreeDSecureInfoUnitTest.java
+++ b/Card/src/test/java/com/braintreepayments/api/card/ThreeDSecureInfoUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.card;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -7,6 +7,9 @@ import org.junit.Test;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.ThreeDSecureInfo;
 
 public class ThreeDSecureInfoUnitTest {
 

--- a/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFragment.java
@@ -15,10 +15,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.braintreepayments.api.Card;
-import com.braintreepayments.api.CardClient;
-import com.braintreepayments.api.CardNonce;
-import com.braintreepayments.api.CardResult;
+import com.braintreepayments.api.card.Card;
+import com.braintreepayments.api.card.CardClient;
+import com.braintreepayments.api.card.CardNonce;
+import com.braintreepayments.api.card.CardResult;
 import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.DataCollectorResult;
 import com.braintreepayments.api.PaymentMethodNonce;

--- a/Demo/src/main/java/com/braintreepayments/demo/CreateTransactionFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/CreateTransactionFragment.java
@@ -16,7 +16,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import com.braintreepayments.api.PaymentMethodNonce;
-import com.braintreepayments.api.CardNonce;
 import com.braintreepayments.demo.models.Transaction;
 
 import retrofit.Callback;

--- a/Demo/src/main/java/com/braintreepayments/demo/PaymentMethodNonceFormatter.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PaymentMethodNonceFormatter.java
@@ -1,7 +1,7 @@
 package com.braintreepayments.demo;
 
-import com.braintreepayments.api.BinData;
-import com.braintreepayments.api.CardNonce;
+import com.braintreepayments.api.card.BinData;
+import com.braintreepayments.api.card.CardNonce;
 import com.braintreepayments.api.GooglePayCardNonce;
 import com.braintreepayments.api.LocalPaymentNonce;
 import com.braintreepayments.api.PayPalAccountNonce;

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayCardNonce.java
@@ -1,13 +1,15 @@
 package com.braintreepayments.api;
 
+import static com.braintreepayments.api.card.BinData.BIN_DATA_KEY;
+
 import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 
+import com.braintreepayments.api.card.BinData;
+
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import static com.braintreepayments.api.BinData.BIN_DATA_KEY;
 
 /**
  * {@link PaymentMethodNonce} representing a Google Pay card.

--- a/TestUtils/src/main/java/com/braintreepayments/api/Assertions.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/Assertions.java
@@ -4,6 +4,8 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
+import com.braintreepayments.api.card.BinData;
+
 public class Assertions {
 
     public static void assertIsANonce(String maybeANonce) {

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureInfo.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureInfo.java
@@ -4,6 +4,9 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+
+import com.braintreepayments.api.card.CardNonce;
 
 import org.json.JSONObject;
 
@@ -50,7 +53,8 @@ public class ThreeDSecureInfo implements Parcelable {
     private String lookupTransactionStatus;
     private String lookupTransactionStatusReason;
 
-    static ThreeDSecureInfo fromJson(JSONObject json) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static ThreeDSecureInfo fromJson(JSONObject json) {
         if (json == null) {
             json = new JSONObject();
         }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureNonce.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureNonce.java
@@ -4,6 +4,11 @@ package com.braintreepayments.api;
 import android.os.Parcel;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+
+import com.braintreepayments.api.card.AuthenticationInsight;
+import com.braintreepayments.api.card.BinData;
+import com.braintreepayments.api.card.CardNonce;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -33,8 +38,9 @@ public class ThreeDSecureNonce extends CardNonce {
         this.threeDSecureInfo = threeDSecureInfo;
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @NonNull
-    static ThreeDSecureNonce fromJSON(JSONObject inputJson) throws JSONException {
+    public static ThreeDSecureNonce fromJSON(JSONObject inputJson) throws JSONException {
         CardNonce cardNonce = CardNonce.fromJSON(inputJson);
         ThreeDSecureInfo threeDSecureInfo;
         if (inputJson.has(DATA_KEY)) { // graphQL

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureParams.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureParams.java
@@ -5,6 +5,8 @@ import android.os.Parcelable;
 
 import androidx.annotation.Nullable;
 
+import com.braintreepayments.api.card.CardNonce;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureNonceUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureNonceUnitTest.java
@@ -1,9 +1,9 @@
 package com.braintreepayments.api;
 
 import static com.braintreepayments.api.Assertions.assertBinDataEqual;
-import static com.braintreepayments.api.BinData.NO;
-import static com.braintreepayments.api.BinData.UNKNOWN;
-import static com.braintreepayments.api.BinData.YES;
+import static com.braintreepayments.api.card.BinData.NO;
+import static com.braintreepayments.api.card.BinData.UNKNOWN;
+import static com.braintreepayments.api.card.BinData.YES;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/VisaCheckoutNonce.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/VisaCheckoutNonce.java
@@ -1,10 +1,12 @@
 package com.braintreepayments.api;
 
-import static com.braintreepayments.api.BinData.BIN_DATA_KEY;
+import static com.braintreepayments.api.card.BinData.BIN_DATA_KEY;
 
 import android.os.Parcel;
 
 import androidx.annotation.NonNull;
+
+import com.braintreepayments.api.card.BinData;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/VisaCheckoutNonceUnitTest.java
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/VisaCheckoutNonceUnitTest.java
@@ -1,5 +1,13 @@
 package com.braintreepayments.api;
 
+import static com.braintreepayments.api.Assertions.assertBinDataEqual;
+import static com.braintreepayments.api.card.BinData.NO;
+import static com.braintreepayments.api.card.BinData.UNKNOWN;
+import static com.braintreepayments.api.card.BinData.YES;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+
 import android.os.Parcel;
 
 import org.json.JSONArray;
@@ -8,14 +16,6 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
-import static com.braintreepayments.api.BinData.NO;
-import static com.braintreepayments.api.BinData.UNKNOWN;
-import static com.braintreepayments.api.BinData.YES;
-import static com.braintreepayments.api.Assertions.assertBinDataEqual;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class VisaCheckoutNonceUnitTest {

--- a/docs/Card/com.braintreepayments.api/-card-client/tokenize.html
+++ b/docs/Card/com.braintreepayments.api/-card-client/tokenize.html
@@ -46,7 +46,7 @@
         <div id="sideMenu"></div>
     </div>
     <div id="main">
-<div class="main-content" id="content" pageids="Card::com.braintreepayments.api/CardClient/tokenize/#com.braintreepayments.api.Card#com.braintreepayments.api.CardTokenizeCallback/PointingToDeclaration//1795318307">
+<div class="main-content" id="content" pageids="Card::com.braintreepayments.api/CardClient/tokenize/#com.braintreepayments.api.Card#com.braintreepayments.api.card.CardTokenizeCallback/PointingToDeclaration//1795318307">
   <div class="breadcrumbs"><a href="../../index.html">Card</a><span class="delimiter">/</span><a href="../index.html">com.braintreepayments.api</a><span class="delimiter">/</span><a href="index.html">CardClient</a><span class="delimiter">/</span><span class="current">tokenize</span></div>
   <div class="cover ">
     <h1 class="cover"><span><span>tokenize</span></span></h1>


### PR DESCRIPTION
### Summary of changes

 - Update the Card module package name to `com.braintreepayments.api.card`

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
