### PR TITLE
Initialize PayPalAccountNonce Values into Empty Strings Instead of `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Fix `PayPalAccountNonce` Null Pointer Exception by ensuring that all `@NonNull` values are initialized with a non-null value.
+* PayPalNativeCheckout
+  * Fix `PayPalNativeCheckoutAccountNonce` Null Pointer Exception by ensuring that all `@NonNull` values are initialized with a non-null value.
+
 ## 4.47.0 (2024-06-06)
 
 * BraintreeCore

--- a/PayPal/src/main/java/com/braintreepayments/api/PayPalAccountNonce.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/PayPalAccountNonce.java
@@ -76,10 +76,10 @@ public class PayPalAccountNonce extends PaymentMethodNonce {
         PayPalCreditFinancing payPalCreditFinancing = null;
         PostalAddress shippingAddress;
         PostalAddress billingAddress;
-        String firstName = null;
-        String lastName = null;
-        String phone = null;
-        String payerId = null;
+        String firstName = "";
+        String lastName = "";
+        String phone = "";
+        String payerId = "";
         try {
             if (details.has(CREDIT_FINANCING_KEY)) {
                 JSONObject creditFinancing = details.getJSONObject(CREDIT_FINANCING_KEY);

--- a/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccountNonce.java
+++ b/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccountNonce.java
@@ -76,10 +76,10 @@ public class PayPalNativeCheckoutAccountNonce extends PaymentMethodNonce {
         PayPalNativeCheckoutCreditFinancing payPalCreditFinancing = null;
         PostalAddress shippingAddress;
         PostalAddress billingAddress;
-        String firstName = null;
-        String lastName = null;
-        String phone = null;
-        String payerId = null;
+        String firstName = "";
+        String lastName = "";
+        String phone = "";
+        String payerId = "";
         try {
             if (details.has(CREDIT_FINANCING_KEY)) {
                 JSONObject creditFinancing = details.getJSONObject(CREDIT_FINANCING_KEY);


### PR DESCRIPTION
### Summary of changes

- The following `PayPalAccountNonce` and `PayPalNativeCheckoutAccountNonce` properties are annotated as `@NonNull` in Java:
  - `firstName`
  - `lastName`
  - `phone`
  - `payerId`
- `@NonNull` is not strictly enforced in Java, but it is strictly enforced on the Kotlin side
- We do initialize these values to `null` [here](https://github.com/braintree/braintree_android/blob/main/PayPal/src/main/java/com/braintreepayments/api/PayPalAccountNonce.java#L79) in `PayPalAccountNonce.java` and [here](https://github.com/braintree/braintree_android/blob/7c950a2a3c6483272fa5a5abe99740a8f7c21157/PayPalNativeCheckout/src/main/java/com/braintreepayments/api/PayPalNativeCheckoutAccountNonce.java#L79) in `PayPalNativeCheckoutAccountNonce.java`
- This causes a crash in Kotlin that has been reported by our merchants
- This PR addresses the issue by setting the values to an empty string to keep the SDK consistent with the `@NonNull` annotations

### Checklist

 - [x] Added a changelog entry
 ~- [ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@sshropshire