### PR TITLE
Buyer Email for PayPal One Time Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * PayPal
-    * Add optional property `PayPalVaultRequest.setUserAuthenticationEmail()`
+    * Add optional property `PayPalCheckoutRequest.setUserAuthenticationEmail()`
 
 ## 4.45.0 (2024-04-16)
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -207,6 +207,8 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
             parameters.put(BILLING_AGREEMENT_DETAILS_KEY, details);
         }
 
+        parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail);
+
         String currencyCode = getCurrencyCode();
         if (currencyCode == null) {
             currencyCode = configuration.getPayPalCurrencyIsoCode();

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -71,6 +71,7 @@ public abstract class PayPalRequest implements Parcelable {
     private String riskCorrelationId;
     private final ArrayList<PayPalLineItem> lineItems;
     private final boolean hasUserLocationConsent;
+    protected String userAuthenticationEmail;
 
     /**
      * Deprecated. Use {@link PayPalRequest#PayPalRequest(boolean)} instead.
@@ -279,6 +280,21 @@ public abstract class PayPalRequest implements Parcelable {
 
     public boolean hasUserLocationConsent() {
         return hasUserLocationConsent;
+    }
+
+    /**
+     * Optional: User email to initiate a quicker authentication flow in cases where the user has a
+     * PayPal Account with the same email.
+     *
+     * @param userAuthenticationEmail - email address of the payer
+     */
+    public void setUserAuthenticationEmail(@Nullable String userAuthenticationEmail) {
+        this.userAuthenticationEmail = userAuthenticationEmail;
+    }
+
+    @Nullable
+    public String getUserAuthenticationEmail() {
+        return this.userAuthenticationEmail;
     }
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalVaultRequest.java
@@ -16,8 +16,6 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     private boolean shouldOfferCredit;
 
-    private String userAuthenticationEmail;
-
     /**
      * Deprecated. Use {@link PayPalVaultRequest#PayPalVaultRequest(boolean)} instead.
      */
@@ -50,21 +48,6 @@ public class PayPalVaultRequest extends PayPalRequest implements Parcelable {
 
     public boolean getShouldOfferCredit() {
         return shouldOfferCredit;
-    }
-
-    /**
-     * Optional: User email to initiate a quicker authentication flow in cases where the user has a
-     * PayPal Account with the same email.
-     *
-     * @param userAuthenticationEmail - email address of the payer
-     */
-    public void setUserAuthenticationEmail(@Nullable String userAuthenticationEmail) {
-        this.userAuthenticationEmail = userAuthenticationEmail;
-    }
-
-    @Nullable
-    public String getUserAuthenticationEmail() {
-        return this.userAuthenticationEmail;
     }
 
     String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException {

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -2,6 +2,7 @@ package com.braintreepayments.api;
 
 import android.os.Parcel;
 
+import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -13,6 +14,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 public class PayPalCheckoutRequestUnitTest {
@@ -121,5 +123,21 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
+    }
+
+    @Test
+    public void createRequestBody_sets_userAuthenticationEmail_when_not_null() throws JSONException {
+        String payerEmail = "payer_email@example.com";
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        request.setUserAuthenticationEmail(payerEmail);
+        String requestBody = request.createRequestBody(
+            mock(Configuration.class),
+            mock(Authorization.class),
+            "success_url",
+            "cancel_url"
+        );
+
+        assertTrue(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Move `userAuthenticationEmail` from `PayPalVaultRequest` to the abstract `PayPalRequest` so that it's included in `PayPalCheckoutRequest`

### Checklist

 - [X] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

