### PR TITLE
Update Visa Checkout Package Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
     * Rename `SEPADirectDebitPaymentAuthRequestCallback#onResult` to
      `SEPADirectDebitPaymentAuthRequestCallback#onSEPADirectDebitPaymentAuthResult`
   * Visa Checkout
+    * Update package name to `com.braintreepayments.api.visacheckout`
     * Change parameters of `VisaCheckoutCreateProfileBuilderCallback` and
       `VisaCheckoutTokenizeCallback`
     * Add `VisaCheckoutProfileBuilderResult` and `VisaCheckoutTokenizeResult`

--- a/Demo/src/main/java/com/braintreepayments/demo/PaymentMethodNonceFormatter.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PaymentMethodNonceFormatter.java
@@ -9,8 +9,8 @@ import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.PostalAddress;
 import com.braintreepayments.api.ThreeDSecureNonce;
 import com.braintreepayments.api.VenmoAccountNonce;
-import com.braintreepayments.api.VisaCheckoutAddress;
-import com.braintreepayments.api.VisaCheckoutNonce;
+import com.braintreepayments.api.visacheckout.VisaCheckoutAddress;
+import com.braintreepayments.api.visacheckout.VisaCheckoutNonce;
 
 import java.util.Arrays;
 import java.util.List;

--- a/Demo/src/main/java/com/braintreepayments/demo/VisaCheckoutFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/VisaCheckoutFragment.java
@@ -10,9 +10,9 @@ import androidx.annotation.Nullable;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.braintreepayments.api.PaymentMethodNonce;
-import com.braintreepayments.api.VisaCheckoutClient;
-import com.braintreepayments.api.VisaCheckoutProfileBuilderResult;
-import com.braintreepayments.api.VisaCheckoutResult;
+import com.braintreepayments.api.visacheckout.VisaCheckoutClient;
+import com.braintreepayments.api.visacheckout.VisaCheckoutProfileBuilderResult;
+import com.braintreepayments.api.visacheckout.VisaCheckoutResult;
 import com.visa.checkout.CheckoutButton;
 import com.visa.checkout.Profile;
 import com.visa.checkout.PurchaseInfo;

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccount.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccount.java
@@ -1,7 +1,8 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import androidx.annotation.RestrictTo;
 
