### PR TITLE
Add useAppLinkReturn to PayPalRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Add 'appLinkReturnUri' to `BraintreeClient` constructors for Android App Link support
 * Venmo
   * Send `link_type` in `event_params` to PayPal's analytics service (FPTI)
+* PayPal
+  * Add `useAppLinkReturn` property to `PayPalRequest` for Android App Link support
   
 ## 4.45.0 (2024-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Venmo
   * Send `link_type` in `event_params` to PayPal's analytics service (FPTI)
 * PayPal
-  * Add `useAppLinkReturn` property to `PayPalRequest` for Android App Link support
+  * Add `appLinkEnabled` property to `PayPalRequest` for Android App Link support
   
 ## 4.45.0 (2024-04-16)
 

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -71,6 +71,7 @@ public abstract class PayPalRequest implements Parcelable {
     private String riskCorrelationId;
     private final ArrayList<PayPalLineItem> lineItems;
     private final boolean hasUserLocationConsent;
+    private boolean useAppLinkReturn;
 
     /**
      * Deprecated. Use {@link PayPalRequest#PayPalRequest(boolean)} instead.
@@ -228,6 +229,20 @@ public abstract class PayPalRequest implements Parcelable {
         this.lineItems.addAll(lineItems);
     }
 
+    /**
+     * Optional: When set to true, the Android App Link website associated with your application
+     * will be used to return to your app from browser or app switch based payment flows. When set
+     * to false, the Set the deep link return URL will be used.
+     *
+     * Set the App Link value on `appLinkReturnUri` parameter in the {@link BraintreeClient}
+     * constructor.
+     *
+     * @param useAppLinkReturn indicates whether to use the set Android App Link
+     */
+    public void setUseAppLinkReturn(boolean useAppLinkReturn) {
+        this.useAppLinkReturn = useAppLinkReturn;
+    }
+
     @Nullable
     public String getLocaleCode() {
         return localeCode;
@@ -281,6 +296,10 @@ public abstract class PayPalRequest implements Parcelable {
         return hasUserLocationConsent;
     }
 
+    public boolean isUseAppLinkReturn() {
+        return useAppLinkReturn;
+    }
+
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
 
     protected PayPalRequest(Parcel in) {
@@ -295,6 +314,7 @@ public abstract class PayPalRequest implements Parcelable {
         riskCorrelationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
         hasUserLocationConsent = in.readByte() != 0;
+        useAppLinkReturn = in.readByte() != 0;
     }
 
     @Override
@@ -315,5 +335,6 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(riskCorrelationId);
         parcel.writeTypedList(lineItems);
         parcel.writeByte((byte) (hasUserLocationConsent ? 1 : 0));
+        parcel.writeByte((byte) (useAppLinkReturn ? 1 : 0));
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -232,7 +232,7 @@ public abstract class PayPalRequest implements Parcelable {
     /**
      * Optional: When set to true, the Android App Link website associated with your application
      * will be used to return to your app from browser or app switch based payment flows. When set
-     * to false, the Set the deep link return URL will be used.
+     * to false, the default or set deep link return URL will be used.
      *
      * Set the App Link value on `appLinkReturnUri` parameter in the {@link BraintreeClient}
      * constructor.

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -71,7 +71,7 @@ public abstract class PayPalRequest implements Parcelable {
     private String riskCorrelationId;
     private final ArrayList<PayPalLineItem> lineItems;
     private final boolean hasUserLocationConsent;
-    private boolean useAppLinkReturn;
+    private boolean appLinkEnabled;
 
     /**
      * Deprecated. Use {@link PayPalRequest#PayPalRequest(boolean)} instead.
@@ -237,10 +237,10 @@ public abstract class PayPalRequest implements Parcelable {
      * Set the App Link value on `appLinkReturnUri` parameter in the {@link BraintreeClient}
      * constructor.
      *
-     * @param useAppLinkReturn indicates whether to use the set Android App Link
+     * @param appLinkEnabled indicates whether to use the set Android App Link
      */
-    public void setUseAppLinkReturn(boolean useAppLinkReturn) {
-        this.useAppLinkReturn = useAppLinkReturn;
+    public void setAppLinkEnabled(boolean appLinkEnabled) {
+        this.appLinkEnabled = appLinkEnabled;
     }
 
     @Nullable
@@ -296,8 +296,8 @@ public abstract class PayPalRequest implements Parcelable {
         return hasUserLocationConsent;
     }
 
-    public boolean isUseAppLinkReturn() {
-        return useAppLinkReturn;
+    public boolean isAppLinkEnabled() {
+        return appLinkEnabled;
     }
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization, String successUrl, String cancelUrl) throws JSONException;
@@ -314,7 +314,7 @@ public abstract class PayPalRequest implements Parcelable {
         riskCorrelationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
         hasUserLocationConsent = in.readByte() != 0;
-        useAppLinkReturn = in.readByte() != 0;
+        appLinkEnabled = in.readByte() != 0;
     }
 
     @Override
@@ -335,6 +335,6 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(riskCorrelationId);
         parcel.writeTypedList(lineItems);
         parcel.writeByte((byte) (hasUserLocationConsent ? 1 : 0));
-        parcel.writeByte((byte) (useAppLinkReturn ? 1 : 0));
+        parcel.writeByte((byte) (appLinkEnabled ? 1 : 0));
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -32,6 +32,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertNull(request.getBillingAgreementDescription());
         assertFalse(request.getShouldOfferPayLater());
         assertFalse(request.hasUserLocationConsent());
+        assertFalse(request.isUseAppLinkReturn());
     }
 
     @Test
@@ -57,6 +58,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setDisplayName("Display Name");
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
+        request.setUseAppLinkReturn(true);
 
         assertEquals("1.00", request.getAmount());
         assertEquals("USD", request.getCurrencyCode());
@@ -72,6 +74,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferPayLater());
         assertTrue(request.hasUserLocationConsent());
+        assertTrue(request.isUseAppLinkReturn());
     }
 
     @Test
@@ -93,6 +96,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setDisplayName("Display Name");
         request.setRiskCorrelationId("123-correlation");
         request.setMerchantAccountId("merchant_account_id");
+        request.setUseAppLinkReturn(true);
 
         ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
         lineItems.add(new PayPalLineItem(PayPalLineItem.KIND_DEBIT, "An Item", "1", "1"));
@@ -121,5 +125,6 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
+        assertTrue(result.isUseAppLinkReturn());
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -32,7 +32,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertNull(request.getBillingAgreementDescription());
         assertFalse(request.getShouldOfferPayLater());
         assertFalse(request.hasUserLocationConsent());
-        assertFalse(request.isUseAppLinkReturn());
+        assertFalse(request.isAppLinkEnabled());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setDisplayName("Display Name");
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
-        request.setUseAppLinkReturn(true);
+        request.setAppLinkEnabled(true);
 
         assertEquals("1.00", request.getAmount());
         assertEquals("USD", request.getCurrencyCode());
@@ -74,7 +74,7 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferPayLater());
         assertTrue(request.hasUserLocationConsent());
-        assertTrue(request.isUseAppLinkReturn());
+        assertTrue(request.isAppLinkEnabled());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setDisplayName("Display Name");
         request.setRiskCorrelationId("123-correlation");
         request.setMerchantAccountId("merchant_account_id");
-        request.setUseAppLinkReturn(true);
+        request.setAppLinkEnabled(true);
 
         ArrayList<PayPalLineItem> lineItems = new ArrayList<>();
         lineItems.add(new PayPalLineItem(PayPalLineItem.KIND_DEBIT, "An Item", "1", "1"));
@@ -125,6 +125,6 @@ public class PayPalCheckoutRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
-        assertTrue(result.isUseAppLinkReturn());
+        assertTrue(result.isAppLinkEnabled());
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -1,12 +1,10 @@
 package com.braintreepayments.api;
 
-import android.content.pm.Signature;
 import android.os.Parcel;
 
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
@@ -31,7 +29,7 @@ public class PayPalVaultRequestUnitTest {
         assertNull(request.getLandingPageType());
         assertFalse(request.getShouldOfferCredit());
         assertFalse(request.hasUserLocationConsent());
-        assertFalse(request.isUseAppLinkReturn());
+        assertFalse(request.isAppLinkEnabled());
     }
 
     @Test
@@ -52,7 +50,7 @@ public class PayPalVaultRequestUnitTest {
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setShouldOfferCredit(true);
-        request.setUseAppLinkReturn(true);
+        request.setAppLinkEnabled(true);
 
         assertEquals("US", request.getLocaleCode());
         assertEquals("Billing Agreement Description", request.getBillingAgreementDescription());
@@ -63,7 +61,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
         assertTrue(request.hasUserLocationConsent());
-        assertTrue(request.isUseAppLinkReturn());
+        assertTrue(request.isAppLinkEnabled());
     }
 
     @Test
@@ -74,7 +72,7 @@ public class PayPalVaultRequestUnitTest {
         request.setShippingAddressRequired(true);
         request.setShippingAddressEditable(true);
         request.setShouldOfferCredit(true);
-        request.setUseAppLinkReturn(true);
+        request.setAppLinkEnabled(true);
 
         PostalAddress postalAddress = new PostalAddress();
         postalAddress.setRecipientName("Postal Address");
@@ -109,7 +107,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
-        assertTrue(result.isUseAppLinkReturn());
+        assertTrue(result.isAppLinkEnabled());
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalVaultRequestUnitTest.java
@@ -31,6 +31,7 @@ public class PayPalVaultRequestUnitTest {
         assertNull(request.getLandingPageType());
         assertFalse(request.getShouldOfferCredit());
         assertFalse(request.hasUserLocationConsent());
+        assertFalse(request.isUseAppLinkReturn());
     }
 
     @Test
@@ -51,6 +52,7 @@ public class PayPalVaultRequestUnitTest {
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setShouldOfferCredit(true);
+        request.setUseAppLinkReturn(true);
 
         assertEquals("US", request.getLocaleCode());
         assertEquals("Billing Agreement Description", request.getBillingAgreementDescription());
@@ -61,6 +63,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
         assertTrue(request.hasUserLocationConsent());
+        assertTrue(request.isUseAppLinkReturn());
     }
 
     @Test
@@ -71,6 +74,7 @@ public class PayPalVaultRequestUnitTest {
         request.setShippingAddressRequired(true);
         request.setShippingAddressEditable(true);
         request.setShouldOfferCredit(true);
+        request.setUseAppLinkReturn(true);
 
         PostalAddress postalAddress = new PostalAddress();
         postalAddress.setRecipientName("Postal Address");
@@ -105,6 +109,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
+        assertTrue(result.isUseAppLinkReturn());
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Add `useAppLinkReturn` to `PayPalRequest` for Android App Link support

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

