### PR TITLE
Add App Switch settings to Demo App

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -23,6 +23,10 @@ public class PayPalRequestFactory {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
+        if (Settings.isPayPalAppSwithEnabled(context)) {
+            request.setEnablePayPalAppSwitch(true);
+        }
+
         request.setDisplayName(Settings.getPayPalDisplayName(context));
 
         String landingPageType = Settings.getPayPalLandingPageType(context);

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -192,6 +192,10 @@ public class Settings {
         return getPreferences(context).getBoolean("paypal_credit_offered", false);
     }
 
+    public static boolean isPayPalAppSwithEnabled(Context context) {
+        return getPreferences(context).getBoolean("paypal_app_switch", false);
+    }
+
     public static boolean isPayPalSignatureVerificationDisabled(Context context) {
         return getPreferences(context).getBoolean("paypal_disable_signature_verification", true);
     }

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -127,6 +127,12 @@
             android:summary="@string/paypal_credit_offered_summary"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+            android:key="paypal_app_switch"
+            android:title="PayPal App Switch"
+            android:summary="Enable or disable PayPal App Switch"
+            android:defaultValue="false" />
+
         <ListPreference
             android:key="paypal_landing_page_type"
             android:title="@string/paypal_landing_page_type"

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -130,7 +130,7 @@
         <CheckBoxPreference
             android:key="paypal_app_switch"
             android:title="PayPal App Switch"
-            android:summary="Enable or disable PayPal App Switch"
+            android:summary="Enable PayPal App Switch"
             android:defaultValue="false" />
 
         <ListPreference


### PR DESCRIPTION
### Summary of changes

 - Add a new Enable PayPal App Switch checkbox to the settings
 
NOTE: Displaying an error message if the email is not configured will be added in a separate PR. (DTMOBILES-923)

![Screenshot 2024-07-24 at 1 08 13 p m](https://github.com/user-attachments/assets/c282d72a-2bb8-4f40-8ede-546169d6c7c4)

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors

- @richherrera 

