### PR TITLE
Fix demo app fragment layout

### DIFF
--- a/Demo/src/main/res/layout/fragment_main.xml
+++ b/Demo/src/main/res/layout/fragment_main.xml
@@ -15,6 +15,21 @@
         android:layout_height="match_parent">
 
         <Button
+            android:id="@+id/shopper_insights"
+            style="?android:attr/buttonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/shopper_insights_button"
+            android:textSize="12sp" />
+
+    </TableRow>
+
+    <TableRow
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Button
             android:id="@+id/card"
             style="?android:attr/buttonStyle"
             android:layout_width="match_parent"
@@ -30,15 +45,6 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/paypal_messaging_button"
-            android:textSize="12sp" />
-
-        <Button
-            android:id="@+id/shopper_insights"
-            style="?android:attr/buttonStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/shopper_insights_button"
             android:textSize="12sp" />
 
     </TableRow>


### PR DESCRIPTION
### Summary of changes

 - Fix demo app fragment layout that was introduced by a merge conflict
 
 Before:
![Screenshot_20240605_152430](https://github.com/braintree/braintree_android/assets/5005216/45f064ef-5c84-4cad-9294-fe3957d012ef)

After:
![Screenshot_20240605_152349](https://github.com/braintree/braintree_android/assets/5005216/50cfde55-b3ac-4840-93e4-b5430821a5f5)


### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

