### PR TITLE
Send app link URLs to PayPal API

### DIFF
--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalInternalClientUnitTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import android.net.Uri;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -678,5 +679,88 @@ public class PayPalInternalClientUnitTest {
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         verify(payPalDataCollector).getClientMetadataId(context, configuration, true);
+    }
+
+    @Test
+    public void when_appLink_is_enabled_appLinkReturnUri_is_used_for_cancel_and_success_urls() throws JSONException {
+        String appLink = "https://example.com";
+
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(configuration)
+            .authorizationSuccess(clientToken)
+            .returnUrlScheme("sample-scheme")
+            .appLinkUri(Uri.parse(appLink))
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
+        payPalRequest.setAppLinkEnabled(true);
+
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        ArgumentCaptor<String> requestCaptor = ArgumentCaptor.forClass(String.class);
+        verify(braintreeClient).sendPOST(any(), requestCaptor.capture(), any(HttpResponseCallback.class));
+
+        JSONObject request = new JSONObject(requestCaptor.getValue());
+
+        assertEquals(appLink + "/success", request.get("return_url"));
+        assertEquals(appLink + "/cancel", request.get("cancel_url"));
+    }
+
+    @Test
+    public void when_appLink_is_enabled_with_null_appLinkReturnUri_returnUrlScheme_is_used_for_cancel_and_success_urls() throws JSONException {
+        String returnUrlScheme = "sample-scheme";
+
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(configuration)
+            .authorizationSuccess(clientToken)
+            .returnUrlScheme(returnUrlScheme)
+            .appLinkUri(null)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
+        payPalRequest.setAppLinkEnabled(true);
+
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        ArgumentCaptor<String> requestCaptor = ArgumentCaptor.forClass(String.class);
+        verify(braintreeClient).sendPOST(any(), requestCaptor.capture(), any(HttpResponseCallback.class));
+
+        JSONObject request = new JSONObject(requestCaptor.getValue());
+
+        assertEquals(returnUrlScheme + "://onetouch/v1/success", request.get("return_url"));
+        assertEquals(returnUrlScheme + "://onetouch/v1/cancel", request.get("cancel_url"));
+    }
+
+    @Test
+    public void when_appLink_is_disabled_returnUrlScheme_is_used_for_cancel_and_success_urls() throws JSONException {
+        String returnUrlScheme = "sample-scheme";
+
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(configuration)
+            .authorizationSuccess(clientToken)
+            .returnUrlScheme(returnUrlScheme)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
+
+        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, payPalDataCollector, apiClient);
+
+        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
+        payPalRequest.setAppLinkEnabled(false);
+
+        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        ArgumentCaptor<String> requestCaptor = ArgumentCaptor.forClass(String.class);
+        verify(braintreeClient).sendPOST(any(), requestCaptor.capture(), any(HttpResponseCallback.class));
+
+        JSONObject request = new JSONObject(requestCaptor.getValue());
+
+        assertEquals(returnUrlScheme + "://onetouch/v1/success", request.get("return_url"));
+        assertEquals(returnUrlScheme + "://onetouch/v1/cancel", request.get("cancel_url"));
     }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.content.pm.ActivityInfo;
+import android.net.Uri;
 
 import androidx.fragment.app.FragmentActivity;
 
@@ -35,6 +36,8 @@ public class MockBraintreeClientBuilder {
     private String sessionId;
     private String integration;
     private String returnUrlScheme;
+
+    private Uri appLinkUri;
 
     private BrowserSwitchResult browserSwitchResult;
     private BrowserSwitchException browserSwitchAssertionError;
@@ -116,6 +119,11 @@ public class MockBraintreeClientBuilder {
          return this;
     }
 
+    public MockBraintreeClientBuilder appLinkUri(Uri appLinkUri) {
+        this.appLinkUri = appLinkUri;
+        return this;
+    }
+
     public MockBraintreeClientBuilder browserSwitchAssertionError(BrowserSwitchException browserSwitchAssertionError) {
         this.browserSwitchAssertionError = browserSwitchAssertionError;
         return this;
@@ -145,6 +153,7 @@ public class MockBraintreeClientBuilder {
         }).when(braintreeClient).getAuthorization(any(AuthorizationCallback.class));
 
         when(braintreeClient.getReturnUrlScheme()).thenReturn(returnUrlScheme);
+        when(braintreeClient.getAppLinkReturnUri()).thenReturn(appLinkUri);
 
         if (browserSwitchAssertionError != null) {
             try {


### PR DESCRIPTION
### Summary of changes

 - Send app link URLs to the PayPal API when `AppLinkReturnUri` is set on `BraintreeClient` and `appLinkEnabled` is set to true on the `PayPalRequest`

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

