### PR TITLE
Add has user location consent param in PayPal, PayPal Native, and Local Payment modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
 * PayPalNativeCheckout
   * Add required property `hasUserLocationConsent` to `PayPalNativeCheckoutRequest`, `PayPalNativeVaultRequest` and `PayPalNativeCheckoutRequest`
   * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
+* BraintreeDataCollector
+  * Add `DataCollectorRequest` to pass in `hasUserLocationConsent`
+  * Update `DataCollector.collectDeviceData()` to take in `DataCollectorRequest`
+  * Deprecate existing `DataCollector.collectDeviceData()`
+* PayPalDataCollector
+  * Add `PayPalDataCollectorRequest` to pass in `hasUserLocationConsent`
+  * Update `PayPalDataCollector.collectDeviceData()` to take in `PayPalDataCollectorRequest`
+  * Deprecate existing `PayPalDataCollector.collectDeviceData()`
 
 ## 4.43.0 (2024-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Local Payment
+  * Add required property `hasUserLocationConsent` to `LocalPaymentRequest`
+  * Deprecate existing constructor that does not pass in `hasUserLocationConsent`
+* PayPal
+  * Add required property `hasUserLocationConsent` to `PayPalCheckoutRequest`, `PayPalVaultRequest` and `PayPalRequest`
+  * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
+* PayPalNativeCheckout
+  * Add required property `hasUserLocationConsent` to `PayPalNativeCheckoutRequest`, `PayPalNativeVaultRequest` and `PayPalNativeCheckoutRequest`
+  * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
+
 ## 4.43.0 (2024-03-19)
 
 * Move from Braintree to PayPal analytics service (FPTI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,34 @@
 
 ## unreleased
 
+
 * Local Payment
-  * Add required property `hasUserLocationConsent` to `LocalPaymentRequest`
-  * Deprecate existing constructor that does not pass in `hasUserLocationConsent`
+  * Fixes Google Play Store Rejection
+    * See [developer documentation](link) for required updates for user location data compliance
+    * Add `hasUserLocationConsent` property to `LocalPaymentRequest`
+    * Deprecate existing constructor that does not pass in `hasUserLocationConsent`
 * PayPal
-  * Add required property `hasUserLocationConsent` to `PayPalCheckoutRequest`, `PayPalVaultRequest` and `PayPalRequest`
-  * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
+  * Fixes Google Play Store Rejection
+    * See [developer documentation](link) for required updates for user location data compliance
+    * Add `hasUserLocationConsent` property to `PayPalCheckoutRequest`, `PayPalVaultRequest` and `PayPalRequest`
+    * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
 * PayPalNativeCheckout
-  * Add required property `hasUserLocationConsent` to `PayPalNativeCheckoutRequest`, `PayPalNativeVaultRequest` and `PayPalNativeCheckoutRequest`
-  * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
+  * Fixes Google Play Store Rejection
+    * See [developer documentation](link) for required updates for user location data compliance
+    * Add `hasUserLocationConsent` property to `PayPalNativeCheckoutRequest`, `PayPalNativeVaultRequest` and `PayPalNativeCheckoutRequest`
+    * Deprecate existing constructors that do not pass in `hasUserLocationConsent`
 * BraintreeDataCollector
-  * Add `DataCollectorRequest` to pass in `hasUserLocationConsent`
-  * Update `DataCollector.collectDeviceData()` to take in `DataCollectorRequest`
-  * Deprecate existing `DataCollector.collectDeviceData()`
+  * Fixes Google Play Store Rejection
+    * See [developer documentation](link) for required updates for user location data compliance
+    * Add `DataCollectorRequest` to pass in `hasUserLocationConsent`
+    * Update `DataCollector.collectDeviceData()` to take in `DataCollectorRequest`
+    * Deprecate existing `DataCollector.collectDeviceData()`
 * PayPalDataCollector
-  * Add `PayPalDataCollectorRequest` to pass in `hasUserLocationConsent`
-  * Update `PayPalDataCollector.collectDeviceData()` to take in `PayPalDataCollectorRequest`
-  * Deprecate existing `PayPalDataCollector.collectDeviceData()`
+  * Fixes Google Play Store Rejection
+    * See [developer documentation](link) for required updates for user location data compliance
+    * Add `PayPalDataCollectorRequest` to pass in `hasUserLocationConsent`
+    * Update `PayPalDataCollector.collectDeviceData()` to take in `PayPalDataCollectorRequest`
+    * Deprecate existing `PayPalDataCollector.collectDeviceData()`
 
 ## 4.43.0 (2024-03-19)
 

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentClient.java
@@ -33,6 +33,8 @@ public class LocalPaymentClient {
      */
     private String payPalContextId = null;
 
+    private boolean hasUserLocationConsent;
+
     @VisibleForTesting
     BrowserSwitchResult pendingBrowserSwitchResult;
 
@@ -136,6 +138,7 @@ public class LocalPaymentClient {
                                     if (pairingId != null && !pairingId.isEmpty()) {
                                         payPalContextId = pairingId;
                                     }
+                                    hasUserLocationConsent = request.hasUserLocationConsent();
                                     sendAnalyticsEvent(request.getPaymentType(), "local-payment.create.succeeded");
                                 } else if (error != null) {
                                     sendAnalyticsEvent(request.getPaymentType(), "local-payment.webswitch.initiate.failed");
@@ -323,18 +326,18 @@ public class LocalPaymentClient {
                     @Override
                     public void onResult(@Nullable Configuration configuration, @Nullable Exception error) {
                         if (configuration != null) {
-                            // TODO: pass in hasUserLocationConsent value
-                            localPaymentApi.tokenize(merchantAccountId, responseString, payPalDataCollector.getClientMetadataId(context, configuration, false), new LocalPaymentBrowserSwitchResultCallback() {
-                                @Override
-                                public void onResult(@Nullable LocalPaymentNonce localPaymentNonce, @Nullable Exception error) {
-                                    if (localPaymentNonce != null) {
-                                        sendAnalyticsEvent(paymentType, "local-payment.tokenize.succeeded");
-                                    } else if (error != null) {
-                                        sendAnalyticsEvent(paymentType, "local-payment.tokenize.failed");
+                            localPaymentApi.tokenize(merchantAccountId, responseString, payPalDataCollector.getClientMetadataId(context, configuration, hasUserLocationConsent),
+                                new LocalPaymentBrowserSwitchResultCallback() {
+                                    @Override
+                                    public void onResult(@Nullable LocalPaymentNonce localPaymentNonce, @Nullable Exception error) {
+                                        if (localPaymentNonce != null) {
+                                            sendAnalyticsEvent(paymentType, "local-payment.tokenize.succeeded");
+                                        } else if (error != null) {
+                                            sendAnalyticsEvent(paymentType, "local-payment.tokenize.failed");
+                                        }
+                                        callback.onResult(localPaymentNonce, error);
                                     }
-                                    callback.onResult(localPaymentNonce, error);
-                                }
-                            });
+                                });
                         } else if (error != null) {
                             callback.onResult(null, error);
                         }

--- a/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentRequest.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/LocalPaymentRequest.java
@@ -45,6 +45,22 @@ public class LocalPaymentRequest {
     private String phone;
     private boolean shippingAddressRequired;
     private String surname;
+    private final boolean hasUserLocationConsent;
+
+    /**
+     * Deprecated. Use {@link LocalPaymentRequest#LocalPaymentRequest(boolean)} instead.
+     **/
+    @Deprecated
+    public LocalPaymentRequest() {
+        hasUserLocationConsent = false;
+    }
+
+    /**
+     * TODO: add javadoc for hasUserLocationConsent param
+     */
+    public LocalPaymentRequest(boolean hasUserLocationConsent) {
+        this.hasUserLocationConsent = hasUserLocationConsent;
+    }
 
     /**
      * @param address Optional - The address of the customer. An error will occur if this address is not valid.
@@ -204,6 +220,10 @@ public class LocalPaymentRequest {
     @Nullable
     public String getSurname() {
         return surname;
+    }
+
+    public boolean hasUserLocationConsent() {
+        return hasUserLocationConsent;
     }
 
     public String build(String returnUrl, String cancelUrl) {

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -764,6 +764,42 @@ public class LocalPaymentClientUnitTest {
         verify(braintreeClient).clearActiveBrowserSwitchRequests(activity);
     }
 
+    @Test
+    public void onBrowserSwitchResult_sends_the_correct_value_of_hasUserLocationConsent_to_getClientMetadataId() throws JSONException {
+        BrowserSwitchResult browserSwitchResult = mock(BrowserSwitchResult.class);
+        when(browserSwitchResult.getStatus()).thenReturn(BrowserSwitchStatus.SUCCESS);
+
+        when(browserSwitchResult.getRequestMetadata()).thenReturn(new JSONObject()
+            .put("payment-type", "ideal")
+            .put("merchant-account-id", "local-merchant-account-id"));
+
+        String webUrl = "sample-scheme://local-payment-success?paymentToken=successTokenId";
+        when(browserSwitchResult.getDeepLinkUrl()).thenReturn(Uri.parse(webUrl));
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(payPalEnabledConfig)
+            .integration("custom")
+            .sessionId("session-id")
+            .build();
+        when(payPalDataCollector.getClientMetadataId(any(Context.class), same(payPalEnabledConfig), anyBoolean())).thenReturn("client-metadata-id");
+
+        LocalPaymentNonce successNonce = LocalPaymentNonce.fromJSON(new JSONObject(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_RESPONSE));
+        LocalPaymentResult localPaymentResult = mock(LocalPaymentResult.class);
+        LocalPaymentApi localPaymentApi = new MockLocalPaymentApiBuilder()
+            .tokenizeSuccess(successNonce)
+            .createPaymentMethodSuccess(localPaymentResult)
+            .build();
+
+        LocalPaymentRequest request = getIdealLocalPaymentRequest();
+        LocalPaymentClient sut = new LocalPaymentClient(activity, lifecycle, braintreeClient, payPalDataCollector, localPaymentApi);
+
+        sut.startPayment(request, localPaymentStartCallback);
+
+        sut.setListener(listener);
+        sut.onBrowserSwitchResult(activity, browserSwitchResult);
+
+        verify(payPalDataCollector).getClientMetadataId(any(), eq(payPalEnabledConfig), eq(true));
+    }
+
     private LocalPaymentRequest getIdealLocalPaymentRequest() {
         PostalAddress address = new PostalAddress();
         address.setStreetAddress("836486 of 22321 Park Lake");
@@ -773,7 +809,7 @@ public class LocalPaymentClientUnitTest {
         address.setRegion("CA");
         address.setPostalCode("2585 GJ");
 
-        LocalPaymentRequest request = new LocalPaymentRequest();
+        LocalPaymentRequest request = new LocalPaymentRequest(true);
         request.setPaymentType("ideal");
         request.setAmount("1.10");
         request.setAddress(address);

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentClientUnitTest.java
@@ -797,7 +797,7 @@ public class LocalPaymentClientUnitTest {
         sut.setListener(listener);
         sut.onBrowserSwitchResult(activity, browserSwitchResult);
 
-        verify(payPalDataCollector).getClientMetadataId(any(), eq(payPalEnabledConfig), eq(true));
+        verify(payPalDataCollector).getClientMetadataId(any(), same(payPalEnabledConfig), eq(true));
     }
 
     private LocalPaymentRequest getIdealLocalPaymentRequest() {

--- a/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentRequestUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/LocalPaymentRequestUnitTest.java
@@ -9,10 +9,17 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class LocalPaymentRequestUnitTest {
+
+    @Test
+    public void constructor_without_hasUserLocationConsent_defaults_to_false() {
+        LocalPaymentRequest request = new LocalPaymentRequest();
+        assertFalse(request.hasUserLocationConsent());
+    }
     
     @Test
     public void build_setsAllParams() throws JSONException {
@@ -24,7 +31,7 @@ public class LocalPaymentRequestUnitTest {
         address.setRegion("CA");
         address.setPostalCode("2585 GJ");
 
-        LocalPaymentRequest request = new LocalPaymentRequest();
+        LocalPaymentRequest request = new LocalPaymentRequest(true);
         request.setPaymentType("ideal");
         request.setAmount("1.10");
         request.setAddress(address);
@@ -38,6 +45,8 @@ public class LocalPaymentRequestUnitTest {
         request.setPaymentTypeCountryCode("NL");
         request.setBic("bank-id-code");
         request.setDisplayName("My Brand!");
+
+        assertTrue(request.hasUserLocationConsent());
 
         JSONObject json = new JSONObject(request.build("http://success-url.com", "http://cancel-url.com"));
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -49,6 +49,8 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
     private boolean shouldOfferPayLater;
 
     /**
+     * Deprecated. Use {@link PayPalCheckoutRequest#PayPalCheckoutRequest(String, boolean)} instead.
+     *
      * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
      *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
      *               number, may optionally contain exactly 2 decimal places separated by '.' and is
@@ -57,8 +59,26 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
      *               This amount may differ slightly from the transaction amount. The exact decline rules
      *               for mismatches between this client-side amount and the final amount in the Transaction
      *               are determined by the gateway.
-     **/
+     */
+    @Deprecated
     public PayPalCheckoutRequest(@NonNull String amount) {
+        super(false);
+        this.amount = amount;
+    }
+
+    /**
+     * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
+     *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
+     *               number, may optionally contain exactly 2 decimal places separated by '.' and is
+     *               limited to 7 digits before the decimal point.
+     *               <p>
+     *               This amount may differ slightly from the transaction amount. The exact decline rules
+     *               for mismatches between this client-side amount and the final amount in the Transaction
+     *               are determined by the gateway.
+     * TODO: add javadoc for hasUserLocationConsent param
+     */
+    public PayPalCheckoutRequest(@NonNull String amount, boolean hasUserLocationConsent) {
+        super(hasUserLocationConsent);
         this.amount = amount;
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalInternalClient.java
@@ -71,9 +71,8 @@ class PayPalInternalClient {
 
                                                     String pairingIdKey = isBillingAgreement ? "ba_token" : "token";
                                                     String pairingId = parsedRedirectUri.getQueryParameter(pairingIdKey);
-                                                    // TODO: pass in hasUserLocationConsent value
                                                     String clientMetadataId = payPalRequest.getRiskCorrelationId() != null
-                                                            ? payPalRequest.getRiskCorrelationId() : payPalDataCollector.getClientMetadataId(context, configuration, false);
+                                                            ? payPalRequest.getRiskCorrelationId() : payPalDataCollector.getClientMetadataId(context, configuration, payPalRequest.hasUserLocationConsent());
 
                                                     if (pairingId != null) {
                                                         payPalResponse

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -70,13 +70,17 @@ public abstract class PayPalRequest implements Parcelable {
     private String merchantAccountId;
     private String riskCorrelationId;
     private final ArrayList<PayPalLineItem> lineItems;
+    private final boolean hasUserLocationConsent;
 
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
+     *
+     * TODO: add javadoc for hasUserLocationConsent param
      */
-    public PayPalRequest() {
+    public PayPalRequest(boolean hasUserLocationConsent) {
         shippingAddressRequired = false;
         lineItems = new ArrayList<>();
+        this.hasUserLocationConsent = hasUserLocationConsent;
     }
 
     /**
@@ -255,6 +259,10 @@ public abstract class PayPalRequest implements Parcelable {
         return landingPageType;
     }
 
+    public boolean hasUserLocationConsent() {
+        return hasUserLocationConsent;
+    }
+
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
 
     protected PayPalRequest(Parcel in) {
@@ -268,6 +276,7 @@ public abstract class PayPalRequest implements Parcelable {
         merchantAccountId = in.readString();
         riskCorrelationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
+        hasUserLocationConsent = in.readByte() != 0;
     }
 
     @Override
@@ -287,5 +296,6 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(merchantAccountId);
         parcel.writeString(riskCorrelationId);
         parcel.writeTypedList(lineItems);
+        parcel.writeByte((byte) (hasUserLocationConsent ? 1 : 0));
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -73,6 +73,18 @@ public abstract class PayPalRequest implements Parcelable {
     private final boolean hasUserLocationConsent;
 
     /**
+     * Deprecated. Use {@link PayPalRequest#PayPalRequest(boolean)} instead.
+     *
+     * Constructs a request for PayPal Checkout and Vault flows.
+     */
+    @Deprecated
+    public PayPalRequest() {
+        shippingAddressRequired = false;
+        lineItems = new ArrayList<>();
+        hasUserLocationConsent = false;
+    }
+
+    /**
      * Constructs a request for PayPal Checkout and Vault flows.
      *
      * TODO: add javadoc for hasUserLocationConsent param

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -18,7 +18,19 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     private String userAuthenticationEmail;
 
+    /**
+     * Deprecated. Use {@link PayPalVaultRequest#PayPalVaultRequest(boolean)} instead.
+     */
+    @Deprecated
     public PayPalVaultRequest() {
+        super(false);
+    }
+
+    /**
+     * TODO: add javadoc for hasUserLocationConsent param
+     */
+    public PayPalVaultRequest(boolean hasUserLocationConsent) {
+        super(hasUserLocationConsent);
     }
 
     /**

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -19,7 +19,7 @@ public class PayPalCheckoutRequestUnitTest {
 
     @Test
     public void newPayPalCheckoutRequest_setsDefaultValues() {
-        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00");
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", false);
 
         assertNotNull(request.getAmount());
         assertNull(request.getCurrencyCode());
@@ -31,12 +31,19 @@ public class PayPalCheckoutRequestUnitTest {
         assertNull(request.getLandingPageType());
         assertNull(request.getBillingAgreementDescription());
         assertFalse(request.getShouldOfferPayLater());
+        assertFalse(request.hasUserLocationConsent());
+    }
+
+    @Test
+    public void newPayPalCheckoutRequest_without_hasUserLocationConsent_defaults_to_false() {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00");
+        assertFalse(request.hasUserLocationConsent());
     }
 
     @Test
     public void setsValuesCorrectly() {
         PostalAddress postalAddress = new PostalAddress();
-        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00");
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
         request.setCurrencyCode("USD");
         request.setShouldOfferPayLater(true);
         request.setIntent(PayPalPaymentIntent.SALE);
@@ -64,11 +71,12 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals("123-correlation", request.getRiskCorrelationId());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferPayLater());
+        assertTrue(request.hasUserLocationConsent());
     }
 
     @Test
     public void parcelsCorrectly() {
-        PayPalCheckoutRequest request = new PayPalCheckoutRequest("12.34");
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("12.34", true);
         request.setCurrencyCode("USD");
         request.setLocaleCode("en-US");
         request.setBillingAgreementDescription("Billing Agreement Description");
@@ -112,5 +120,6 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+        assertTrue(result.hasUserLocationConsent());
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -658,4 +658,25 @@ public class PayPalInternalClientUnitTest {
 
         verify(callback).onResult((PayPalAccountNonce) isNull(), same(error));
     }
+
+    @Test
+    public void payPalDataCollector_passes_correct_arguments_to_getClientMetadataId() throws Exception {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL);
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(configuration)
+            .authorizationSuccess(clientToken)
+            .returnUrlScheme("sample-scheme")
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
+        payPalRequest.setIntent("authorize");
+        payPalRequest.setMerchantAccountId("sample-merchant-account-id");
+
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        verify(payPalDataCollector).getClientMetadataId(context, configuration, true);
+    }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -22,7 +22,7 @@ public class PayPalVaultRequestUnitTest {
 
     @Test
     public void newPayPalVaultRequest_setsDefaultValues() {
-        PayPalVaultRequest request = new PayPalVaultRequest();
+        PayPalVaultRequest request = new PayPalVaultRequest(false);
 
         assertNull(request.getLocaleCode());
         assertFalse(request.isShippingAddressRequired());
@@ -30,12 +30,19 @@ public class PayPalVaultRequestUnitTest {
         assertNull(request.getDisplayName());
         assertNull(request.getLandingPageType());
         assertFalse(request.getShouldOfferCredit());
+        assertFalse(request.hasUserLocationConsent());
+    }
+
+    @Test
+    public void newPayPalVaultRequest_without_hasUserLocationConsent_defaults_to_false() {
+        PayPalVaultRequest request = new PayPalVaultRequest();
+        assertFalse(request.hasUserLocationConsent());
     }
 
     @Test
     public void setsValuesCorrectly() {
         PostalAddress postalAddress = new PostalAddress();
-        PayPalVaultRequest request = new PayPalVaultRequest();
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
         request.setLocaleCode("US");
         request.setBillingAgreementDescription("Billing Agreement Description");
         request.setShippingAddressRequired(true);
@@ -53,11 +60,12 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("123-correlation", request.getRiskCorrelationId());
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
+        assertTrue(request.hasUserLocationConsent());
     }
 
     @Test
     public void parcelsCorrectly() {
-        PayPalVaultRequest request = new PayPalVaultRequest();
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
         request.setLocaleCode("en-US");
         request.setBillingAgreementDescription("Billing Agreement Description");
         request.setShippingAddressRequired(true);
@@ -96,6 +104,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+        assertTrue(result.hasUserLocationConsent());
     }
 
     @Test

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutInternalClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutInternalClient.java
@@ -59,9 +59,8 @@ class PayPalNativeCheckoutInternalClient {
 
                                         String pairingIdKey = isBillingAgreement ? "ba_token" : "token";
                                         String pairingId = parsedRedirectUri.getQueryParameter(pairingIdKey);
-                                        // TODO: pass in hasUserLocationConsent value
                                         String clientMetadataId = payPalRequest.getRiskCorrelationId() != null
-                                                ? payPalRequest.getRiskCorrelationId() : payPalDataCollector.getClientMetadataId(context, configuration, false);
+                                                ? payPalRequest.getRiskCorrelationId() : payPalDataCollector.getClientMetadataId(context, configuration, payPalRequest.hasUserLocationConsent());
 
                                         if (pairingId != null) {
                                             payPalResponse

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutRequest.java
@@ -49,6 +49,8 @@ public class PayPalNativeCheckoutRequest extends PayPalNativeRequest implements 
     private boolean shouldOfferPayLater;
 
     /**
+     * Deprecated. Use {@link PayPalNativeCheckoutRequest#PayPalNativeCheckoutRequest(String, boolean)} instead.
+     *
      * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
      *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
      *               number, may optionally contain exactly 2 decimal places separated by '.' and is
@@ -58,7 +60,25 @@ public class PayPalNativeCheckoutRequest extends PayPalNativeRequest implements 
      *               for mismatches between this client-side amount and the final amount in the Transaction
      *               are determined by the gateway.
      **/
+    @Deprecated
     public PayPalNativeCheckoutRequest(@NonNull String amount) {
+        super(false);
+        this.amount = amount;
+    }
+
+    /**
+     * @param amount The transaction amount in currency units (as * determined by setCurrencyCode).
+     *               For example, "1.20" corresponds to one dollar and twenty cents. Amount must be a non-negative
+     *               number, may optionally contain exactly 2 decimal places separated by '.' and is
+     *               limited to 7 digits before the decimal point.
+     *               <p>
+     *               This amount may differ slightly from the transaction amount. The exact decline rules
+     *               for mismatches between this client-side amount and the final amount in the Transaction
+     *               are determined by the gateway.
+     * TODO: add javadoc for hasUserLocationConsent param
+     **/
+    public PayPalNativeCheckoutRequest(@NonNull String amount, boolean hasUserLocationConsent) {
+        super(hasUserLocationConsent);
         this.amount = amount;
     }
 

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutVaultRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutVaultRequest.java
@@ -14,7 +14,19 @@ public class PayPalNativeCheckoutVaultRequest extends PayPalNativeRequest implem
 
     private boolean shouldOfferCredit;
 
+    /**
+     * Deprecated. Use {@link PayPalNativeCheckoutVaultRequest#PayPalNativeCheckoutVaultRequest(boolean)} instead.
+     */@Deprecated
+
     public PayPalNativeCheckoutVaultRequest() {
+        super(false);
+    }
+
+    /**
+     * TODO: add javadoc for hasUserLocationConsent param
+     */
+    public PayPalNativeCheckoutVaultRequest(boolean hasUserLocationConsent) {
+        super(hasUserLocationConsent);
     }
 
     /**

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeRequest.java
@@ -52,13 +52,16 @@ public abstract class PayPalNativeRequest implements Parcelable {
     private final ArrayList<PayPalNativeCheckoutLineItem> lineItems;
     private String returnUrl;
     private String userAuthenticationEmail;
+    private final boolean hasUserLocationConsent;
+
 
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
      */
-    public PayPalNativeRequest() {
+    public PayPalNativeRequest(boolean hasUserLocationConsent) {
         shippingAddressRequired = false;
         lineItems = new ArrayList<>();
+        this.hasUserLocationConsent = hasUserLocationConsent;
     }
 
     /**
@@ -256,6 +259,10 @@ public abstract class PayPalNativeRequest implements Parcelable {
         return lineItems;
     }
 
+    public boolean hasUserLocationConsent() {
+        return hasUserLocationConsent;
+    }
+
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
 
     protected PayPalNativeRequest(Parcel in) {
@@ -271,6 +278,7 @@ public abstract class PayPalNativeRequest implements Parcelable {
         lineItems = in.createTypedArrayList(PayPalNativeCheckoutLineItem.CREATOR);
         returnUrl = in.readString();
         userAuthenticationEmail = in.readString();
+        hasUserLocationConsent = in.readByte() != 0;
     }
 
     @Override
@@ -292,5 +300,6 @@ public abstract class PayPalNativeRequest implements Parcelable {
         parcel.writeTypedList(lineItems);
         parcel.writeString(returnUrl);
         parcel.writeString(userAuthenticationEmail);
+        parcel.writeByte((byte) (hasUserLocationConsent ? 1 : 0));
     }
 }

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -1,5 +1,11 @@
 package com.braintreepayments.api;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
 import android.os.Parcel;
 
 import org.junit.Test;
@@ -8,18 +14,12 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-
 @RunWith(RobolectricTestRunner.class)
 public class PayPalCheckoutRequestUnitTest {
 
     @Test
     public void newPayPalCheckoutRequest_setsDefaultValues() {
-        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00");
+        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00", false);
 
         assertNotNull(request.getAmount());
         assertNull(request.getCurrencyCode());
@@ -29,11 +29,18 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(PayPalNativeCheckoutPaymentIntent.AUTHORIZE, request.getIntent());
         assertNull(request.getBillingAgreementDescription());
         assertFalse(request.getShouldOfferPayLater());
+        assertFalse(request.hasUserLocationConsent());
+    }
+
+    @Test
+    public void newPayPalCheckoutRequest_without_hasUserLocationConsent_defaults_to_false() {
+        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00");
+        assertFalse(request.hasUserLocationConsent());
     }
 
     @Test
     public void setsValuesCorrectly() {
-        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00");
+        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("1.00", true);
         request.setCurrencyCode("USD");
         request.setShouldOfferPayLater(true);
         request.setIntent(PayPalNativeCheckoutPaymentIntent.SALE);
@@ -74,11 +81,12 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals("CA", request.getShippingAddressOverride().getRegion());
         assertEquals("US", request.getShippingAddressOverride().getCountryCodeAlpha2());
         assertTrue(request.getShouldOfferPayLater());
+        assertTrue(request.hasUserLocationConsent());
     }
 
     @Test
     public void parcelsCorrectly() {
-        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("12.34");
+        PayPalNativeCheckoutRequest request = new PayPalNativeCheckoutRequest("12.34", true);
         request.setCurrencyCode("USD");
         request.setLocaleCode("en-US");
         request.setBillingAgreementDescription("Billing Agreement Description");
@@ -117,5 +125,6 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+        assertTrue(result.hasUserLocationConsent());
     }
 }

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.kt
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutClientUnitTest.kt
@@ -58,7 +58,7 @@ class PayPalNativeCheckoutClientUnitTest {
 
     @Test
     fun tokenizePayPalAccount_throwsWhenPayPalRequestIsBaseClass() {
-        val baseRequest: PayPalNativeRequest = object : PayPalNativeRequest() {
+        val baseRequest: PayPalNativeRequest = object : PayPalNativeRequest(true) {
             @Throws(JSONException::class)
             public override fun createRequestBody(
                 configuration: Configuration,
@@ -346,7 +346,7 @@ class PayPalNativeCheckoutClientUnitTest {
 
     @Test
     fun launchNativeCheckout_notifiesErrorWhenPayPalRequestIsBaseClass_sendsAnalyticsEvents() {
-        val baseRequest: PayPalNativeRequest = object : PayPalNativeRequest() {
+        val baseRequest: PayPalNativeRequest = object : PayPalNativeRequest(true) {
             @Throws(JSONException::class)
             public override fun createRequestBody(
                 configuration: Configuration,

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutInternalClientUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalNativeCheckoutInternalClientUnitTest.java
@@ -606,4 +606,25 @@ public class PayPalNativeCheckoutInternalClientUnitTest {
 
         verify(callback).onResult(isNull(), same(error));
     }
+
+    @Test
+    public void payPalDataCollector_passes_correct_arguments_to_getClientMetadataId() throws Exception {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL);
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(configuration)
+            .authorizationSuccess(clientToken)
+            .returnUrlScheme("sample-scheme")
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
+
+        PayPalNativeCheckoutInternalClient sut = new PayPalNativeCheckoutInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        PayPalNativeCheckoutRequest payPalRequest = new PayPalNativeCheckoutRequest("1.00", true);
+        payPalRequest.setIntent("authorize");
+        payPalRequest.setMerchantAccountId("sample-merchant-account-id");
+
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        verify(payPalDataCollector).getClientMetadataId(context, configuration, true);
+    }
 }

--- a/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPalNativeCheckout/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -18,18 +18,25 @@ public class PayPalVaultRequestUnitTest {
 
     @Test
     public void newPayPalVaultRequest_setsDefaultValues() {
-        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest();
+        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest(false);
 
         assertNull(request.getLocaleCode());
         assertFalse(request.isShippingAddressRequired());
         assertNull(request.getDisplayName());
         assertFalse(request.getShouldOfferCredit());
+        assertFalse(request.hasUserLocationConsent());
+    }
+
+    @Test
+    public void newPayPalNativeVaultRequest_without_hasUserLocationConsent_defaults_to_false() {
+        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest();
+        assertFalse(request.hasUserLocationConsent());
     }
 
     @Test
     public void setsValuesCorrectly() {
         PostalAddress postalAddress = new PostalAddress();
-        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest();
+        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest(true);
         request.setLocaleCode("US");
         request.setBillingAgreementDescription("Billing Agreement Description");
         request.setShippingAddressRequired(true);
@@ -44,11 +51,12 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("Display Name", request.getDisplayName());
         assertEquals("123-correlation", request.getRiskCorrelationId());
         assertTrue(request.getShouldOfferCredit());
+        assertTrue(request.hasUserLocationConsent());
     }
 
     @Test
     public void parcelsCorrectly() {
-        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest();
+        PayPalNativeCheckoutVaultRequest request = new PayPalNativeCheckoutVaultRequest(true);
         request.setLocaleCode("en-US");
         request.setBillingAgreementDescription("Billing Agreement Description");
         request.setShippingAddressRequired(true);
@@ -82,5 +90,6 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("merchant_account_id", result.getMerchantAccountId());
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
+        assertTrue(result.hasUserLocationConsent());
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Add `hasUserLocationConsent` param to PayPal, PayPal Native, and Local Payment modules
 - Update missing changelog for Data Collector and PayPal Data Collector

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

### PayPal and Braintree engineering requirements
 > If you're an engineer for PayPal or Braintree, complete this section. For PRs from the community, please ignore!

**When do these changes need to be released?** 
[ ] ASAP (let's discuss outside this PR)
[ ] Soon, here's our target release date: <DD/MM/YYYY>
[ ] Whenever, no rush
