### PR TITLE
Add Java Setup to all release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup
       - name: Set GitHub User
         uses: ./.github/actions/set_github_user
       - name: Update Version
@@ -277,6 +279,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup
       - name: Save changelog entries to a file
         run: |
           sed -e '1,/##/d' -e '/##/,$d' CHANGELOG.md > changelog_entries.md

--- a/.github/workflows/temp_release.yml
+++ b/.github/workflows/temp_release.yml
@@ -1,0 +1,59 @@
+name: Temp Release Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+env:
+  SIGNING_KEY_FILE_PATH: /home/runner/secretKey.gpg
+jobs:
+  bump_version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup
+      - name: Set GitHub User
+        uses: ./.github/actions/set_github_user
+      - name: Update Version
+        run: |
+          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeGradleReleaseVersion
+          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeREADMEVersion
+          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeMigrationGuideVersion
+          ./gradlew -PversionParam=${{ github.event.inputs.version }} updateCHANGELOGVersion
+          ./gradlew dokkaHtmlMultiModule
+          git add -A
+          git commit -am 'Release ${{ github.event.inputs.version }}'
+          git tag ${{ github.event.inputs.version }} -a -m 'Release ${{ github.event.inputs.version }}'
+
+          ./gradlew -PversionParam=${{ github.event.inputs.version }} incrementSNAPSHOTVersion
+          ./gradlew incrementVersionCode
+          git commit -am 'Prepare for development'
+          git push origin main ${{ github.event.inputs.version }}
+
+  create_github_release:
+    needs: [ bump_version ]
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup
+      - name: Save changelog entries to a file
+        run: |
+          sed -e '1,/##/d' -e '/##/,$d' CHANGELOG.md > changelog_entries.md
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body_path: changelog_entries.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
### Summary of changes

 - Add Setup Java steps to release workflow
 - Add Temp Release Workflow for running `bump_version` and `create_github_release` jobs for `5.0.0-beta1` release. This workflow will be removed once it runs.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

