### PR TITLE
Replace initial null values with empty strings in PayPalAccountNonce parse method

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.java
@@ -84,10 +84,10 @@ public class PayPalAccountNonce extends PaymentMethodNonce {
         PayPalCreditFinancing payPalCreditFinancing = null;
         PostalAddress shippingAddress;
         PostalAddress billingAddress;
-        String firstName = null;
-        String lastName = null;
-        String phone = null;
-        String payerId = null;
+        String firstName = "";
+        String lastName = "";
+        String phone = "";
+        String payerId = "";
         try {
             if (details.has(CREDIT_FINANCING_KEY)) {
                 JSONObject creditFinancing = details.getJSONObject(CREDIT_FINANCING_KEY);


### PR DESCRIPTION
### Summary of changes

 - Replace initial null values with empty strings in PayPalAccountNonce parse method
 - Original PR into main: https://github.com/braintree/braintree_android/pull/1028

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