+import com.braintreepayments.api.PaymentMethod;
 import com.visa.checkout.VisaPaymentSummary;
 
 import org.json.JSONException;

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAddress.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAddress.java
@@ -1,9 +1,11 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
+
+import com.braintreepayments.api.Json;
 
 import org.json.JSONObject;
 

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalytics.kt
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalytics.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
 internal object VisaCheckoutAnalytics {
 

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutClient.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutClient.java
@@ -1,10 +1,13 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import com.braintreepayments.api.ApiClient;
+import com.braintreepayments.api.BraintreeClient;
+import com.braintreepayments.api.ConfigurationException;
 import com.visa.checkout.Environment;
 import com.visa.checkout.Profile;
 import com.visa.checkout.VisaPaymentSummary;

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutCreateProfileBuilderCallback.kt
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutCreateProfileBuilderCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
 /**
  * Callback for receiving result of[VisaCheckoutClient.createProfileBuilder].

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutNonce.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutNonce.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import static com.braintreepayments.api.card.BinData.BIN_DATA_KEY;
 
@@ -6,6 +6,8 @@ import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 
+import com.braintreepayments.api.Json;
+import com.braintreepayments.api.PaymentMethodNonce;
 import com.braintreepayments.api.card.BinData;
 
 import org.json.JSONException;

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutProfileBuilderResult.kt
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutProfileBuilderResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
 import com.visa.checkout.Profile
 

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutResult.kt
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
 /**
  * Result of tokenizing a Visa Checkout account

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutTokenizeCallback.kt
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutTokenizeCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
 /**
  * Callback for receiving result of [VisaCheckoutClient.tokenize].

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutUserData.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/visacheckout/VisaCheckoutUserData.java
@@ -1,9 +1,11 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
+
+import com.braintreepayments.api.Json;
 
 import org.json.JSONObject;
 

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccountUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccountUnitTest.kt
@@ -1,5 +1,6 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
+import com.braintreepayments.api.visacheckout.VisaCheckoutAccount
 import com.visa.checkout.VisaPaymentSummary
 import io.mockk.every
 import io.mockk.mockk

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAddressUnitTest.java
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAddressUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import android.os.Parcel;
 
@@ -10,6 +10,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
+
+import com.braintreepayments.api.visacheckout.VisaCheckoutAddress;
 
 @RunWith(RobolectricTestRunner.class)
 public class VisaCheckoutAddressUnitTest {

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalyticsUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalyticsUnitTest.kt
@@ -1,5 +1,6 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
+import com.braintreepayments.api.visacheckout.VisaCheckoutAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutClientUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutClientUnitTest.kt
@@ -1,6 +1,11 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.visacheckout
 
+import com.braintreepayments.api.Configuration
 import com.braintreepayments.api.Configuration.Companion.fromJson
+import com.braintreepayments.api.Fixtures
+import com.braintreepayments.api.MockkApiClientBuilder
+import com.braintreepayments.api.MockkBraintreeClientBuilder
+import com.braintreepayments.api.TestConfigurationBuilder
 import com.braintreepayments.api.TestConfigurationBuilder.TestVisaCheckoutConfigurationBuilder
 import com.visa.checkout.Profile.CardBrand
 import com.visa.checkout.VisaPaymentSummary
@@ -43,7 +48,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         val listener = mockk<VisaCheckoutCreateProfileBuilderCallback>(relaxed = true)
         sut.createProfileBuilder(listener)
 
@@ -73,7 +81,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(fromJson(configString))
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         sut.createProfileBuilder { profileBuilderResult ->
             assertTrue(profileBuilderResult is VisaCheckoutProfileBuilderResult.Success)
             val profileBuilder = (profileBuilderResult as VisaCheckoutProfileBuilderResult
@@ -104,7 +115,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(fromJson(configString))
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         sut.createProfileBuilder { profileBuilderResult ->
             val profileBuilder = (profileBuilderResult as VisaCheckoutProfileBuilderResult
             .Success).profileBuilder
@@ -126,7 +140,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configurationWithVisaCheckout)
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         sut.tokenize(visaPaymentSummary) { visaCheckoutResult ->
             assertTrue(visaCheckoutResult is VisaCheckoutResult.Success)
             val nonce = (visaCheckoutResult as VisaCheckoutResult.Success).nonce
@@ -143,7 +160,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configurationWithVisaCheckout)
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         val listener = mockk<VisaCheckoutTokenizeCallback>(relaxed = true)
         sut.tokenize(visaPaymentSummary, listener)
         verify { braintreeClient.sendAnalyticsEvent(VisaCheckoutAnalytics.TOKENIZE_STARTED) }
@@ -159,7 +179,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configurationWithVisaCheckout)
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         sut.tokenize(visaPaymentSummary) { visaCheckoutResult ->
             assertTrue(visaCheckoutResult is VisaCheckoutResult.Failure)
             val error = (visaCheckoutResult as VisaCheckoutResult.Failure).error
@@ -176,7 +199,10 @@ class VisaCheckoutClientUnitTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configurationWithVisaCheckout)
             .build()
-        val sut = VisaCheckoutClient(braintreeClient, apiClient)
+        val sut = VisaCheckoutClient(
+            braintreeClient,
+            apiClient
+        )
         val listener = mockk<VisaCheckoutTokenizeCallback>(relaxed = true)
         sut.tokenize(visaPaymentSummary, listener)
         verify { braintreeClient.sendAnalyticsEvent(VisaCheckoutAnalytics.TOKENIZE_STARTED) }

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutNonceUnitTest.java
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutNonceUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import static com.braintreepayments.api.Assertions.assertBinDataEqual;
 import static com.braintreepayments.api.card.BinData.NO;
@@ -9,6 +9,10 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 
 import android.os.Parcel;
+
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.visacheckout.VisaCheckoutAddress;
+import com.braintreepayments.api.visacheckout.VisaCheckoutNonce;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutUserDataUnitTest.java
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutUserDataUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.visacheckout;
 
 import android.os.Parcel;
 
@@ -10,6 +10,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
+
+import com.braintreepayments.api.visacheckout.VisaCheckoutUserData;
 
 @RunWith(RobolectricTestRunner.class)
 public class VisaCheckoutUserDataUnitTest {


### PR DESCRIPTION
### Summary of changes

 - Update Visa Checkout package name to `com.braintreepayments.api.visacheckout`

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.