### PR TITLE
Fix PayPal Pay Later Parsing Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,11 +146,13 @@
     * Shopper Insights (BETA)
         * Remove `BraintreeClient` from constructor
         * Update package name to `com.braintreepayments.api.shopperinsights`
-    
-## v4 unreleased
+
+## 4.49.1 (2024-07-15)
 
 * PayPal
     * Fix issue that causes a JSON parsing error when Pay Later is selected during checkout.
+* ShopperInsights (BETA)
+    * Add error when using an invalid authorization type
 
 ## 4.49.0 (2024-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,11 @@
     * Shopper Insights (BETA)
         * Remove `BraintreeClient` from constructor
         * Update package name to `com.braintreepayments.api.shopperinsights`
+    
+## v4 unreleased
+
+* PayPal
+    * Fix issue that causes a JSON parsing error when Pay Later is selected during checkout.
 
 ## 4.49.0 (2024-07-08)
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCreditFinancing.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCreditFinancing.java
@@ -39,13 +39,13 @@ public class PayPalCreditFinancing implements Parcelable {
 
         result.cardAmountImmutable = creditFinancing.optBoolean(CARD_AMOUNT_IMMUTABLE_KEY, false);
         result.monthlyPayment = PayPalCreditFinancingAmount.fromJson(
-                creditFinancing.getJSONObject(MONTHLY_PAYMENT_KEY));
+                creditFinancing.optJSONObject(MONTHLY_PAYMENT_KEY));
         result.payerAcceptance = creditFinancing.optBoolean(PAYER_ACCEPTANCE_KEY, false);
         result.term = creditFinancing.optInt(TERM_KEY, 0);
         result.totalCost =
-                PayPalCreditFinancingAmount.fromJson(creditFinancing.getJSONObject(TOTAL_COST_KEY));
+                PayPalCreditFinancingAmount.fromJson(creditFinancing.optJSONObject(TOTAL_COST_KEY));
         result.totalInterest = PayPalCreditFinancingAmount.fromJson(
-                creditFinancing.getJSONObject(TOTAL_INTEREST_KEY));
+                creditFinancing.optJSONObject(TOTAL_INTEREST_KEY));
 
         return result;
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCreditFinancingUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCreditFinancingUnitTest.java
@@ -54,6 +54,25 @@ public class PayPalCreditFinancingUnitTest {
     }
 
     @Test
+    public void canCreateCreditFinancing_fromJsonWithoutCreditFinancingData() throws JSONException {
+        String paypalAccountResponse = Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE_WITHOUT_CREDIT_FINANCING_DATA;
+        JSONObject creditFinancingJsonObject = new JSONObject(paypalAccountResponse).getJSONArray("paypalAccounts")
+            .getJSONObject(0).getJSONObject("details").getJSONObject("creditFinancingOffered");
+
+        PayPalCreditFinancing payPalCreditFinancing = PayPalCreditFinancing.fromJson(creditFinancingJsonObject);
+
+        assertFalse(payPalCreditFinancing.isCardAmountImmutable());
+        assertEquals(18, payPalCreditFinancing.getTerm());
+        assertFalse(payPalCreditFinancing.hasPayerAcceptance());
+        assertNull(payPalCreditFinancing.getMonthlyPayment().getCurrency());
+        assertNull(payPalCreditFinancing.getTotalCost().getCurrency());
+        assertNull(payPalCreditFinancing.getTotalInterest().getCurrency());
+        assertNull(payPalCreditFinancing.getMonthlyPayment().getValue());
+        assertNull(payPalCreditFinancing.getTotalCost().getValue());
+        assertNull(payPalCreditFinancing.getTotalInterest().getValue());
+    }
+
+    @Test
     public void writeToParcel_serializesCorrectly() throws JSONException {
         String paypalAccountResponse = Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE;
         JSONObject creditFinancingJsonObject =

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
@@ -1653,6 +1653,52 @@ object Fixtures {
     """
 
     // language=JSON
+    const val PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE_WITHOUT_CREDIT_FINANCING_DATA = """
+    {
+      "paypalAccounts": [
+        {
+          "type": "PayPalAccount",
+          "nonce": "8d4e91d2-4627-10f4-6336-113e331ff9ce",
+          "description": "PayPal",
+          "consumed": false,
+          "details": {
+            "creditFinancingOffered": {
+              "term": 18
+            },
+            "payerInfo": {
+              "email": "paypal@vividseats.com",
+              "firstName": "Vivid",
+              "lastName": "Tester",
+              "payerId": "NSXGUJGV6WMGW",
+              "phone": "408-242-6641",
+              "countryCode": "US",
+              "billingAddress": {
+                "line1": "1 Main St",
+                "line2": "",
+                "city": "San Jose",
+                "state": "CA",
+                "postalCode": "95131",
+                "countryCode": "US"
+              },
+              "shippingAddress": {}
+            },
+            "correlationId": "EC-1NY995367L811651K",
+            "billingAddress": {
+              "line1": "1 Main St",
+              "line2": "",
+              "city": "San Jose",
+              "state": "CA",
+              "postalCode": "95131",
+              "countryCode": "US"
+            },
+            "shippingAddress": {}
+          }
+        }
+      ]
+    }
+    """
+
+    // language=JSON
     const val PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE = """
         {
           "paypalAccounts": [


### PR DESCRIPTION
### Summary of changes

 - Fix issue that causes a JSON parsing error when Pay Later is selected during checkout.
 - Original v4 PR: https://github.com/braintree/braintree_android/pull/1059

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

