### PR TITLE
Add Google Pay Direct Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* Google Pay
+  * Add `GooglePayClient#tokenize(PaymentData, GooglePayOnActivityResultCallback)` to be invoked after direct Google Play Services integration
+
 ## 4.44.0 (2024-04-05)
 
 * Local Payment
@@ -24,7 +29,6 @@
 * GooglePay
   * Add `GooglePayClient#isReadyToPay(Context, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)` method
   * Deprecate  `GooglePayClient#isReadyToPay(FragmentActivity, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)` method
-  * Add `GooglePayClient#tokenize(PaymentData, GooglePayOnActivityResultCallback)` to be invoked after direct Google Play Services integration
 
 ## 4.43.0 (2024-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * GooglePay
   * Add `GooglePayClient#isReadyToPay(Context, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)` method
   * Deprecate  `GooglePayClient#isReadyToPay(FragmentActivity, ReadyForGooglePayRequest, GooglePayIsReadyToPayCallback)` method
+  * Add `GooglePayClient#tokenize(PaymentData, GooglePayOnActivityResultCallback)` to be invoked after direct Google Play Services integration
 
 ## 4.43.0 (2024-03-19)
 

--- a/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/GooglePayClient.java
@@ -332,15 +332,15 @@ public class GooglePayClient {
     }
 
     /**
-     * This method is called when you've received a successful {@link PaymentData} response in
-     * {@link GooglePayClient#onActivityResult(int, Intent, GooglePayOnActivityResultCallback)}
-     * to get a {@link GooglePayCardNonce} or {@link PayPalAccountNonce}.
+     * Call this method when you've received a successful {@link PaymentData} response from a
+     * direct Google Play Services integration to get a {@link GooglePayCardNonce} or
+     * {@link PayPalAccountNonce}.
      *
-     * @param paymentData {@link PaymentData} from the Intent in
-     *                    {@link GooglePayClient#onActivityResult(int, Intent, GooglePayOnActivityResultCallback)} method.
+     * @param paymentData {@link PaymentData} retrieved from directly integrating with Google Play
+     *                                       Services through {@link PaymentsClient#loadPaymentData(PaymentDataRequest)}
      * @param callback    {@link GooglePayOnActivityResultCallback}
      */
-    void tokenize(PaymentData paymentData, GooglePayOnActivityResultCallback callback) {
+    public void tokenize(PaymentData paymentData, GooglePayOnActivityResultCallback callback) {
         try {
             JSONObject result = new JSONObject(paymentData.toJson());
             callback.onResult(GooglePayCardNonce.fromJSON(result), null);


### PR DESCRIPTION
### Summary of changes

 - The ability to tokenize with `PaymentData` retrieved from a direct Google Play Services integration (calling `PaymentsClient.loadPaymentData`) [existed in v3 ](https://developer.paypal.com/braintree/docs/guides/google-pay/client-side/android/v3#direct-google-play-services-integration), but was made internal in v4. This PR adds back that functionality to allow merchants to more easily upgrade their integrations from v3 to v4. 

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
@sarahkoop 
