### PR TITLE
Fix 3DS Black Screen Bug on Android 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * ShopperInsights (BETA)
     * Requires opt in - `@OptIn(ExperimentalBetaApi::class)`
     * Add `ShopperInsightsClient.getRecommendedPaymentMethods()` for returning recommendations based on the buyer
+* ThreeDSecure
+  * Fix issue that causes a black screen to display after successful 3DS validation.
 
 ## 4.46.0 (2024-05-30)
 

--- a/ThreeDSecure/src/main/AndroidManifest.xml
+++ b/ThreeDSecure/src/main/AndroidManifest.xml
@@ -4,6 +4,6 @@
     <application>
         <activity
             android:name="com.braintreepayments.api.ThreeDSecureActivity"
-            android:theme="@style/Theme.AppCompat" />
+            android:theme="@style/Theme.Translucent.NoTitleBar.Fullscreen" />
     </application>
 </manifest>

--- a/ThreeDSecure/src/main/res/values/themes.xml
+++ b/ThreeDSecure/src/main/res/values/themes.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Translucent" parent="Theme.AppCompat">
+        <item name="android:windowBackground">#00000000</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
+    <style name="Theme.Translucent.NoTitleBar">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+    </style>
+
+    <style name="Theme.Translucent.NoTitleBar.Fullscreen">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>

--- a/ThreeDSecure/src/main/res/values/themes.xml
+++ b/ThreeDSecure/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Ref: https://stackoverflow.com/a/21492572 -->
+    <!-- Ref: https://github.com/aosp-mirror/platform_frameworks_base/blob/dc2cfc8a10b8b74ec2c70f3b2d32aa9bf765de87/core/res/res/values/themes.xml#L678C1-L698C13 -->
     <style name="Theme.Translucent" parent="Theme.AppCompat">
         <item name="android:windowBackground">#00000000</item>
         <item name="android:colorBackgroundCacheHint">@null</item>


### PR DESCRIPTION
### Summary of changes

* Fix issue that causes a black screen to display after successful 3DS validation
* Make `ThreeDSecureActivity` transparency explicit via Activity theme 

### Screen Captures

#### Before

https://github.com/braintree/braintree_android/assets/58225613/0e4e2967-f19b-49c5-bb2a-e0077cdcf738

#### After

https://github.com/braintree/braintree_android/assets/58225613/fa3dc5e6-3bf5-411d-9f41-60ca4dbe1864


### Checklist

- [x] Added a changelog entry 
~- [ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@sshropshire