### PR TITLE
Remove the Release build type from the demo 

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -25,27 +25,11 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
-        release {
-            storeFile file(System.env['KEYSTORE_FILE'] ?: 'debug.keystore')
-            storePassword System.env['KEYSTORE_PASSWORD'] ?: 'android'
-            keyAlias System.env['KEY_ALIAS'] ?: 'androiddebugkey'
-            keyPassword System.env['KEY_PASSWORD'] ?: 'android'
-        }
     }
 
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
-        }
-        release {
-            signingConfig signingConfigs.release
-        }
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.pro'
         }
     }
 


### PR DESCRIPTION
### Summary of changes

 - Remove `release` build type from the demo module to fix a build issue with Retrofit and R8

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

