### PR TITLE
Demo App - Add text input for setting buyer email address

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -10,9 +10,16 @@ import com.braintreepayments.api.PostalAddress;
 
 public class PayPalRequestFactory {
 
-    public static PayPalVaultRequest createPayPalVaultRequest(Context context) {
+    public static PayPalVaultRequest createPayPalVaultRequest(
+        Context context,
+        String buyerEmailAddress
+    ) {
 
         PayPalVaultRequest request = new PayPalVaultRequest();
+
+        if (!buyerEmailAddress.isEmpty()) {
+            request.setUserAuthenticationEmail(buyerEmailAddress);
+        }
 
         request.setDisplayName(Settings.getPayPalDisplayName(context));
 
@@ -42,8 +49,16 @@ public class PayPalRequestFactory {
         return request;
     }
 
-    public static PayPalCheckoutRequest createPayPalCheckoutRequest(Context context, String amount) {
+    public static PayPalCheckoutRequest createPayPalCheckoutRequest(
+        Context context,
+        String amount,
+        String buyerEmailAddress
+    ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount);
+
+        if (!buyerEmailAddress.isEmpty()) {
+            request.setUserAuthenticationEmail(buyerEmailAddress);
+        }
 
         request.setDisplayName(Settings.getPayPalDisplayName(context));
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -137,7 +137,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
         shopperInsightsClient.sendPayPalSelectedEvent()
         payPalClient.tokenizePayPalAccount(
             requireActivity(),
-            PayPalRequestFactory.createPayPalVaultRequest(activity)
+            PayPalRequestFactory.createPayPalVaultRequest(activity, emailInput.editText?.text.toString())
         )
     }
 

--- a/Demo/src/main/res/layout/fragment_paypal.xml
+++ b/Demo/src/main/res/layout/fragment_paypal.xml
@@ -10,8 +10,20 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:gravity="center"
         android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:hint="@string/paypal_buyer_email_address">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/buyer_email_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/paypal_single_payment_button"

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="require_three_d_secure_summary">Requires a successful authentication for 3D Secure transactions</string>
     <string name="paypal_disable_signature_verification">Disable app switch signature verification</string>
     <string name="paypal_disable_signature_verification_summary">Allows app switch with a PayPal Wallet app that is not signed</string>
+    <string name="paypal_buyer_email_address">Buyer Email Address</string>
     <string name="paypal_single_payment">Single Payment</string>
     <string name="paypal_billing_agreement">Billing Agreement</string>
     <string name="paypal_deferred_billing_agreement">Deferred Billing Agreement</string>


### PR DESCRIPTION
### Summary of changes

 - Add text input for buyer email address in the PayPal flow

![Screenshot_20240418_152711](https://github.com/braintree/braintree_android/assets/5005216/12258c88-ac72-4f08-b775-980e3956fb96)

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

