### PR TITLE
Update 3DS and GraphQL Endpoint Sent to FPTI (v5)

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -357,21 +357,12 @@ class BraintreeClient @VisibleForTesting internal constructor(
     }
 
     private fun sendAnalyticsTimingEvent(endpoint: String, timing: HttpResponseTiming) {
-        val cleanedPath = endpoint.replace(Regex("/merchants/([A-Za-z0-9]+)/client_api"), "")
+        var cleanedPath = endpoint.replace(Regex("/merchants/([A-Za-z0-9]+)/client_api"), "")
+        cleanedPath = cleanedPath.replace(
+            Regex("payment_methods/.*/three_d_secure"), "payment_methods/three_d_secure"
+        )
 
-        if (cleanedPath.contains("three_d_secure")) {
-            val threeDSecurePath = cleanedPath.replace(
-                Regex("payment_methods/.*/three_d_secure"), "payment_methods/three_d_secure"
-            )
-            sendAnalyticsEvent(
-                CoreAnalytics.apiRequestLatency,
-                AnalyticsEventParams(
-                    startTime = timing.startTime,
-                    endTime = timing.endTime,
-                    endpoint = threeDSecurePath
-                )
-            )
-        } else if (cleanedPath != "/v1/tracking/batch/events") {
+        if (cleanedPath != "/v1/tracking/batch/events") {
             sendAnalyticsEvent(
                 CoreAnalytics.apiRequestLatency,
                 AnalyticsEventParams(

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -276,7 +276,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
                 ) { response, httpError ->
                     response?.let {
                         try {
-                            json?.optString("query")
+                            json?.optString(GraphQLConstants.Keys.QUERY)
                                 ?.let { query ->
                                     val queryDiscardHolder = query.replace(Regex("^[^\\(]*"), "")
                                     val finalQuery = query.replace(queryDiscardHolder, "")

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -362,16 +362,14 @@ class BraintreeClient @VisibleForTesting internal constructor(
             Regex("payment_methods/.*/three_d_secure"), "payment_methods/three_d_secure"
         )
 
-        if (cleanedPath != "/v1/tracking/batch/events") {
-            sendAnalyticsEvent(
-                CoreAnalytics.apiRequestLatency,
-                AnalyticsEventParams(
-                    startTime = timing.startTime,
-                    endTime = timing.endTime,
-                    endpoint = cleanedPath
-                )
+        sendAnalyticsEvent(
+            CoreAnalytics.apiRequestLatency,
+            AnalyticsEventParams(
+                startTime = timing.startTime,
+                endTime = timing.endTime,
+                endpoint = cleanedPath
             )
-        }
+        )
     }
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/GraphQLConstants.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/GraphQLConstants.kt
@@ -20,7 +20,6 @@ object GraphQLConstants {
         const val LEGACY_CODE = "legacyCode"
         const val URL = "url"
         const val FEATURES = "features"
-        const val OPERATION_NAME = "operationName"
     }
 
     object ErrorTypes {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* BraintreeCore
+  * Update `endpoint` syntax sent to FPTI for 3D Secure and Venmo flows
+
 ## 5.0.0-beta1 (2024-07-23)
 
 * Breaking Changes


### PR DESCRIPTION
### Summary of changes

- 3D Secure: remove token/unique ID from path
- GraphQL: remove reliance on `operationName` since this is only present for card, causing us not to send the correct path for the Venmo flow
- Both endpoints sending as expected have been verified in FPTI and via breakpoints, additionally all endpoint have been checked to ensure we are sending the expected paths now
- iOS PR: https://github.com/braintree/braintree_ios/pull/1375

### Checklist

- [x] Added a changelog entry

### Authors

- @jaxdesmarais