### PR TITLE
Call Cardinal Cleanup from ThreeDSecureActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * BraintreeCore
   * Use TLS 1.3 for all HTTP requests, when available
   * Refactor TLSCertificatePinning `certInputStream` property to initialize a `ByteArrayInputStream` once instead of every time the property is accessed.
+* ThreeDSecure
+  * Move Cardinal cleanup from SDK internals into `ThreeDSecureActivity`.
 
 ## 4.47.0 (2024-06-06)
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/CardinalClient.java
@@ -58,8 +58,6 @@ class CardinalClient {
         } catch (RuntimeException e) {
             throw new BraintreeException("Cardinal SDK cca_continue Error.", e);
         }
-
-        Cardinal.getInstance().cleanup();
     }
 
     private void configureCardinal(Context context, Configuration configuration, ThreeDSecureRequest request) throws BraintreeException {
@@ -115,5 +113,9 @@ class CardinalClient {
 
     String getConsumerSessionId() {
         return consumerSessionId;
+    }
+
+    void cleanup() {
+        Cardinal.getInstance().cleanup();
     }
 }

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
@@ -88,6 +88,8 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
     }
 
     private void handleValidated(ValidateResponse validateResponse, String jwt) {
+        cardinalClient.cleanup();
+
         Intent result = new Intent();
         result.putExtra(EXTRA_JWT, jwt);
         result.putExtra(EXTRA_THREE_D_SECURE_RESULT, (ThreeDSecureResult) getIntent().getExtras()

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/ThreeDSecureActivity.java
@@ -33,7 +33,7 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         challengeObserver = new CardinalChallengeObserver(
-                this, (context, validateResponse, s) -> handleValidated(validateResponse, s));
+                this, (context, validateResponse, s) -> handleValidated(cardinalClient, validateResponse, s));
 
         /*
             Here, we schedule the 3DS auth challenge launch to run immediately after onCreate() is
@@ -84,10 +84,11 @@ public class ThreeDSecureActivity extends AppCompatActivity implements CardinalV
     // TODO: NEXT_MAJOR_VERSION remove implementation of CardinalValidateReceiver
     @Override
     public void onValidated(Context context, ValidateResponse validateResponse, String jwt) {
-        handleValidated(validateResponse, jwt);
+        handleValidated(cardinalClient, validateResponse, jwt);
     }
 
-    private void handleValidated(ValidateResponse validateResponse, String jwt) {
+    @VisibleForTesting
+    void handleValidated(CardinalClient cardinalClient, ValidateResponse validateResponse, String jwt) {
         cardinalClient.cleanup();
 
         Intent result = new Intent();

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/CardinalClientUnitTest.kt
@@ -243,8 +243,6 @@ class CardinalClientUnitTest {
                 cardinalChallengeObserver
             )
         }
-
-        verify { cardinalInstance.cleanup() }
     }
 
     @Test
@@ -269,5 +267,14 @@ class CardinalClientUnitTest {
             assertEquals("Cardinal SDK cca_continue Error.", e.message)
             assertSame(runtimeException, e.cause)
         }
+    }
+
+    @Test
+    fun cleanup_cleansUpCardinalInstance() {
+        every { Cardinal.getInstance() } returns cardinalInstance
+
+        val sut = CardinalClient()
+        sut.cleanup()
+        verify { cardinalInstance.cleanup() }
     }
 }

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/ThreeDSecureActivityUnitTest.java
@@ -106,7 +106,7 @@ public class ThreeDSecureActivityUnitTest {
     }
 
     @Test
-    public void onValidated_returnsValidationResults() throws JSONException {
+    public void handleValidated_returnsValidationResults() throws JSONException {
         ThreeDSecureResult threeDSecureResult =
                 ThreeDSecureResult.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE);
 
@@ -121,11 +121,14 @@ public class ThreeDSecureActivityUnitTest {
 
         ValidateResponse cardinalValidateResponse = mock(ValidateResponse.class);
         when(cardinalValidateResponse.getActionCode()).thenReturn(CardinalActionCode.SUCCESS);
-        sut.onValidated(null, cardinalValidateResponse, "jwt");
+
+        CardinalClient cardinalClient = mock(CardinalClient.class);
+        sut.handleValidated(cardinalClient, cardinalValidateResponse, "jwt");
         verify(sut).finish();
 
         ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
         verify(sut).setResult(eq(RESULT_OK), captor.capture());
+        verify(cardinalClient).cleanup();
 
         Intent intentForResult = captor.getValue();
         ValidateResponse activityResult = (ValidateResponse) (intentForResult.getSerializableExtra(ThreeDSecureActivity.EXTRA_VALIDATION_RESPONSE));


### PR DESCRIPTION
### Summary of changes

 - This PR extracts Cardinal cleanup functionality into it's own `CardinalClient` method
 - Calling `CardinalClient.cleanup()` in `ThreeDSecureActivity` gives the Cardinal SDK enough time to finish it's async method invocations before injecting the ProgressDialog into the merchant UI
 - Potential fix for #982 

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 