### PR TITLE
Add isEligibleInPayPalNetwork boolean to ShopperInsightsInfo

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -123,6 +123,7 @@ class ShopperInsightsFragment : BaseFragment(), PayPalListener, VenmoListener {
 
                     responseTextView.text =
                         """
+                            Eligible in PayPal Network: ${result.response.isEligibleInPayPalNetwork}
                             PayPal Recommended: ${result.response.isPayPalRecommended}
                             Venmo Recommended: ${result.response.isVenmoRecommended}
                         """.trimIndent()

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
@@ -16,6 +16,7 @@ package com.braintreepayments.api
  */
 @ExperimentalBetaApi
 data class ShopperInsightsInfo(
+    val isEligibleInPayPalNetwork: Boolean,
     val isPayPalRecommended: Boolean,
     val isVenmoRecommended: Boolean
 )

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/ShopperInsightsInfo.kt
@@ -7,6 +7,8 @@ package com.braintreepayments.api
  * The recommendations include flags for whether payment methods like PayPal or Venmo
  * should be displayed with high priority in the user interface.
  *
+ * @property isEligibleInPayPalNetwork If true, buyer is a member of the PayPal Inc. (PayPal, Venmo,
+ * Honey) network.
  * @property isPayPalRecommended If true, indicates that the PayPal payment option
  * should be given high priority in the checkout UI.
  * @property isVenmoRecommended If true, indicates that the Venmo payment option

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/ShopperInsightsClientUnitTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -239,6 +240,104 @@ class ShopperInsightsClientUnitTest {
                     assertTrue { result is ShopperInsightsResult.Success }
                     val success = result as ShopperInsightsResult.Success
                     assertEquals(false, success.response.isPayPalRecommended)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `getRecommendedPaymentMethods paypal's eligibleInPayPalNetwork true, isEligibleInPayPalNetwork is true`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = true,
+                        recommended = false,
+                        recommendedPriority = 1
+                    ),
+                    venmo = null
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertTrue(success.response.isEligibleInPayPalNetwork)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `getRecommendedPaymentMethods venmo's eligibleInPayPalNetwork true, isEligibleInPayPalNetwork is true`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = null,
+                    venmo = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = true,
+                        recommended = false,
+                        recommendedPriority = 1
+                    )
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertTrue(success.response.isEligibleInPayPalNetwork)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `getRecommendedPaymentMethods both eligibleInPayPalNetwork false, isEligibleInPayPalNetwork is false`() {
+        val callback = mockk<ShopperInsightsCallback>(relaxed = true)
+
+        executeTestForFindEligiblePaymentsApi(
+            result = EligiblePaymentsApiResult(
+                EligiblePaymentMethods(
+                    paypal = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = false,
+                        recommended = false,
+                        recommendedPriority = 1
+                    ),
+                    venmo = EligiblePaymentMethodDetails(
+                        canBeVaulted = true,
+                        eligibleInPayPalNetwork = false,
+                        recommended = false,
+                        recommendedPriority = 1
+                    )
+                )
+            ),
+            error = null,
+            callback = callback
+        )
+
+        verify {
+            callback.onResult(
+                withArg { result ->
+                    assertTrue { result is ShopperInsightsResult.Success }
+                    val success = result as ShopperInsightsResult.Success
+                    assertFalse(success.response.isEligibleInPayPalNetwork)
                 }
             )
         }


### PR DESCRIPTION
### Summary of changes

 - Add `isEligibleInPayPalNetwork` to `ShopperInsightsInfo` success response object
 - Update logic of `isPayPalRecommended ` and `isVenmoRecommended ` to return the direct boolean from the API

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

