### PR TITLE
Send `is_vault` FPTI tag

### DIFF
--- a/BraintreeCore/schemas/com.braintreepayments.api.AnalyticsDatabase/5.json
+++ b/BraintreeCore/schemas/com.braintreepayments.api.AnalyticsDatabase/5.json
@@ -1,0 +1,72 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "be2819613b2d28975a74cd80ed788cd5",
+    "entities": [
+      {
+        "tableName": "analytics_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `paypal_context_id` TEXT, `link_type` TEXT, `timestamp` INTEGER NOT NULL, `venmo_installed` INTEGER NOT NULL DEFAULT 0, `is_vault` INTEGER NOT NULL DEFAULT 0, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payPalContextId",
+            "columnName": "paypal_context_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "linkType",
+            "columnName": "link_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "venmoInstalled",
+            "columnName": "venmo_installed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isVault",
+            "columnName": "is_vault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'be2819613b2d28975a74cd80ed788cd5')"
+    ]
+  }
+}

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/AnalyticsClientTest.java
@@ -40,7 +40,7 @@ public class AnalyticsClientTest {
         Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT);
         
-        AnalyticsEvent event = new AnalyticsEvent("event.started", null, null, 123, false);
+        AnalyticsEvent event = new AnalyticsEvent("event.started", null, null, 123, false, false);
 
         AnalyticsClient sut = new AnalyticsClient(context);
         UUID workSpecId = sut.sendEvent(configuration, event, "sessionId", "custom", authorization);

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsClient.kt
@@ -49,6 +49,7 @@ internal class AnalyticsClient @VisibleForTesting constructor(
             .putString(WORK_INPUT_KEY_LINK_TYPE, event.linkType)
             .putLong(WORK_INPUT_KEY_TIMESTAMP, event.timestamp)
             .putBoolean(WORK_INPUT_KEY_VENMO_INSTALLED, event.venmoInstalled)
+            .putBoolean(WORK_INPUT_KEY_IS_VAULT_REQUEST, event.isVaultRequest)
             .build()
 
         val analyticsWorkRequest =
@@ -66,6 +67,7 @@ internal class AnalyticsClient @VisibleForTesting constructor(
         val linkType = inputData.getString(WORK_INPUT_KEY_LINK_TYPE)
         val timestamp = inputData.getLong(WORK_INPUT_KEY_TIMESTAMP, INVALID_TIMESTAMP)
         val venmoInstalled = inputData.getBoolean(WORK_INPUT_KEY_VENMO_INSTALLED, false)
+        val isVaultRequest = inputData.getBoolean(WORK_INPUT_KEY_IS_VAULT_REQUEST, false)
 
         return if (eventName == null || timestamp == INVALID_TIMESTAMP) {
             ListenableWorker.Result.failure()
@@ -75,7 +77,8 @@ internal class AnalyticsClient @VisibleForTesting constructor(
                 payPalContextId,
                 linkType,
                 timestamp,
-                venmoInstalled
+                venmoInstalled,
+                isVaultRequest
             )
             val analyticsEventDao = analyticsDatabase.analyticsEventDao()
             analyticsEventDao.insertEvent(event)
@@ -202,6 +205,7 @@ internal class AnalyticsClient @VisibleForTesting constructor(
                 .putOpt(LINK_TYPE_KEY, analyticsEvent.linkType)
                 .put(TIMESTAMP_KEY, analyticsEvent.timestamp)
                 .put(VENMO_INSTALLED_KEY, analyticsEvent.venmoInstalled)
+                .put(IS_VAULT_REQUEST_KEY, analyticsEvent.isVaultRequest)
                 .put(TENANT_NAME_KEY, "Braintree")
             eventParamsJSON.put(singleEventJSON)
         }
@@ -216,6 +220,7 @@ internal class AnalyticsClient @VisibleForTesting constructor(
         private const val FPTI_ANALYTICS_URL = "https://api-m.paypal.com/v1/tracking/batch/events"
         private const val PAYPAL_CONTEXT_ID_KEY = "paypal_context_id"
         private const val VENMO_INSTALLED_KEY = "venmo_installed"
+        private const val IS_VAULT_REQUEST_KEY = "is_vault"
         private const val LINK_TYPE_KEY = "link_type"
         private const val TOKENIZATION_KEY = "tokenization_key"
         private const val AUTHORIZATION_FINGERPRINT_KEY = "authorization_fingerprint"
@@ -236,6 +241,7 @@ internal class AnalyticsClient @VisibleForTesting constructor(
         const val WORK_INPUT_KEY_TIMESTAMP = "timestamp"
         const val WORK_INPUT_KEY_PAYPAL_CONTEXT_ID = "payPalContextId"
         const val WORK_INPUT_KEY_VENMO_INSTALLED = "venmoInstalled"
+        const val WORK_INPUT_KEY_IS_VAULT_REQUEST = "isVaultRequest"
         const val WORK_INPUT_KEY_LINK_TYPE = "linkType"
         private const val DELAY_TIME_SECONDS = 30L
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsDatabase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsDatabase.kt
@@ -8,12 +8,13 @@ import androidx.room.RoomDatabase
 
 // Ref: https://developer.android.com/training/data-storage/room/migrating-db-versions
 @Database(
-        version = 4,
+        version = 5,
         entities = [AnalyticsEvent::class],
         autoMigrations = [
             AutoMigration(from = 1, to = 2),
             AutoMigration(from = 2, to = 3),
-            AutoMigration(from = 3, to = 4)
+            AutoMigration(from = 3, to = 4),
+            AutoMigration(from = 4, to = 5)
         ]
 )
 internal abstract class AnalyticsDatabase : RoomDatabase() {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/AnalyticsEvent.kt
@@ -23,7 +23,10 @@ open class AnalyticsEvent internal constructor(
     open val timestamp: Long = System.currentTimeMillis(),
 
     @ColumnInfo(name = "venmo_installed", defaultValue = "0")
-    open val venmoInstalled: Boolean = false
+    open val venmoInstalled: Boolean = false,
+
+    @ColumnInfo(name = "is_vault", defaultValue = "0")
+    open val isVaultRequest: Boolean = false
 ) {
     @JvmField
     @PrimaryKey(autoGenerate = true)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -216,13 +216,14 @@ open class BraintreeClient @VisibleForTesting internal constructor(
     fun sendAnalyticsEvent(
             eventName: String,
             payPalContextId: String? = null,
-            linkType: String? = null
+            linkType: String? = null,
+            isVaultRequest: Boolean = false
     ) {
         getAuthorization { authorization, _ ->
             if (authorization != null) {
                 getConfiguration { configuration, _ ->
                     val isVenmoInstalled = deviceInspector.isVenmoInstalled(applicationContext)
-                    val event = AnalyticsEvent(eventName, payPalContextId, linkType, venmoInstalled = isVenmoInstalled)
+                    val event = AnalyticsEvent(eventName, payPalContextId, linkType, venmoInstalled = isVenmoInstalled, isVaultRequest = isVaultRequest)
                     sendAnalyticsEvent(event, configuration, authorization)
                 }
             }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/BraintreeClient.kt
@@ -223,7 +223,13 @@ open class BraintreeClient @VisibleForTesting internal constructor(
             if (authorization != null) {
                 getConfiguration { configuration, _ ->
                     val isVenmoInstalled = deviceInspector.isVenmoInstalled(applicationContext)
-                    val event = AnalyticsEvent(eventName, payPalContextId, linkType, venmoInstalled = isVenmoInstalled, isVaultRequest = isVaultRequest)
+                    val event = AnalyticsEvent(
+                            eventName,
+                            payPalContextId,
+                            linkType,
+                            venmoInstalled = isVenmoInstalled,
+                            isVaultRequest = isVaultRequest
+                    )
                     sendAnalyticsEvent(event, configuration, authorization)
                 }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## unreleased
 * PayPal
-  * Send `is_vault` in `event_params` to PayPal's analytics
+  * Send `is_vault` in `event_params` analytics
 * Venmo
-  * Send `link_type` and `is_vault` in `event_params` to PayPal's analytics
+  * Send `link_type` and `is_vault` in `event_params` analytics
   
 ## 4.45.0 (2024-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## unreleased
 * PayPal
-  * Send `is_vault` in `event_params` to PayPal's analytics service (FPTI)s
+  * Send `is_vault` in `event_params` to PayPal's analytics
 * Venmo
-  * Send `link_type` and `is_vault` in `event_params` to PayPal's analytics service (FPTI)
+  * Send `link_type` and `is_vault` in `event_params` to PayPal's analytics
   
 ## 4.45.0 (2024-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## unreleased
 * PayPal
-  * Send `isVaultRequest` in `event_params` to PayPal's analytics service (FPTI)s
+  * Send `is_vault` in `event_params` to PayPal's analytics service (FPTI)s
 * Venmo
-  * Send `link_type` and `isVaultRequest` in `event_params` to PayPal's analytics service (FPTI)
+  * Send `link_type` and `is_vault` in `event_params` to PayPal's analytics service (FPTI)
   
 ## 4.45.0 (2024-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
-
+* PayPal
+  * Send `isVaultRequest` in `event_params` to PayPal's analytics service (FPTI)s
 * Venmo
-  * Send `link_type` in `event_params` to PayPal's analytics service (FPTI)
+  * Send `link_type` and `isVaultRequest` in `event_params` to PayPal's analytics service (FPTI)
   
 ## 4.45.0 (2024-04-16)
 

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -289,8 +289,8 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalVaultRequest);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.selected", null);
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.started", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.selected", null, null, true);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.started", null, null, true);
     }
 
     @Test
@@ -428,8 +428,8 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.selected", null);
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.started", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.selected", null, null, false);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.started", null, null, false);
     }
 
     @Test
@@ -442,7 +442,7 @@ public class PayPalClientUnitTest {
         request.setShouldOfferPayLater(true);
         sut.tokenizePayPalAccount(activity, request);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.paylater.offered", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.paylater.offered", null, null, false);
     }
 
     @Test
@@ -488,7 +488,7 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(activity, lifecycle, braintreeClient, payPalInternalClient);
         sut.tokenizePayPalAccount(activity, payPalRequest);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.credit.offered", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.credit.offered", null, null, true);
     }
 
     @Test
@@ -616,7 +616,7 @@ public class PayPalClientUnitTest {
 
         sut.onBrowserSwitchResult(browserSwitchResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.succeeded", "EC-HERMES-SANDBOX-EC-TOKEN");
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.succeeded", "EC-HERMES-SANDBOX-EC-TOKEN", null, false);
     }
 
     @Test
@@ -647,7 +647,7 @@ public class PayPalClientUnitTest {
 
         sut.onBrowserSwitchResult(browserSwitchResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.succeeded", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.succeeded", null, null, false);
     }
 
     @Test
@@ -678,7 +678,7 @@ public class PayPalClientUnitTest {
 
         sut.onBrowserSwitchResult(browserSwitchResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.succeeded", "EC-HERMES-SANDBOX-EC-TOKEN");
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.succeeded", "EC-HERMES-SANDBOX-EC-TOKEN", null, false);
     }
 
     public void onBrowserSwitchResult_oneTimePayment_whenTokenIsNull_sendsAnalyticsEvents() throws JSONException {
@@ -770,7 +770,7 @@ public class PayPalClientUnitTest {
 
         sut.onBrowserSwitchResult(browserSwitchResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.credit.accepted", "EC-HERMES-SANDBOX-EC-TOKEN");
+        verify(braintreeClient).sendAnalyticsEvent("paypal.credit.accepted", "EC-HERMES-SANDBOX-EC-TOKEN", null, false);
     }
 
     @Test
@@ -802,7 +802,7 @@ public class PayPalClientUnitTest {
 
         sut.onBrowserSwitchResult(browserSwitchResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.credit.accepted", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.credit.accepted", null, null, false);
     }
 
     @Test
@@ -840,7 +840,7 @@ public class PayPalClientUnitTest {
         assertEquals("User canceled PayPal.", exception.getMessage());
         assertTrue(((UserCanceledException) exception).isExplicitCancelation());
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null, null, false);
     }
 
     @Test
@@ -878,7 +878,7 @@ public class PayPalClientUnitTest {
         assertEquals("User canceled PayPal.", exception.getMessage());
         assertTrue(((UserCanceledException) exception).isExplicitCancelation());
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", "EC-HERMES-SANDBOX-EC-TOKEN");
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", "EC-HERMES-SANDBOX-EC-TOKEN", null, false);
     }
 
     @Test
@@ -916,7 +916,7 @@ public class PayPalClientUnitTest {
         assertEquals("User canceled PayPal.", exception.getMessage());
         assertTrue(((UserCanceledException) exception).isExplicitCancelation());
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null, null, false);
     }
 
     @Test
@@ -940,7 +940,7 @@ public class PayPalClientUnitTest {
         assertEquals("User canceled PayPal.", exception.getMessage());
         assertFalse(((UserCanceledException) exception).isExplicitCancelation());
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null, null, false);
     }
 
     @Test
@@ -968,7 +968,7 @@ public class PayPalClientUnitTest {
         assertEquals("User canceled PayPal.", exception.getMessage());
         assertFalse(((UserCanceledException) exception).isExplicitCancelation());
 
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.canceled", null, null, false);
     }
 
     @Test

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutClient.java
@@ -85,7 +85,7 @@ public class PayPalNativeCheckoutClient {
      */
     @Deprecated
     public void tokenizePayPalAccount(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) throws Exception {
-        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started", payPalContextId, null);
+        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started", payPalContextId, null, false);
         // NEXT_MAJOR_VERSION: remove tokenizePayPalAccount method and refactor tests to center
         // around launchNativeCheckout in the future. Keeping the tests as they are for now allows
         // us to maintain test coverage across both the tokenizePayPalAccount and launchNativeCheckout methods
@@ -94,7 +94,7 @@ public class PayPalNativeCheckoutClient {
         if (isCheckoutRequest || isVaultRequest) {
             launchNativeCheckout(activity, payPalRequest);
         } else {
-            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.invalid-request.failed", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.invalid-request.failed", payPalContextId, null, false);
             String message = "Unsupported request type. Please use either a "
                     + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
             throw new Exception(message);
@@ -111,15 +111,15 @@ public class PayPalNativeCheckoutClient {
      * @param payPalRequest a {@link PayPalNativeRequest} used to customize the request.
      */
     public void launchNativeCheckout(@NonNull final FragmentActivity activity, @NonNull final PayPalNativeRequest payPalRequest) {
-        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started", payPalContextId, null);
+        braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.started", payPalContextId, null, false);
         if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
             sendCheckoutRequest(activity, (PayPalNativeCheckoutRequest) payPalRequest);
-            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.succeeded", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.succeeded", payPalContextId, null, false);
         } else if (payPalRequest instanceof PayPalNativeCheckoutVaultRequest) {
             sendVaultRequest(activity, (PayPalNativeCheckoutVaultRequest) payPalRequest);
-            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.succeeded", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.succeeded", payPalContextId, null, false);
         } else if (listener != null) {
-            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.invalid-request.failed", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.tokenize.invalid-request.failed", payPalContextId, null, false);
             String message = "Unsupported request type. Please use either a "
                     + "PayPalNativeCheckoutRequest or a PayPalNativeCheckoutVaultRequest.";
             listener.onPayPalFailure(new BraintreeException(message));
@@ -127,9 +127,9 @@ public class PayPalNativeCheckoutClient {
     }
 
     private void sendCheckoutRequest(final FragmentActivity activity, final PayPalNativeCheckoutRequest payPalCheckoutRequest) {
-        braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.selected", payPalContextId, null);
+        braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.selected", payPalContextId, null, false);
         if (payPalCheckoutRequest.getShouldOfferPayLater()) {
-            braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.paylater.offered", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.paylater.offered", payPalContextId, null, false);
         }
 
         braintreeClient.getConfiguration((configuration, error) -> {
@@ -138,9 +138,9 @@ public class PayPalNativeCheckoutClient {
     }
 
     private void sendVaultRequest(final FragmentActivity activity, final PayPalNativeCheckoutVaultRequest payPalVaultRequest) {
-        braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.selected", payPalContextId, null);
+        braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.selected", payPalContextId, null, false);
         if (payPalVaultRequest.getShouldOfferCredit()) {
-            braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.credit.offered", payPalContextId, null);
+            braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.credit.offered", payPalContextId, null, false);
         }
 
         braintreeClient.getConfiguration((configuration, error) -> {
@@ -160,7 +160,7 @@ public class PayPalNativeCheckoutClient {
                     payPalContextId = pairingId;
                 }
                 String analyticsPrefix = payPalRequest instanceof PayPalNativeCheckoutVaultRequest ? "billing-agreement" : "single-payment";
-                braintreeClient.sendAnalyticsEvent(String.format("paypal-native.%s.started", analyticsPrefix), payPalContextId, null);
+                braintreeClient.sendAnalyticsEvent(String.format("paypal-native.%s.started", analyticsPrefix), payPalContextId, null, false);
 
                 Environment environment;
                 if ("sandbox".equals(configuration.getEnvironment())) {
@@ -213,10 +213,10 @@ public class PayPalNativeCheckoutClient {
                 PayPalCheckout.startCheckout(createOrderActions -> {
                     if (payPalRequest instanceof PayPalNativeCheckoutRequest) {
                         createOrderActions.set(payPalResponse.getPairingId());
-                        braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.succeeded", payPalContextId, null);
+                        braintreeClient.sendAnalyticsEvent("paypal-native.single-payment.succeeded", payPalContextId, null, false);
                     } else if (payPalRequest instanceof PayPalNativeCheckoutVaultRequest) {
                         createOrderActions.setBillingAgreementId(payPalResponse.getPairingId());
-                        braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.succeeded", payPalContextId, null);
+                        braintreeClient.sendAnalyticsEvent("paypal-native.billing-agreement.succeeded", payPalContextId, null, false);
                     }
                 }, payPalRequest.hasUserLocationConsent());
             } else {
@@ -232,25 +232,25 @@ public class PayPalNativeCheckoutClient {
     ) {
         PayPalCheckout.registerCallbacks(
                 approval -> {
-                    braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.started", payPalContextId, null);
+                    braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.started", payPalContextId, null, false);
                     PayPalNativeCheckoutAccount payPalAccount = setupAccount(payPalRequest, approval.getData());
                     internalPayPalClient.tokenize(payPalAccount, (payPalAccountNonce, error) -> {
                         if (payPalAccountNonce != null) {
-                            braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.succeeded", payPalContextId, null);
+                            braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.succeeded", payPalContextId, null, false);
                             listener.onPayPalSuccess(payPalAccountNonce);
                         } else {
-                            braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.failed", payPalContextId, null);
+                            braintreeClient.sendAnalyticsEvent("paypal-native.on-approve.failed", payPalContextId, null, false);
                             listener.onPayPalFailure(new Exception("PaypalAccountNonce is null"));
                         }
                     });
                 },
                 null,
                 () -> {
-                    braintreeClient.sendAnalyticsEvent("paypal-native.canceled", payPalContextId, null);
+                    braintreeClient.sendAnalyticsEvent("paypal-native.canceled", payPalContextId, null, false);
                     listener.onPayPalFailure(new Exception("User has canceled"));
                 },
                 errorInfo -> {
-                    braintreeClient.sendAnalyticsEvent("paypal-native.on-error.failed", payPalContextId, null);
+                    braintreeClient.sendAnalyticsEvent("paypal-native.on-error.failed", payPalContextId, null, false);
                     listener.onPayPalFailure(new Exception(errorInfo.getError().getMessage()));
                 }
         );

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -254,8 +254,8 @@ public class VenmoClient {
             @Nullable final String paymentContextId
     ) {
         boolean isClientTokenAuth = (authorization instanceof ClientToken);
-        boolean shouldVault = request.getShouldVault() && isClientTokenAuth;
-        sharedPrefsWriter.persistVenmoVaultOption(activity, shouldVault);
+        isVaultRequest = request.getShouldVault() && isClientTokenAuth;
+        sharedPrefsWriter.persistVenmoVaultOption(activity, isVaultRequest);
         if (observer != null) {
             VenmoIntentData intentData = new VenmoIntentData(configuration, venmoProfileId, paymentContextId, braintreeClient.getSessionId(), braintreeClient.getIntegrationType());
             if (request.getFallbackToWeb()) {
@@ -291,8 +291,8 @@ public class VenmoClient {
                                 @Override
                                 public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
                                     if (nonce != null) {
-                                        boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
-                                        if (shouldVault && isClientTokenAuth) {
+                                        isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
+                                        if (isVaultRequest && isClientTokenAuth) {
                                             vaultVenmoAccountNonce(nonce.getString(), new VenmoOnActivityResultCallback() {
                                                 @Override
                                                 public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
@@ -316,8 +316,8 @@ public class VenmoClient {
                         } else {
                             String nonce = venmoResult.getVenmoAccountNonce();
 
-                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
-                            if (shouldVault && isClientTokenAuth) {
+                            isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(braintreeClient.getApplicationContext());
+                            if (isVaultRequest && isClientTokenAuth) {
                                 vaultVenmoAccountNonce(nonce, new VenmoOnActivityResultCallback() {
                                     @Override
                                     public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
@@ -387,8 +387,8 @@ public class VenmoClient {
                                 @Override
                                 public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
                                     if (nonce != null) {
-                                        boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                                        if (shouldVault && isClientTokenAuth) {
+                                        isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(context);
+                                        if (isVaultRequest && isClientTokenAuth) {
                                             vaultVenmoAccountNonce(nonce.getString(), callback);
                                         } else {
                                             braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType, isVaultRequest);
@@ -404,8 +404,8 @@ public class VenmoClient {
                         } else {
                             String nonce = data.getStringExtra(EXTRA_PAYMENT_METHOD_NONCE);
 
-                            boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                            if (shouldVault && isClientTokenAuth) {
+                            isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(context);
+                            if (isVaultRequest && isClientTokenAuth) {
                                 vaultVenmoAccountNonce(nonce, callback);
                             } else {
                                 String venmoUsername = data.getStringExtra(EXTRA_USERNAME);
@@ -503,8 +503,8 @@ public class VenmoClient {
                                         @Override
                                         public void onResult(@Nullable VenmoAccountNonce nonce, @Nullable Exception error) {
                                             if (nonce != null) {
-                                                boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                                                if (shouldVault && isClientTokenAuth) {
+                                                isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(context);
+                                                if (isVaultRequest && isClientTokenAuth) {
                                                     braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                                     vaultVenmoAccountNonce(nonce.getString(), callback);
                                                 } else {
@@ -518,8 +518,8 @@ public class VenmoClient {
                                         }
                                     });
                                 } else if (paymentMethodNonce != null && username != null) {
-                                    boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
-                                    if (shouldVault && isClientTokenAuth) {
+                                    isVaultRequest = sharedPrefsWriter.getVenmoVaultOption(context);
+                                    if (isVaultRequest && isClientTokenAuth) {
                                         braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                         vaultVenmoAccountNonce(paymentMethodNonce, callback);
                                     } else {

--- a/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
+++ b/Venmo/src/main/java/com/braintreepayments/api/VenmoClient.java
@@ -52,6 +52,11 @@ public class VenmoClient {
      */
     private String linkType = null;
 
+    /**
+     * True if `tokenize()` was called with a Vault request object type
+     */
+    private Boolean isVaultRequest = false;
+
     @VisibleForTesting
     VenmoLifecycleObserver observer;
 
@@ -131,7 +136,7 @@ public class VenmoClient {
      * @param activity used to open the Venmo's Google Play Store
      */
     public void showVenmoInGooglePlayStore(@NonNull FragmentActivity activity) {
-        braintreeClient.sendAnalyticsEvent("android.pay-with-venmo.app-store.invoked", payPalContextId, linkType);
+        braintreeClient.sendAnalyticsEvent("android.pay-with-venmo.app-store.invoked", payPalContextId, linkType, isVaultRequest);
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(
                 "https://play.google.com/store/apps/details?id=" + VENMO_PACKAGE_NAME));
@@ -171,13 +176,13 @@ public class VenmoClient {
     @Deprecated
     public void tokenizeVenmoAccount(@NonNull final FragmentActivity activity, @NonNull final VenmoRequest request, @NonNull final VenmoTokenizeAccountCallback callback) {
         linkType = request.getFallbackToWeb() ? "universal" : "deeplink";
-        braintreeClient.sendAnalyticsEvent("pay-with-venmo.selected", payPalContextId, linkType);
+        braintreeClient.sendAnalyticsEvent("pay-with-venmo.selected", payPalContextId, linkType, isVaultRequest);
         braintreeClient.getConfiguration(new ConfigurationCallback() {
             @Override
             public void onResult(@Nullable final Configuration configuration, @Nullable Exception error) {
                 if (configuration == null) {
                     callback.onResult(error);
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType, isVaultRequest);
                     return;
                 }
 
@@ -194,14 +199,14 @@ public class VenmoClient {
 
                 if (exceptionMessage != null) {
                     callback.onResult(new AppSwitchNotAvailableException(exceptionMessage));
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType, isVaultRequest);
                     return;
                 }
 
                 // Merchants are not allowed to collect user addresses unless ECD (Enriched Customer Data) is enabled on the BT Control Panel.
                 if ((request.getCollectCustomerShippingAddress() || request.getCollectCustomerBillingAddress()) && !configuration.getVenmoEnrichedCustomerDataEnabled()) {
                     callback.onResult(new BraintreeException("Cannot collect customer data when ECD is disabled. Enable this feature in the Control Panel to collect this data."));
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType, isVaultRequest);
                     return;
                 }
 
@@ -232,7 +237,7 @@ public class VenmoClient {
                             });
                         } else {
                             callback.onResult(exception);
-                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType);
+                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failed", payPalContextId, linkType, isVaultRequest);
                         }
                     }
                 });
@@ -257,7 +262,7 @@ public class VenmoClient {
                 try {
                     startAppLinkFlow(activity, intentData);
                 } catch (JSONException | BrowserSwitchException exception) {
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType, isVaultRequest);
                     deliverVenmoFailure(exception);
                 }
             } else {
@@ -267,12 +272,12 @@ public class VenmoClient {
             Intent launchIntent = getLaunchIntent(configuration, venmoProfileId, paymentContextId);
             activity.startActivityForResult(launchIntent, BraintreeRequestCodes.VENMO);
         }
-        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started", payPalContextId, linkType);
+        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.started", payPalContextId, linkType, isVaultRequest);
     }
 
     void onVenmoResult(final VenmoResult venmoResult) {
         if (venmoResult.getError() == null) {
-            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success", payPalContextId, linkType);
+            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success", payPalContextId, linkType, isVaultRequest);
 
             braintreeClient.getAuthorization(new AuthorizationCallback() {
                 @Override
@@ -299,11 +304,11 @@ public class VenmoClient {
                                                 }
                                             });
                                         } else {
-                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType);
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType, isVaultRequest);
                                             deliverVenmoSuccess(nonce);
                                         }
                                     } else {
-                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType);
+                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType, isVaultRequest);
                                         deliverVenmoFailure(error);
                                     }
                                 }
@@ -338,7 +343,7 @@ public class VenmoClient {
 
         } else if (venmoResult.getError() != null) {
             if (venmoResult.getError() instanceof UserCanceledException) {
-                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", payPalContextId, linkType);
+                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", payPalContextId, linkType, isVaultRequest);
             }
             deliverVenmoFailure(venmoResult.getError());
         }
@@ -368,7 +373,7 @@ public class VenmoClient {
      */
     public void onActivityResult(@NonNull final Context context, int resultCode, @Nullable final Intent data, @NonNull final VenmoOnActivityResultCallback callback) {
         if (resultCode == AppCompatActivity.RESULT_OK) {
-            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success", payPalContextId, linkType);
+            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.success", payPalContextId, linkType, isVaultRequest);
 
             braintreeClient.getAuthorization(new AuthorizationCallback() {
                 @Override
@@ -386,12 +391,12 @@ public class VenmoClient {
                                         if (shouldVault && isClientTokenAuth) {
                                             vaultVenmoAccountNonce(nonce.getString(), callback);
                                         } else {
-                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType);
+                                            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType, isVaultRequest);
                                             callback.onResult(nonce, null);
                                         }
 
                                     } else {
-                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType);
+                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.failure", payPalContextId, linkType, isVaultRequest);
                                         callback.onResult(null, error);
                                     }
                                 }
@@ -415,7 +420,7 @@ public class VenmoClient {
             });
 
         } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
-            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", payPalContextId, linkType);
+            braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", payPalContextId, linkType, isVaultRequest);
             callback.onResult(null, new UserCanceledException("User canceled Venmo."));
         }
     }
@@ -425,9 +430,9 @@ public class VenmoClient {
             @Override
             public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
                 if (venmoAccountNonce != null) {
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.vault.success", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.vault.success", payPalContextId, linkType, isVaultRequest);
                 } else {
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.vault.failed", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.vault.failed", payPalContextId, linkType, isVaultRequest);
                 }
                 callback.onResult(venmoAccountNonce, error);
             }
@@ -475,7 +480,7 @@ public class VenmoClient {
         int result = browserSwitchResult.getStatus();
         switch (result) {
             case BrowserSwitchStatus.CANCELED:
-                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.canceled", payPalContextId, linkType);
+                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.canceled", payPalContextId, linkType, isVaultRequest);
                 callback.onResult(null, new UserCanceledException("User canceled Venmo."));
                 break;
             case BrowserSwitchStatus.SUCCESS:
@@ -500,14 +505,14 @@ public class VenmoClient {
                                             if (nonce != null) {
                                                 boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
                                                 if (shouldVault && isClientTokenAuth) {
-                                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType);
+                                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                                     vaultVenmoAccountNonce(nonce.getString(), callback);
                                                 } else {
-                                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType);
+                                                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                                     callback.onResult(nonce, null);
                                                 }
                                             } else {
-                                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType);
+                                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType, isVaultRequest);
                                                 callback.onResult(null, error);
                                             }
                                         }
@@ -515,29 +520,29 @@ public class VenmoClient {
                                 } else if (paymentMethodNonce != null && username != null) {
                                     boolean shouldVault = sharedPrefsWriter.getVenmoVaultOption(context);
                                     if (shouldVault && isClientTokenAuth) {
-                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType);
+                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                         vaultVenmoAccountNonce(paymentMethodNonce, callback);
                                     } else {
-                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType);
+                                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.success", payPalContextId, linkType, isVaultRequest);
                                         VenmoAccountNonce venmoAccountNonce = new VenmoAccountNonce(paymentMethodNonce, username, false);
                                         callback.onResult(venmoAccountNonce, null);
                                     }
                                 }
                             } else if (authError != null) {
-                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType);
+                                braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType, isVaultRequest);
                                 callback.onResult(null, authError);
                             }
                         }
                         });
                     } else if (deepLinkUri.getPath().contains("cancel")) {
-                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.canceled", payPalContextId, linkType);
+                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.canceled", payPalContextId, linkType, isVaultRequest);
                         callback.onResult(null, new UserCanceledException("User canceled Venmo."));
                     } else if (deepLinkUri.getPath().contains("error")) {
-                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType);
+                        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType, isVaultRequest);
                         callback.onResult(null, new Exception("Error returned from Venmo."));
                     }
                 } else {
-                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType);
+                    braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.failure", payPalContextId, linkType, isVaultRequest);
                     callback.onResult(null, new Exception("Unknown error"));
                 }
                 break;
@@ -703,7 +708,7 @@ public class VenmoClient {
                 .returnUrlScheme(braintreeClient.getReturnUrlScheme());
 
         braintreeClient.startBrowserSwitch(activity, browserSwitchOptions);
-        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.started", payPalContextId, linkType);
+        braintreeClient.sendAnalyticsEvent("pay-with-venmo.app-links.started", payPalContextId, linkType, isVaultRequest);
     }
 
     /**

--- a/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/VenmoClientUnitTest.java
@@ -158,7 +158,7 @@ public class VenmoClientUnitTest {
         ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
 
         verify(activity).startActivity(captor.capture());
-        verify(braintreeClient).sendAnalyticsEvent("android.pay-with-venmo.app-store.invoked", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("android.pay-with-venmo.app-store.invoked", null, null, false);
     }
 
     @Test
@@ -221,7 +221,7 @@ public class VenmoClientUnitTest {
         assertEquals("session-id", intent.getSessionId());
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink", false);
     }
 
     @Test
@@ -259,7 +259,7 @@ public class VenmoClientUnitTest {
         assertEquals("session-id", intent.getSessionId());
 
         verify(sharedPrefsWriter).persistVenmoVaultOption(activity, false);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", null, "deeplink", false);
     }
 
     @Test
@@ -288,7 +288,7 @@ public class VenmoClientUnitTest {
         sut.tokenizeVenmoAccount(activity, request);
 
         verify(listener).onVenmoFailure(captor.capture());
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
         assertEquals("Cannot collect customer data when ECD is disabled. Enable this feature in the Control Panel to collect this data.", captor.getValue().getMessage());
     }
 
@@ -318,7 +318,7 @@ public class VenmoClientUnitTest {
 
         InOrder inOrder = Mockito.inOrder(activity, braintreeClient);
 
-        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink");
+        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink", false);
     }
 
     @Test
@@ -347,7 +347,7 @@ public class VenmoClientUnitTest {
 
         InOrder inOrder = Mockito.inOrder(activity, braintreeClient);
 
-        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", null, "deeplink");
+        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", null, "deeplink", false);
     }
 
     @Test
@@ -377,7 +377,7 @@ public class VenmoClientUnitTest {
         ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
         inOrder.verify(activity).startActivityForResult(captor.capture(), eq(BraintreeRequestCodes.VENMO));
 
-        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink");
+        inOrder.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink", false);
 
         Intent intent = captor.getValue();
         assertEquals(new ComponentName("com.venmo", "com.venmo.controller.SetupMerchantActivity"), intent.getComponent());
@@ -457,7 +457,7 @@ public class VenmoClientUnitTest {
                 ArgumentCaptor.forClass(Exception.class);
         verify(listener).onVenmoFailure(captor.capture());
         assertEquals("Configuration fetching error", captor.getValue().getMessage());
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
     }
 
     @Test
@@ -478,7 +478,7 @@ public class VenmoClientUnitTest {
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
         verify(listener).onVenmoFailure(captor.capture());
         assertEquals("Venmo is not enabled", captor.getValue().getMessage());
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
     }
 
     @Test
@@ -502,7 +502,7 @@ public class VenmoClientUnitTest {
                 ArgumentCaptor.forClass(AppSwitchNotAvailableException.class);
         verify(venmoTokenizeAccountCallback).onResult(captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
     }
 
     @Test
@@ -696,7 +696,7 @@ public class VenmoClientUnitTest {
         sut.setListener(listener);
         sut.tokenizeVenmoAccount(activity, request);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink", false);
     }
 
     @Test
@@ -720,8 +720,8 @@ public class VenmoClientUnitTest {
         sut.observer = mock(VenmoLifecycleObserver.class);
         sut.tokenizeVenmoAccount(activity, request);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink");
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink", false);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "deeplink", false);
     }
 
     @Test
@@ -746,8 +746,8 @@ public class VenmoClientUnitTest {
         sut.observer = mock(VenmoLifecycleObserver.class);
         sut.tokenizeVenmoAccount(activity, request);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "universal");
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "universal");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "universal", false);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.started", "venmo-payment-context-id", "universal", false);
     }
 
     @Test
@@ -926,8 +926,8 @@ public class VenmoClientUnitTest {
         verify(listener).onVenmoFailure(captor.capture());
         assertEquals("Venmo is not installed", captor.getValue().getMessage());
 
-        order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink");
-        order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.selected", null, "deeplink", false);
+        order.verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
     }
 
     @Test
@@ -950,7 +950,7 @@ public class VenmoClientUnitTest {
         sut.tokenizeVenmoAccount(activity, request);
 
         verify(listener).onVenmoFailure(graphQLError);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink");
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failed", null, "deeplink", false);
     }
 
     @Test
@@ -993,7 +993,7 @@ public class VenmoClientUnitTest {
         assertEquals("fake-venmo-nonce", nonce.getString());
         assertEquals("venmojoe", nonce.getUsername());
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null, false);
     }
 
     @Test
@@ -1016,7 +1016,7 @@ public class VenmoClientUnitTest {
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
         verify(onActivityResultCallback).onResult(null, graphQLError);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure", null, null, false);
     }
 
     @Test
@@ -1078,7 +1078,7 @@ public class VenmoClientUnitTest {
 
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null, false);
     }
 
     @Test
@@ -1086,7 +1086,7 @@ public class VenmoClientUnitTest {
         VenmoClient sut = new VenmoClient(activity, lifecycle, braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
         sut.onActivityResult(activity, AppCompatActivity.RESULT_CANCELED, new Intent(), onActivityResultCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", null, null, false);
     }
 
     @Test
@@ -1199,7 +1199,7 @@ public class VenmoClientUnitTest {
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
         verify(onActivityResultCallback).onResult(any(VenmoAccountNonce.class), (Exception) isNull());
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null, true);
     }
 
     @Test
@@ -1224,7 +1224,7 @@ public class VenmoClientUnitTest {
         VenmoClient sut = new VenmoClient(activity, lifecycle, braintreeClient, venmoApi, sharedPrefsWriter, deviceInspector);
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null, true);
     }
 
     @Test
@@ -1278,7 +1278,7 @@ public class VenmoClientUnitTest {
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
         verify(onActivityResultCallback).onResult(null, error);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null, true);
     }
 
     @Test
@@ -1304,7 +1304,7 @@ public class VenmoClientUnitTest {
                 .putExtra(EXTRA_PAYMENT_METHOD_NONCE, "nonce");
         sut.onActivityResult(activity, AppCompatActivity.RESULT_OK, intent, onActivityResultCallback);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null, true);
     }
 
     @Test
@@ -1406,7 +1406,7 @@ public class VenmoClientUnitTest {
         assertEquals("fake-venmo-nonce", nonce.getString());
         assertEquals("venmojoe", nonce.getUsername());
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null, false);
     }
 
     @Test
@@ -1429,7 +1429,7 @@ public class VenmoClientUnitTest {
         sut.onVenmoResult(venmoResult);
 
         verify(listener).onVenmoFailure(graphQLError);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.failure", null, null, false);
     }
 
     @Test
@@ -1487,7 +1487,7 @@ public class VenmoClientUnitTest {
         VenmoResult venmoResult = new VenmoResult("payment-context-id", "some-nonce", "venmo-username", null);
         sut.onVenmoResult(venmoResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.success", null, null, false);
     }
 
     @Test
@@ -1498,7 +1498,7 @@ public class VenmoClientUnitTest {
         VenmoResult venmoResult = new VenmoResult("payment-context-id", null, null, new UserCanceledException("User canceled Venmo."));
         sut.onVenmoResult(venmoResult);
 
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.app-switch.canceled", null, null, false);
     }
 
     @Test
@@ -1586,7 +1586,7 @@ public class VenmoClientUnitTest {
         sut.onVenmoResult(venmoResult);
 
         verify(listener).onVenmoSuccess(venmoAccountNonce);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null, true);
     }
 
     @Test
@@ -1615,7 +1615,7 @@ public class VenmoClientUnitTest {
         sut.onVenmoResult(venmoResult);
 
         verify(listener).onVenmoSuccess(venmoAccountNonce);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.success", null, null, true);
     }
 
     @Test
@@ -1642,7 +1642,7 @@ public class VenmoClientUnitTest {
         sut.onVenmoResult(venmoResult);
 
         verify(listener).onVenmoFailure(error);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null, true);
     }
 
     @Test
@@ -1672,7 +1672,7 @@ public class VenmoClientUnitTest {
         sut.onVenmoResult(venmoResult);
 
         verify(listener).onVenmoFailure(error);
-        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null);
+        verify(braintreeClient).sendAnalyticsEvent("pay-with-venmo.vault.failed", null, null, true);
     }
 
     @Test

--- a/VisaCheckout/src/main/java/com/braintreepayments/api/VisaCheckoutClient.java
+++ b/VisaCheckout/src/main/java/com/braintreepayments/api/VisaCheckoutClient.java
@@ -108,13 +108,13 @@ public class VisaCheckoutClient {
                     try {
                         VisaCheckoutNonce visaCheckoutNonce = VisaCheckoutNonce.fromJSON(tokenizationResponse);
                         callback.onResult(visaCheckoutNonce, null);
-                        braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.succeeded", null, null);
+                        braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.succeeded", null, null, false);
                     } catch (JSONException e) {
                         callback.onResult(null, e);
                     }
                 } else {
                     callback.onResult(null, exception);
-                    braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.failed", null, null);
+                    braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.failed", null, null, false);
                 }
             }
         });

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/VisaCheckoutClientUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/VisaCheckoutClientUnitTest.kt
@@ -135,7 +135,7 @@ class VisaCheckoutClientUnitTest {
         val sut = VisaCheckoutClient(braintreeClient, apiClient)
         val listener = mockk<VisaCheckoutTokenizeCallback>(relaxed = true)
         sut.tokenize(visaPaymentSummary, listener)
-        verify { braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.succeeded", null, null) }
+        verify { braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.succeeded", null, null, false) }
     }
 
     @Test
@@ -165,6 +165,6 @@ class VisaCheckoutClientUnitTest {
         val sut = VisaCheckoutClient(braintreeClient, apiClient)
         val listener = mockk<VisaCheckoutTokenizeCallback>(relaxed = true)
         sut.tokenize(visaPaymentSummary, listener)
-        verify { braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.failed", null, null) }
+        verify { braintreeClient.sendAnalyticsEvent("visacheckout.tokenize.failed", null, null,false) }
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Send `is_vault` in `event_params` to PayPal's analytics service (FPTI)
 - Add `isVaultRequest` analytics tag in `AnalyticsEvent`
 - Modify AnalyticsDatabase to reflect change to `AnalyticsEvent`

![Screenshot 2024-05-21 at 10 55 19 a m](https://github.com/braintree/braintree_android/assets/149086692/d7a0d797-6e89-461e-9df5-689b44cc074d)

### Checklist

 - [X] Added a changelog entry
 - [X] Relevant test coverage

### Authors

- @richherrera 

