### PR TITLE
Update SEPA Direct Debit Package Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
       and modify parameters
     * Rename `SEPADirectDebitPaymentAuthRequestCallback#onResult` to
      `SEPADirectDebitPaymentAuthRequestCallback#onSEPADirectDebitPaymentAuthResult`
+    * Update package name to `com.braintreepayments.api.sepadirectdebit`
   * Visa Checkout
     * Update package name to `com.braintreepayments.api.visacheckout`
     * Change parameters of `VisaCheckoutCreateProfileBuilderCallback` and

--- a/Demo/src/main/java/com/braintreepayments/demo/PendingRequestStore.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PendingRequestStore.java
@@ -5,7 +5,7 @@ import android.content.SharedPreferences;
 
 import com.braintreepayments.api.LocalPaymentPendingRequest;
 import com.braintreepayments.api.PayPalPendingRequest;
-import com.braintreepayments.api.SEPADirectDebitPendingRequest;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitPendingRequest;
 import com.braintreepayments.api.VenmoPendingRequest;
 
 import org.json.JSONException;

--- a/Demo/src/main/java/com/braintreepayments/demo/SEPADirectDebitFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/SEPADirectDebitFragment.java
@@ -9,16 +9,16 @@ import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.braintreepayments.api.SEPADirectDebitClient;
-import com.braintreepayments.api.SEPADirectDebitLauncher;
-import com.braintreepayments.api.SEPADirectDebitMandateType;
-import com.braintreepayments.api.SEPADirectDebitNonce;
-import com.braintreepayments.api.SEPADirectDebitPaymentAuthRequest;
-import com.braintreepayments.api.SEPADirectDebitPaymentAuthResult;
-import com.braintreepayments.api.SEPADirectDebitPendingRequest;
-import com.braintreepayments.api.SEPADirectDebitRequest;
-import com.braintreepayments.api.SEPADirectDebitResult;
 import com.braintreepayments.api.core.PostalAddress;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitClient;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitLauncher;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitMandateType;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitNonce;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitPaymentAuthRequest;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitPaymentAuthResult;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitPendingRequest;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitRequest;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitResult;
 import com.braintreepayments.api.core.UserCanceledException;
 
 import java.util.UUID;

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.java
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import android.content.Context;
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/CreateMandateCallback.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/CreateMandateCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 internal fun interface CreateMandateCallback {
     fun onResult(result: CreateMandateResult?, error: Exception?)

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/CreateMandateResult.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/CreateMandateResult.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 class CreateMandateResult {
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalytics.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalytics.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 internal object SEPADirectDebitAnalytics {
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApi.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApi.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.sharedutils.HttpResponseCallback;

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClient.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClient.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import android.content.Context;
 import android.content.Intent;
@@ -9,6 +9,8 @@ import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import com.braintreepayments.api.BrowserSwitchOptions;
+import com.braintreepayments.api.BrowserSwitchResultInfo;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.BraintreeRequestCodes;

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitInternalTokenizeCallback.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitInternalTokenizeCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 internal interface SEPADirectDebitInternalTokenizeCallback {
     fun onResult(sepaDirectDebitNonce: SEPADirectDebitNonce?, error: Exception?)

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncher.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncher.kt
@@ -1,7 +1,10 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 import android.content.Intent
 import androidx.activity.ComponentActivity
+import com.braintreepayments.api.BrowserSwitchClient
+import com.braintreepayments.api.BrowserSwitchPendingRequest
+import com.braintreepayments.api.BrowserSwitchResult
 
 /**
  * Responsible for launching a SEPA mandate in a web browser

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitMandateType.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitMandateType.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import androidx.annotation.NonNull;
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonce.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonce.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import android.os.Parcel;
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequest.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequest.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 /**
  * A request used to launch the continuation of the SEPA Direct Debit flow.

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequestCallback.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequestCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 /**
  * Callback for receiving result of

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequestParams.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequestParams.java
@@ -1,6 +1,8 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import androidx.fragment.app.FragmentActivity;
+
+import com.braintreepayments.api.BrowserSwitchOptions;
 
 /**
  * Returned via the {@link SEPADirectDebitPaymentAuthRequestCallback} after calling

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResult.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 /**
  * Result of the SEPA Direct Debit web flow received from [SEPADirectDebitLauncher.handleReturnToAppFromBrowser].

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResultInfo.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResultInfo.java
@@ -1,4 +1,6 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
+
+import com.braintreepayments.api.BrowserSwitchResultInfo;
 
 /**
  * Details of a {@link SEPADirectDebitPaymentAuthResult.Success}

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequest.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequest.kt
@@ -1,5 +1,6 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
+import com.braintreepayments.api.BrowserSwitchPendingRequest
 import org.json.JSONException
 import java.lang.Exception
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequest.java
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitResult.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitResult.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 /**
  * Result of tokenizing a SEPA Direct Debit payment method

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitTokenizeCallback.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitTokenizeCallback.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 /**
  * Callback for receiving result of [SEPADirectDebitClient.tokenize]

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/MockSEPADirectDebitApiBuilder.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/MockSEPADirectDebitApiBuilder.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalyticsUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalyticsUnitTest.kt
@@ -1,4 +1,4 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApiUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApiUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
@@ -12,6 +12,15 @@ import static org.mockito.Mockito.verify;
 
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.PostalAddress;
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.MockBraintreeClientBuilder;
+import com.braintreepayments.api.sepadirectdebit.CreateMandateCallback;
+import com.braintreepayments.api.sepadirectdebit.CreateMandateResult;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitApi;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitInternalTokenizeCallback;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitMandateType;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitNonce;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitRequest;
 import com.braintreepayments.api.sharedutils.HttpResponseCallback;
 
 import org.json.JSONException;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.java
@@ -1,21 +1,30 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.net.Uri;
 
+import com.braintreepayments.api.BrowserSwitchOptions;
+import com.braintreepayments.api.BrowserSwitchResultInfo;
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.MockBraintreeClientBuilder;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.BraintreeRequestCodes;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherUnitTest.kt
@@ -1,7 +1,14 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 import android.content.Intent
 import androidx.activity.ComponentActivity
+import com.braintreepayments.api.BrowserSwitchClient
+import com.braintreepayments.api.BrowserSwitchException
+import com.braintreepayments.api.BrowserSwitchOptions
+import com.braintreepayments.api.BrowserSwitchPendingRequest
+import com.braintreepayments.api.BrowserSwitchRequest
+import com.braintreepayments.api.BrowserSwitchResult
+import com.braintreepayments.api.BrowserSwitchResultInfo
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertSame

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonceUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonceUnitTest.java
@@ -1,8 +1,12 @@
-package com.braintreepayments.api;
+package com.braintreepayments.api.sepadirectdebit;
 
 import static junit.framework.TestCase.assertEquals;
 
 import android.os.Parcel;
+
+import com.braintreepayments.api.Fixtures;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitMandateType;
+import com.braintreepayments.api.sepadirectdebit.SEPADirectDebitNonce;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequestUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequestUnitTest.kt
@@ -1,6 +1,8 @@
-package com.braintreepayments.api
+package com.braintreepayments.api.sepadirectdebit
 
 import android.net.Uri
+import com.braintreepayments.api.BrowserSwitchPendingRequest
+import com.braintreepayments.api.BrowserSwitchRequest
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
### Summary of changes

 - Update SEPA Direct Debit package name to `com.braintreepayments.api.sepadirectdebit`
 - These changes require https://github.com/braintree/browser-switch-android/pull/91 which have been published as a snapshot.

### Checklist

 - [X] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

