### PR TITLE
Update `payPalContextId` before launching browser

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalClient.java
@@ -288,6 +288,7 @@ public class PayPalClient {
             public void onResult(PayPalResponse payPalResponse, Exception error) {
                 if (payPalResponse != null) {
                     String analyticsPrefix = getAnalyticsEventPrefix(payPalRequest);
+                    payPalContextId = payPalResponse.getPairingId();
                     braintreeClient.sendAnalyticsEvent(String.format("%s.browser-switch.started", analyticsPrefix), payPalContextId, null, isVaultRequest);
 
                     try {

--- a/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/PayPalClientUnitTest.java
@@ -277,6 +277,7 @@ public class PayPalClientUnitTest {
         PayPalResponse payPalResponse = new PayPalResponse(payPalVaultRequest)
                 .approvalUrl("https://example.com/approval/url")
                 .successUrl("https://example.com/success/url")
+                .pairingId("BA-1234")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
                 .sendRequestSuccess(payPalResponse)
@@ -290,7 +291,7 @@ public class PayPalClientUnitTest {
         sut.tokenizePayPalAccount(activity, payPalVaultRequest);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.selected", null, null, true);
-        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.started", null, null, true);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.billing-agreement.browser-switch.started", "BA-1234", null, true);
     }
 
     @Test
@@ -416,6 +417,7 @@ public class PayPalClientUnitTest {
         PayPalResponse payPalResponse = new PayPalResponse(payPalCheckoutRequest)
                 .approvalUrl("https://example.com/approval/url")
                 .successUrl("https://example.com/success/url")
+                .pairingId("EC-1234")
                 .clientMetadataId("sample-client-metadata-id");
         PayPalInternalClient payPalInternalClient = new MockPayPalInternalClientBuilder()
                 .sendRequestSuccess(payPalResponse)
@@ -429,7 +431,7 @@ public class PayPalClientUnitTest {
         sut.tokenizePayPalAccount(activity, payPalCheckoutRequest);
 
         verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.selected", null, null, false);
-        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.started", null, null, false);
+        verify(braintreeClient).sendAnalyticsEvent("paypal.single-payment.browser-switch.started", "EC-1234", null, false);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Add `payPalContextId` to analytics before launching browser switch based on token existing in URL from API response

### Checklist

 - ~[ ] Added a changelog entry~
 - [x] Relevant test coverage

### Authors

@sarahkoop 
