### PR TITLE
Add appLinkReturnUri to BraintreeClient

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -41,7 +41,12 @@ open class BraintreeClient @VisibleForTesting internal constructor(
     private val manifestValidator: ManifestValidator,
     private val returnUrlScheme: String,
     private val braintreeDeepLinkReturnUrlScheme: String,
-    private val appLinkReturnUri: Uri?,
+
+    /**
+     * @suppress
+     */
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val appLinkReturnUri: Uri?,
 ) {
 
     private val crashReporter: CrashReporter
@@ -84,7 +89,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param authorization   The tokenization key or client token to use. If an invalid
      * authorization is provided, a [BraintreeException] will be returned via callback.
      * @param returnUrlScheme A custom return url to use for browser and app switching
-     * @param appLinkReturnUri TODO
+     * @param appLinkReturnUri A [Uri] containing the Android App Link to use for app switching
      */
     @JvmOverloads
     constructor (
@@ -115,7 +120,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param clientTokenProvider An implementation of [ClientTokenProvider] that [BraintreeClient]
      * will use to fetch a client token on demand.
      * @param returnUrlScheme     A custom return url to use for browser and app switching
-     * @param appLinkReturnUri TODO
+     * @param appLinkReturnUri    A [Uri] containing the Android App Link to use for app switching
      */
     @JvmOverloads
     constructor(

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -89,7 +89,10 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param authorization   The tokenization key or client token to use. If an invalid
      * authorization is provided, a [BraintreeException] will be returned via callback.
      * @param returnUrlScheme A custom return url to use for browser and app switching
-     * @param appLinkReturnUri A [Uri] containing the Android App Link website associated with your application to be used to return to your app from browser or app switch based payment flows. This Android App Link will only be used for payment flows where `useAppLinkReturn` is set to `true`.
+     * @param appLinkReturnUri A [Uri] containing the Android App Link website associated with your
+     * application to be used to return to your app from browser or app switch based payment flows.
+     * This Android App Link will only be used for payment flows where `useAppLinkReturn` is set to
+     * `true`.
      */
     @JvmOverloads
     constructor (

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
-import com.braintreepayments.api.IntegrationType.Integration
 
 /**
  * Core Braintree class that handles network requests.
@@ -42,6 +41,7 @@ open class BraintreeClient @VisibleForTesting internal constructor(
     private val manifestValidator: ManifestValidator,
     private val returnUrlScheme: String,
     private val braintreeDeepLinkReturnUrlScheme: String,
+    private val appLinkReturnUri: Uri?,
 ) {
 
     private val crashReporter: CrashReporter
@@ -60,7 +60,8 @@ open class BraintreeClient @VisibleForTesting internal constructor(
         configurationLoader = params.configurationLoader,
         manifestValidator = params.manifestValidator,
         returnUrlScheme = params.returnUrlScheme,
-        braintreeDeepLinkReturnUrlScheme = params.braintreeReturnUrlScheme
+        braintreeDeepLinkReturnUrlScheme = params.braintreeReturnUrlScheme,
+        appLinkReturnUri = params.appLinkReturnUri
     )
 
     /**
@@ -68,26 +69,6 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(options: BraintreeOptions) : this(BraintreeClientParams(options))
-
-    /**
-     * Create a new instance of [BraintreeClient] using a tokenization key or client token.
-     *
-     * @param context       Android Context
-     * @param authorization The tokenization key or client token to use. If an invalid authorization
-     * is provided, a [BraintreeException] will be returned via callback.
-     */
-    constructor(context: Context, authorization: String) :
-            this(BraintreeOptions(context = context, initialAuthString = authorization))
-
-    /**
-     * Create a new instance of [BraintreeClient] using a [ClientTokenProvider].
-     *
-     * @param context             Android Context
-     * @param clientTokenProvider An implementation of [ClientTokenProvider] that [BraintreeClient]
-     * will use to fetch a client token on demand.
-     */
-    constructor(context: Context, clientTokenProvider: ClientTokenProvider) :
-            this(BraintreeOptions(context = context, clientTokenProvider = clientTokenProvider))
 
     /**
      * Create a new instance of [BraintreeClient] using a tokenization key or client token and a
@@ -103,12 +84,20 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param authorization   The tokenization key or client token to use. If an invalid
      * authorization is provided, a [BraintreeException] will be returned via callback.
      * @param returnUrlScheme A custom return url to use for browser and app switching
+     * @param appLinkReturnUri TODO
      */
-    constructor (context: Context, authorization: String, returnUrlScheme: String) : this(
+    @JvmOverloads
+    constructor (
+        context: Context,
+        authorization: String,
+        returnUrlScheme: String? = null,
+        appLinkReturnUri: Uri? = null,
+    ) : this(
         BraintreeOptions(
             context = context,
             initialAuthString = authorization,
-            returnUrlScheme = returnUrlScheme
+            returnUrlScheme = returnUrlScheme,
+            appLinkReturnUri = appLinkReturnUri
         )
     )
 
@@ -126,44 +115,20 @@ open class BraintreeClient @VisibleForTesting internal constructor(
      * @param clientTokenProvider An implementation of [ClientTokenProvider] that [BraintreeClient]
      * will use to fetch a client token on demand.
      * @param returnUrlScheme     A custom return url to use for browser and app switching
+     * @param appLinkReturnUri TODO
      */
+    @JvmOverloads
     constructor(
         context: Context,
         clientTokenProvider: ClientTokenProvider,
-        returnUrlScheme: String
+        returnUrlScheme: String? = null,
+        appLinkReturnUri: Uri? = null,
     ) : this(
         BraintreeOptions(
             context = context,
             clientTokenProvider = clientTokenProvider,
-            returnUrlScheme = returnUrlScheme
-        )
-    )
-
-    internal constructor(
-        context: Context,
-        clientTokenProvider: ClientTokenProvider,
-        sessionId: String?,
-        @Integration integrationType: String
-    ) : this(
-        BraintreeOptions(
-            context = context,
-            clientTokenProvider = clientTokenProvider,
-            sessionId = sessionId,
-            integrationType = integrationType,
-        )
-    )
-
-    internal constructor(
-        context: Context,
-        authorization: String,
-        sessionId: String?,
-        @Integration integrationType: String
-    ) : this(
-        BraintreeOptions(
-            context = context,
-            initialAuthString = authorization,
-            sessionId = sessionId,
-            integrationType = integrationType,
+            returnUrlScheme = returnUrlScheme,
+            appLinkReturnUri = appLinkReturnUri
         )
     )
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClientParams.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.braintreepayments.api.IntegrationType.Integration
 
@@ -9,6 +10,7 @@ internal data class BraintreeClientParams @VisibleForTesting constructor(
     val sessionId: String,
     val authorizationLoader: AuthorizationLoader,
     val returnUrlScheme: String,
+    val appLinkReturnUri: Uri?,
     val httpClient: BraintreeHttpClient = BraintreeHttpClient(),
     val graphQLClient: BraintreeGraphQLClient = BraintreeGraphQLClient(),
     val analyticsClient: AnalyticsClient = AnalyticsClient(context),
@@ -26,6 +28,7 @@ internal data class BraintreeClientParams @VisibleForTesting constructor(
         },
         sessionId = options.sessionId ?: createUniqueSessionId(),
         returnUrlScheme = options.returnUrlScheme ?: createDefaultReturnUrlScheme(options.context),
+        appLinkReturnUri = options.appLinkReturnUri,
         integrationType = options.integrationType ?: IntegrationType.CUSTOM
     )
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeOptions.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeOptions.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.content.Context
+import android.net.Uri
 import androidx.annotation.RestrictTo
 
 /**
@@ -11,6 +12,7 @@ data class BraintreeOptions @JvmOverloads constructor(
     val context: Context,
     val sessionId: String? = null,
     val returnUrlScheme: String? = null,
+    val appLinkReturnUri: Uri? = null,
     val initialAuthString: String? = null,
     val clientTokenProvider: ClientTokenProvider? = null,
     @IntegrationType.Integration val integrationType: String? = null,

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
@@ -575,47 +575,11 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sessionId_withAuthString_returnsSessionIdDefinedInConstructor() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val authorization = Fixtures.BASE64_CLIENT_TOKEN
-        val sessionId = "custom-session-id"
-        val sut = BraintreeClient(context, authorization, sessionId, IntegrationType.DROP_IN)
-        assertEquals("custom-session-id", sut.sessionId)
-    }
-
-    @Test
-    fun sessionId_withClientTokenProvider_returnsSessionIdDefinedInConstructor() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val clientTokenProvider = mockk<ClientTokenProvider>(relaxed = true)
-        val sessionId = "custom-session-id"
-        val sut = BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN)
-        assertEquals("custom-session-id", sut.sessionId)
-    }
-
-    @Test
     fun integrationType_returnsCustomByDefault() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val authorization = Fixtures.BASE64_CLIENT_TOKEN
         val sut = BraintreeClient(context, authorization)
         assertEquals("custom", sut.integrationType)
-    }
-
-    @Test
-    fun integrationType_withAuthString_returnsIntegrationTypeDefinedInConstructor() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val authorization = Fixtures.BASE64_CLIENT_TOKEN
-        val sessionId = "custom-session-id"
-        val sut = BraintreeClient(context, authorization, sessionId, IntegrationType.DROP_IN)
-        assertEquals("dropin", sut.integrationType)
-    }
-
-    @Test
-    fun integrationType_withClientTokenProvider_returnsIntegrationTypeDefinedInConstructor() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val clientTokenProvider = mockk<ClientTokenProvider>(relaxed = true)
-        val sessionId = "custom-session-id"
-        val sut = BraintreeClient(context, clientTokenProvider, sessionId, IntegrationType.DROP_IN)
-        assertEquals("dropin", sut.integrationType)
     }
 
     @Test
@@ -670,7 +634,8 @@ class BraintreeClientUnitTest {
             browserSwitchClient = browserSwitchClient,
             manifestValidator = manifestValidator,
             configurationLoader = configurationLoader,
-            integrationType = IntegrationType.CUSTOM
+            integrationType = IntegrationType.CUSTOM,
+            appLinkReturnUri = Uri.parse("https://sample-merchant-site.com"),
         )
 
     companion object {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/BraintreeClientUnitTest.kt
@@ -619,6 +619,48 @@ class BraintreeClientUnitTest {
         }
     }
 
+    @Test
+    fun `when client is created with authorization, app link is set on appLinkReturnUri`() {
+        val appLinkUrl = "https://merchant-site.com"
+        val sut: BraintreeClient = BraintreeClient(
+            context = context,
+            authorization = "authorization",
+            returnUrlScheme = "returnUrlScheme",
+            appLinkReturnUri = Uri.parse(appLinkUrl)
+        )
+        assertEquals(appLinkUrl, sut.appLinkReturnUri.toString())
+    }
+
+    @Test
+    fun `when client is created with ClientTokenProvider, app link is set on appLinkReturnUri`() {
+        val appLinkUrl = "https://merchant-site.com"
+        val sut: BraintreeClient = BraintreeClient(
+            context = context,
+            clientTokenProvider = mockk(),
+            returnUrlScheme = "returnUrlScheme",
+            appLinkReturnUri = Uri.parse(appLinkUrl)
+        )
+        assertEquals(appLinkUrl, sut.appLinkReturnUri.toString())
+    }
+
+    @Test
+    fun `when client is created with authorization without an app link, appLinkReturnUri is null`() {
+        val sut: BraintreeClient = BraintreeClient(
+            context = context,
+            authorization = "authorization"
+        )
+        assertNull(sut.appLinkReturnUri)
+    }
+
+    @Test
+    fun `when client is created with ClientTokenProvider without an app link, appLinkReturnUri is null`() {
+        val sut: BraintreeClient = BraintreeClient(
+            context = context,
+            clientTokenProvider = mockk()
+        )
+        assertNull(sut.appLinkReturnUri)
+    }
+
     private fun createDefaultParams(
         configurationLoader: ConfigurationLoader,
         authorizationLoader: AuthorizationLoader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* BraintreeCore
+  * Add 'appLinkReturnUri' to `BraintreeClient` constructors for Android App Link support
 * Venmo
   * Send `link_type` in `event_params` to PayPal's analytics service (FPTI)
   


### PR DESCRIPTION
### Summary of changes

 - Add `appLinkReturnUri` as a parameter passed to the `BraintreeClient` constructor
 - Remove unused `BraintreeClient` constructors that were marked as internal but only used in test classes
 - Collapse public `BraintreeClient` constructors by using default values and `@JvmOverloads` annotation

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

