### PR TITLE
Add Pay Later Setting to Demo App

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -86,6 +86,10 @@ public class PayPalRequestFactory {
             request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
         }
 
+        if (Settings.isPayPalPayLaterOffered(context)) {
+            request.setShouldOfferPayLater(true);
+        }
+
         if (Settings.usePayPalAddressOverride(context)) {
             PostalAddress shippingAddress = new PostalAddress();
             shippingAddress.setRecipientName("Brian Tree");

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -200,6 +200,10 @@ public class Settings {
         return getPreferences(context).getBoolean("paypal_credit_offered", false);
     }
 
+    public static boolean isPayPalPayLaterOffered(Context context) {
+        return getPreferences(context).getBoolean("paypal_pay_later_offered", false);
+    }
+
     public static boolean isPayPalSignatureVerificationDisabled(Context context) {
         return getPreferences(context).getBoolean("paypal_disable_signature_verification", true);
     }

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -123,6 +123,8 @@
     <string name="paypal_useraction_commit_summary">Sets the Payment User Action to Commit for Express Checkout Transactions</string>
     <string name="paypal_address_override">Send a shipping address to PayPal</string>
     <string name="paypal_address_override_summary">Sends a shipping address as an override option to PayPal for any PayPal request</string>
+    <string name="paypal_pay_later_offered">Offer PayPal Pay Later</string>
+    <string name="paypal_pay_later_offered_summary">Offers PayPal Pay Later prominently in the payment flow</string>
 
     <!-- VenmoActivity -->
     <string name="bt_descriptor_pay_with_venmo">Venmo</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -127,6 +127,12 @@
             android:summary="@string/paypal_credit_offered_summary"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+            android:key="paypal_pay_later_offered"
+            android:title="@string/paypal_pay_later_offered"
+            android:summary="@string/paypal_pay_later_offered_summary"
+            android:defaultValue="false" />
+
         <ListPreference
             android:key="paypal_landing_page_type"
             android:title="@string/paypal_landing_page_type"


### PR DESCRIPTION
### Summary of changes

 - Add Demo app Settings option to enable PayPal Pay Later

### Checklist

 ~- [] Added a changelog entry~
 ~- [ ] Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@sshropshire