### PR TITLE
Add ability to launch PayPal flows with app links

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -3,6 +3,7 @@ package com.braintreepayments.demo;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -49,7 +50,13 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
         if (braintreeClient == null) {
             if (Settings.useTokenizationKey(this)) {
                 String tokenizationKey = Settings.getTokenizationKey(this);
-                braintreeClient = new BraintreeClient(this, tokenizationKey);
+
+                boolean useAppLink = Settings.getPayPalLinkType(this).equals(getString(R.string.paypal_app_link));
+                Uri appLinkUri = null;
+                if (useAppLink) {
+                    appLinkUri = Uri.parse("https://example.com");
+                }
+                braintreeClient = new BraintreeClient(this, tokenizationKey, null, appLinkUri);
             } else {
                 braintreeClient =
                     BraintreeClientFactory.createBraintreeClientWithAuthorizationProvider(this);

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -54,7 +54,7 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
                 boolean useAppLink = Settings.getPayPalLinkType(this).equals(getString(R.string.paypal_app_link));
                 Uri appLinkUri = null;
                 if (useAppLink) {
-                    appLinkUri = Uri.parse("https://example.com");
+                    appLinkUri = Uri.parse("https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/");
                 }
                 braintreeClient = new BraintreeClient(this, tokenizationKey, null, appLinkUri);
             } else {

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -14,6 +14,9 @@ public class PayPalRequestFactory {
 
         PayPalVaultRequest request = new PayPalVaultRequest();
 
+        boolean useAppLink = Settings.getPayPalLinkType(context).equals(context.getString(R.string.paypal_app_link));
+        request.setAppLinkEnabled(useAppLink);
+
         request.setDisplayName(Settings.getPayPalDisplayName(context));
 
         String landingPageType = Settings.getPayPalLandingPageType(context);
@@ -44,6 +47,9 @@ public class PayPalRequestFactory {
 
     public static PayPalCheckoutRequest createPayPalCheckoutRequest(Context context, String amount) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount);
+
+        boolean useAppLink = Settings.getPayPalLinkType(context).equals(context.getString(R.string.paypal_app_link));
+        request.setAppLinkEnabled(useAppLink);
 
         request.setDisplayName(Settings.getPayPalDisplayName(context));
 

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -198,6 +198,10 @@ public class Settings {
         return getPreferences(context).getBoolean("paypal_use_hardcoded_configuration", false);
     }
 
+    public static String getPayPalLinkType(Context context) {
+        return getPreferences(context).getString("paypal_link_type", context.getString(R.string.paypal_deep_link));
+    }
+
     public static boolean isThreeDSecureEnabled(Context context) {
         return getPreferences(context).getBoolean("enable_three_d_secure", false);
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
@@ -26,6 +26,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
         onSharedPreferenceChanged(preferences, "google_pay_currency");
         onSharedPreferenceChanged(preferences, "google_pay_allowed_countries_for_shipping");
         onSharedPreferenceChanged(preferences, "tokenization_key_type");
+        onSharedPreferenceChanged(preferences, "paypal_link_type");
         preferences.registerOnSharedPreferenceChangeListener(this);
     }
 

--- a/Demo/src/main/res/values/arrays.xml
+++ b/Demo/src/main/res/values/arrays.xml
@@ -34,4 +34,15 @@
         <item name="billing">@string/paypal_landing_page_type_billing</item>
         <item name="login">@string/paypal_landing_page_type_login</item>
     </string-array>
+
+    <string-array name="paypal_link_types">
+        <item name="deep_link">@string/paypal_deep_link</item>
+        <item name="app_link">@string/paypal_app_link</item>
+    </string-array>
+
+    <string-array name="paypal_link_types_values">
+        <item name="deep_link">@string/paypal_deep_link</item>
+        <item name="app_link">@string/paypal_app_link</item>
+    </string-array>
+
 </resources>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="paypal_display_name_summary">Name to be displayed in the PayPal flow</string>
     <string name="paypal_landing_page_type_billing">Billing</string>
     <string name="paypal_landing_page_type_login">Login</string>
+    <string name="paypal_link">Navigation from Web</string>
+    <string name="paypal_deep_link">Deep Link</string>
+    <string name="paypal_app_link">App Link</string>
     <string name="paypal_native_checkout_launch">Launch PayPal Native Checkout</string>
     <string name="paypal_native_checkout_vault_launch">Launch PayPal Native Vault Checkout</string>
     <string name="venmo">Venmo</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -146,6 +146,13 @@
             android:summary="@string/paypal_address_override_summary"
             android:defaultValue="false" />
 
+        <ListPreference
+            android:key="paypal_link_type"
+            android:title="@string/paypal_link"
+            android:entries="@array/paypal_link_types"
+            android:entryValues="@array/paypal_link_types_values"
+            android:defaultValue="@string/paypal_deep_link"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
### Summary of changes

 - Add an option in Demo app settings for switching between deep links and app links
 - The API currently fails when passing an App Link URL, which is currently expected

![Screenshot_20240501_161327](https://github.com/braintree/braintree_android/assets/5005216/827143ed-1312-44c7-8d1f-c63cb10b2830)

![Screenshot_20240501_161442](https://github.com/braintree/braintree_android/assets/5005216/7c070c33-3cd2-4394-bf64-ed00bf827961)

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

