### PR TITLE
Handle empty email address

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -90,6 +90,7 @@ public class PayPalRequestFactory {
             shippingAddress.setLocality("San Francisco");
             shippingAddress.setRegion("CA");
             shippingAddress.setCountryCodeAlpha2("US");
+            shippingAddress.setPostalCode("94103");
 
             request.setShippingAddressOverride(shippingAddress);
         }

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -208,7 +208,7 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
         }
 
         if (userAuthenticationEmail != null && !userAuthenticationEmail.isEmpty()) {
-            parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail);
+            parameters.put(PAYER_EMAIL_KEY, userAuthenticationEmail);
         }
 
         String currencyCode = getCurrencyCode();

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalCheckoutRequest.java
@@ -207,7 +207,9 @@ public class PayPalCheckoutRequest extends PayPalRequest implements Parcelable {
             parameters.put(BILLING_AGREEMENT_DETAILS_KEY, details);
         }
 
-        parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail);
+        if (userAuthenticationEmail != null && !userAuthenticationEmail.isEmpty()) {
+            parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail);
+        }
 
         String currencyCode = getCurrencyCode();
         if (currencyCode == null) {

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalCheckoutRequestUnitTest.java
@@ -140,4 +140,20 @@ public class PayPalCheckoutRequestUnitTest {
 
         assertTrue(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
     }
+
+    @Test
+    public void createRequestBody_does_not_set_userAuthenticationEmail_when_email_is_empty() throws JSONException {
+        String payerEmail = "";
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        request.setUserAuthenticationEmail(payerEmail);
+        String requestBody = request.createRequestBody(
+            mock(Configuration.class),
+            mock(Authorization.class),
+            "success_url",
+            "cancel_url"
+        );
+
+        assertFalse(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - Check for empty email address - prevent passing the value to the API
 - Provide a postal code in the demo app's `PayPalRequestFactory` which now seems to be required

![Screenshot_20240513_152120](https://github.com/braintree/braintree_android/assets/5005216/2c564434-d051-405c-acba-91a0bf6c2940)

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

