### PR TITLE
Remove isExplicitCancelation

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/UserCanceledException.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/UserCanceledException.kt
@@ -4,17 +4,7 @@ import androidx.annotation.RestrictTo
 
 /**
  * Error class thrown when a user cancels a payment flow
- *
- * @property isExplicitCancelation whether or not the user explicitly canceled the payment flow.
- *
- * This value will be true if the user manually confirms cancellation of the payment flow.
- *
- * This value will be false if the user returns to the app without completing the payment flow
- * and the action performed to return to the app is unknown. For browser switching flows, this
- * could mean the user returned to the app through multi-tasking without completing the flow,
- * the user closed the browser tab, or the user pressed the back button.
  */
-class UserCanceledException @JvmOverloads @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(
+class UserCanceledException @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(
     message: String?,
-    val isExplicitCancelation: Boolean = false
 ) : BraintreeException(message)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
         * Remove `BraintreeSharedPreferencesException`
         * Convert `PostalAddress` to data class
         * Remove `open` modifier on `Configuration`
+        * Remove `UserCanceledException.isExplicitCancelation`
     * UnionPay
         * Remove `union-pay` module
             * UnionPay cards can now be processed as regular cards (through the `card` module) due to their partnership with Discover

--- a/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayActivityResultContract.java
+++ b/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayActivityResultContract.java
@@ -35,7 +35,7 @@ class GooglePayActivityResultContract extends ActivityResultContract<GooglePayPa
                 return new GooglePayPaymentAuthResult(PaymentData.getFromIntent(intent), null);
             }
         } else if (resultCode == RESULT_CANCELED) {
-            return new GooglePayPaymentAuthResult(null, new UserCanceledException("User canceled Google Pay.", true));
+            return new GooglePayPaymentAuthResult(null, new UserCanceledException("User canceled Google Pay."));
         } else if (resultCode == RESULT_ERROR) {
             if (intent != null) {
                 return new GooglePayPaymentAuthResult(null, new GooglePayException("An error was encountered during the Google Pay " +

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayActivityResultContractUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayActivityResultContractUnitTest.java
@@ -77,7 +77,6 @@ public class GooglePayActivityResultContractUnitTest {
         Exception error = result.getError();
         assertTrue(error instanceof UserCanceledException);
         assertEquals("User canceled Google Pay.", error.getMessage());
-        assertTrue(((UserCanceledException) error).isExplicitCancelation());
         assertNull(result.getPaymentData());
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.java
@@ -274,7 +274,7 @@ public class PayPalClient {
         String status = uri.getLastPathSegment();
 
         if (!Uri.parse(successUrl).getLastPathSegment().equals(status)) {
-            throw new UserCanceledException("User canceled PayPal.", true);
+            throw new UserCanceledException("User canceled PayPal.");
         }
 
         String requestXoToken = Uri.parse(approvalUrl).getQueryParameter(tokenKey);


### PR DESCRIPTION
### Summary of changes

 - Remove isExplicitCancelation since UserCanceledException is always an explicit cancellation

### Checklist

 - [X] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

