### PR TITLE
Remove Deprecated Constructors

### DIFF
--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentRequest.java
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentRequest.java
@@ -50,14 +50,6 @@ public class LocalPaymentRequest {
     private final boolean hasUserLocationConsent;
 
     /**
-     * Deprecated. Use {@link LocalPaymentRequest#LocalPaymentRequest(boolean)} instead.
-     **/
-    @Deprecated
-    public LocalPaymentRequest() {
-        this(false);
-    }
-
-    /**
      * @param hasUserLocationConsent is an optional parameter that informs the SDK
      * if your application has obtained consent from the user to collect location data in compliance with
      * <a href="https://support.google.com/googleplay/android-developer/answer/10144311#personal-sensitive">Google Play Developer Program policies</a>

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentRequestUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentRequestUnitTest.java
@@ -17,12 +17,6 @@ import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class LocalPaymentRequestUnitTest {
-
-    @Test
-    public void constructor_without_hasUserLocationConsent_defaults_to_false() {
-        LocalPaymentRequest request = new LocalPaymentRequest();
-        assertFalse(request.hasUserLocationConsent());
-    }
     
     @Test
     public void build_setsAllParams() throws JSONException {

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalRequest.java
@@ -77,18 +77,6 @@ public abstract class PayPalRequest implements Parcelable {
     private final boolean hasUserLocationConsent;
 
     /**
-     * Deprecated. Use {@link PayPalRequest#PayPalRequest(boolean)} instead.
-     *
-     * Constructs a request for PayPal Checkout and Vault flows.
-     */
-    @Deprecated
-    public PayPalRequest() {
-        shippingAddressRequired = false;
-        lineItems = new ArrayList<>();
-        hasUserLocationConsent = false;
-    }
-
-    /**
      * Constructs a request for PayPal Checkout and Vault flows.
      *
      * @param hasUserLocationConsent is an optional parameter that informs the SDK
@@ -291,7 +279,6 @@ public abstract class PayPalRequest implements Parcelable {
     public boolean hasUserLocationConsent() {
         return hasUserLocationConsent;
     }
-
 
     protected PayPalRequest(Parcel in) {
         localeCode = in.readString();


### PR DESCRIPTION
### Summary of changes

 - Remove deprecated constructors for `LocalPaymentRequest` and `PayPalRequest`

The changelog already contains the "Remove overload constructors" entry.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

