### PR TITLE
Add New Demo Tokenization Key for PayPal

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -47,7 +47,10 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
     public BraintreeClient getBraintreeClient() {
         // lazily instantiate braintree client in case the demo has been reset
         if (braintreeClient == null) {
-            if (Settings.useTokenizationKey(this)) {
+            if (Settings.useTokenizationKey(this) && Settings.showCheckoutExperience(this)) {
+                String tokenizationKey = Settings.getPayPalCheckoutTokenizationKey(this);
+                braintreeClient = new BraintreeClient(this, tokenizationKey);
+            } else if (Settings.useTokenizationKey(this)) {
                 String tokenizationKey = Settings.getTokenizationKey(this);
                 braintreeClient = new BraintreeClient(this, tokenizationKey);
             } else {

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -21,11 +21,14 @@ public class Settings {
     private static final String PRODUCTION_BASE_SERVER_URL = MERCHANT_SERVER_URL + "/braintree/production";
     private static final String MOCKED_PAY_PAL_SANDBOX_SERVER_URL = MERCHANT_SERVER_URL + "/braintree/mock_pay_pal";
 
-    private static final String SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn";
+    private static final String SANDBOX_TOKENIZATION_KEY = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c";
     private static final String PRODUCTION_TOKENIZATION_KEY = "production_t2wns2y2_dfy45jdj3dxkmz5m";
     private static final String MOCKED_PAY_PAL_SANDBOX_TOKENIZATION_KEY = "sandbox_q7v35n9n_555d2htrfsnnmfb3";
 
     static final String LOCAL_PAYMENTS_TOKENIZATION_KEY = "sandbox_f252zhq7_hh4cpc39zq4rgjcg";
+
+    private static final String XO_SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn";
+    private static final String XO_PRODUCTION_TOKENIZATION_KEY = "";
 
     private static SharedPreferences sharedPreferences;
 
@@ -112,6 +115,18 @@ public class Settings {
             return MOCKED_PAY_PAL_SANDBOX_TOKENIZATION_KEY;
         } else if (PRODUCTION_ENV_NAME.equals(environment)) {
             return PRODUCTION_TOKENIZATION_KEY;
+        } else {
+            return null;
+        }
+    }
+
+    public static String getPayPalCheckoutTokenizationKey(Context context) {
+        String environment = getEnvironment(context);
+
+        if (SANDBOX_ENV_NAME.equals(environment)) {
+            return XO_SANDBOX_TOKENIZATION_KEY;
+        } else if (PRODUCTION_ENV_NAME.equals(environment)) {
+            return XO_PRODUCTION_TOKENIZATION_KEY;
         } else {
             return null;
         }
@@ -220,5 +235,9 @@ public class Settings {
 
     public static boolean isManualBrowserSwitchingEnabled(Context context) {
         return getPreferences(context).getBoolean("enable_manual_browser_switching", false);
+    }
+
+    public static boolean showCheckoutExperience(Context context) {
+        return getPreferences(context).getBoolean("show_checkout_experience", false);
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -21,13 +21,13 @@ public class Settings {
     private static final String PRODUCTION_BASE_SERVER_URL = MERCHANT_SERVER_URL + "/braintree/production";
     private static final String MOCKED_PAY_PAL_SANDBOX_SERVER_URL = MERCHANT_SERVER_URL + "/braintree/mock_pay_pal";
 
-    private static final String SANDBOX_TOKENIZATION_KEY = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c";
+    private static final String SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn";
     private static final String PRODUCTION_TOKENIZATION_KEY = "production_t2wns2y2_dfy45jdj3dxkmz5m";
     private static final String MOCKED_PAY_PAL_SANDBOX_TOKENIZATION_KEY = "sandbox_q7v35n9n_555d2htrfsnnmfb3";
 
     static final String LOCAL_PAYMENTS_TOKENIZATION_KEY = "sandbox_f252zhq7_hh4cpc39zq4rgjcg";
 
-    private static final String XO_SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn";
+    private static final String XO_SANDBOX_TOKENIZATION_KEY = "sandbox_rz48bqvw_jcyycfw6f9j4nj9c";
     private static final String XO_PRODUCTION_TOKENIZATION_KEY = "";
 
     private static SharedPreferences sharedPreferences;

--- a/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
@@ -26,6 +26,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
         onSharedPreferenceChanged(preferences, "google_pay_currency");
         onSharedPreferenceChanged(preferences, "google_pay_allowed_countries_for_shipping");
         onSharedPreferenceChanged(preferences, "tokenization_key_type");
+        onSharedPreferenceChanged(preferences, "show_checkout_experience");
         preferences.registerOnSharedPreferenceChangeListener(this);
     }
 

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="enable_manual_browser_switching_summary">Use alternate integration pattern to give the Demo app more control over browser switching</string>
     <string name="require_three_d_secure">Require 3D Secure</string>
     <string name="require_three_d_secure_summary">Requires a successful authentication for 3D Secure transactions</string>
+    <string name="paypal_checkout_experience">PayPal Checkout Experience</string>
+    <string name="paypal_checkout_experience_summary">Show new PayPal checkout experience</string>
     <string name="paypal_disable_signature_verification">Disable app switch signature verification</string>
     <string name="paypal_disable_signature_verification_summary">Allows app switch with a PayPal Wallet app that is not signed</string>
     <string name="paypal_buyer_email_address">Buyer Email Address</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -92,7 +92,7 @@
         android:title="@string/paypal">
 
         <CheckBoxPreference
-            android:key="enable_manual_browser_switching"
+            android:key="show_checkout_experience"
             android:title="@string/paypal_checkout_experience"
             android:summary="@string/paypal_checkout_experience_summary"
             android:defaultValue="false" />

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -92,6 +92,12 @@
         android:title="@string/paypal">
 
         <CheckBoxPreference
+            android:key="enable_manual_browser_switching"
+            android:title="@string/paypal_checkout_experience"
+            android:summary="@string/paypal_checkout_experience_summary"
+            android:defaultValue="false" />
+
+        <CheckBoxPreference
             android:key="paypal_disable_signature_verification"
             android:title="@string/paypal_disable_signature_verification"
             android:summary="@string/paypal_disable_signature_verification_summary"


### PR DESCRIPTION
### Summary of changes

 - Add tokenization key to demo app that is associated with merchant account that is configured for new PayPal checkout experience.
 - Requires settings "Tokenization Key", "PayPal Checkout Experience" and "Intent Type = Sale" to be set in demo app to launch new checkout experience from PayPal checkout flow
 - Prod tokenization key does not exist for this yet, but set up demo app at allow for one to be added easily

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

