### PR TITLE
Remove appLinkEnabled property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+* PayPal
+  * Remove `appLinkEnabled` from `PayPalRequest` as Android app links are now required
+
 ## 5.0.0-beta1 (2024-07-23)
 
 * Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
-* PayPal
-  * Remove `appLinkEnabled` from `PayPalRequest` as Android app links are now required
+* Breaking Changes
+    * PayPal
+        * Remove `appLinkEnabled` from `PayPalRequest` as Android app links are now required
 
 ## 5.0.0-beta1 (2024-07-23)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -17,8 +17,6 @@ public class PayPalRequestFactory {
 
         PayPalVaultRequest request = new PayPalVaultRequest(true);
 
-        boolean useAppLink = Settings.getPayPalLinkType(context).equals(context.getString(R.string.paypal_app_link));
-        request.setAppLinkEnabled(useAppLink);
         if (!buyerEmailAddress.isEmpty()) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
@@ -58,8 +56,6 @@ public class PayPalRequestFactory {
     ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount, true);
 
-        boolean useAppLink = Settings.getPayPalLinkType(context).equals(context.getString(R.string.paypal_app_link));
-        request.setAppLinkEnabled(useAppLink);
         if (!buyerEmailAddress.isEmpty()) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -200,14 +200,6 @@ public class Settings {
         return getPreferences(context).getBoolean("paypal_address_override", true);
     }
 
-    public static boolean useHardcodedPayPalConfiguration(Context context) {
-        return getPreferences(context).getBoolean("paypal_use_hardcoded_configuration", false);
-    }
-
-    public static String getPayPalLinkType(Context context) {
-        return getPreferences(context).getString("paypal_link_type", context.getString(R.string.paypal_deep_link));
-    }
-
     public static boolean isThreeDSecureEnabled(Context context) {
         return getPreferences(context).getBoolean("enable_three_d_secure", false);
     }

--- a/Demo/src/main/res/values/arrays.xml
+++ b/Demo/src/main/res/values/arrays.xml
@@ -35,14 +35,4 @@
         <item name="login">@string/paypal_landing_page_type_login</item>
     </string-array>
 
-    <string-array name="paypal_link_types">
-        <item name="deep_link">@string/paypal_deep_link</item>
-        <item name="app_link">@string/paypal_app_link</item>
-    </string-array>
-
-    <string-array name="paypal_link_types_values">
-        <item name="deep_link">@string/paypal_deep_link</item>
-        <item name="app_link">@string/paypal_app_link</item>
-    </string-array>
-
 </resources>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -99,9 +99,6 @@
     <string name="paypal_display_name_summary">Name to be displayed in the PayPal flow</string>
     <string name="paypal_landing_page_type_billing">Billing</string>
     <string name="paypal_landing_page_type_login">Login</string>
-    <string name="paypal_link">Navigation from Web</string>
-    <string name="paypal_deep_link">Deep Link</string>
-    <string name="paypal_app_link">App Link</string>
     <string name="paypal_native_checkout_launch">Launch PayPal Native Checkout</string>
     <string name="paypal_native_checkout_vault_launch">Launch PayPal Native Vault Checkout</string>
     <string name="venmo">Venmo</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -152,13 +152,6 @@
             android:summary="@string/paypal_address_override_summary"
             android:defaultValue="false" />
 
-        <ListPreference
-            android:key="paypal_link_type"
-            android:title="@string/paypal_link"
-            android:entries="@array/paypal_link_types"
-            android:entryValues="@array/paypal_link_types_values"
-            android:defaultValue="@string/paypal_deep_link"/>
-
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 
 import com.braintreepayments.api.core.Authorization;
+import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.PostalAddress;
 
@@ -75,17 +76,15 @@ public abstract class PayPalRequest implements Parcelable {
     private String riskCorrelationId;
     private final ArrayList<PayPalLineItem> lineItems;
     private final boolean hasUserLocationConsent;
-    private boolean appLinkEnabled;
     protected String userAuthenticationEmail;
 
     /**
      * Constructs a request for PayPal Checkout and Vault flows.
      *
      * @param hasUserLocationConsent is an optional parameter that informs the SDK
-     * if your application has obtained consent from the user to collect location data in compliance with
-     * <a href="https://support.google.com/googleplay/android-developer/answer/10144311#personal-sensitive">Google Play Developer Program policies</a>
-     * This flag enables PayPal to collect necessary information required for Fraud Detection and Risk Management.
-     *
+     *                               if your application has obtained consent from the user to collect location data in compliance with
+     *                               <a href="https://support.google.com/googleplay/android-developer/answer/10144311#personal-sensitive">Google Play Developer Program policies</a>
+     *                               This flag enables PayPal to collect necessary information required for Fraud Detection and Risk Management.
      * @see <a href="https://support.google.com/googleplay/android-developer/answer/10144311#personal-sensitive">User Data policies for the Google Play Developer Program </a>
      * @see <a href="https://support.google.com/googleplay/android-developer/answer/9799150?hl=en#Prominent%20in-app%20disclosure">Examples of prominent in-app disclosures</a>
      */
@@ -227,20 +226,6 @@ public abstract class PayPalRequest implements Parcelable {
         this.lineItems.addAll(lineItems);
     }
 
-    /**
-     * Optional: When set to true, the Android App Link website associated with your application
-     * will be used to return to your app from browser or app switch based payment flows. When set
-     * to false, the default or set deep link return URL will be used.
-     *
-     * Set the App Link value on `appLinkReturnUri` parameter in the {@link BraintreeClient}
-     * constructor.
-     *
-     * @param appLinkEnabled indicates whether to use the set Android App Link
-     */
-    public void setAppLinkEnabled(boolean appLinkEnabled) {
-        this.appLinkEnabled = appLinkEnabled;
-    }
-
     @Nullable
     public String getLocaleCode() {
         return localeCode;
@@ -292,12 +277,9 @@ public abstract class PayPalRequest implements Parcelable {
 
     abstract String createRequestBody(Configuration configuration, Authorization authorization,
                                       String successUrl, String cancelUrl) throws JSONException;
+
     public boolean hasUserLocationConsent() {
         return hasUserLocationConsent;
-    }
-
-    public boolean isAppLinkEnabled() {
-        return appLinkEnabled;
     }
 
     /**
@@ -327,7 +309,6 @@ public abstract class PayPalRequest implements Parcelable {
         riskCorrelationId = in.readString();
         lineItems = in.createTypedArrayList(PayPalLineItem.CREATOR);
         hasUserLocationConsent = in.readByte() != 0;
-        appLinkEnabled = in.readByte() != 0;
     }
 
     @Override
@@ -348,6 +329,5 @@ public abstract class PayPalRequest implements Parcelable {
         parcel.writeString(riskCorrelationId);
         parcel.writeTypedList(lineItems);
         parcel.writeByte((byte) (hasUserLocationConsent ? 1 : 0));
-        parcel.writeByte((byte) (appLinkEnabled ? 1 : 0));
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.java
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 
 import com.braintreepayments.api.core.Authorization;
-import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.PostalAddress;
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -36,7 +36,6 @@ public class PayPalVaultRequestUnitTest {
         assertNull(request.getLandingPageType());
         assertFalse(request.getShouldOfferCredit());
         assertFalse(request.hasUserLocationConsent());
-        assertFalse(request.isAppLinkEnabled());
     }
 
     @Test
@@ -51,7 +50,6 @@ public class PayPalVaultRequestUnitTest {
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalRequest.LANDING_PAGE_TYPE_LOGIN);
         request.setShouldOfferCredit(true);
-        request.setAppLinkEnabled(true);
 
         assertEquals("US", request.getLocaleCode());
         assertEquals("Billing Agreement Description", request.getBillingAgreementDescription());
@@ -62,7 +60,6 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(PayPalRequest.LANDING_PAGE_TYPE_LOGIN, request.getLandingPageType());
         assertTrue(request.getShouldOfferCredit());
         assertTrue(request.hasUserLocationConsent());
-        assertTrue(request.isAppLinkEnabled());
     }
 
     @Test
@@ -73,7 +70,6 @@ public class PayPalVaultRequestUnitTest {
         request.setShippingAddressRequired(true);
         request.setShippingAddressEditable(true);
         request.setShouldOfferCredit(true);
-        request.setAppLinkEnabled(true);
 
         PostalAddress postalAddress = new PostalAddress();
         postalAddress.setRecipientName("Postal Address");
@@ -108,7 +104,6 @@ public class PayPalVaultRequestUnitTest {
         assertEquals(1, result.getLineItems().size());
         assertEquals("An Item", result.getLineItems().get(0).getName());
         assertTrue(result.hasUserLocationConsent());
-        assertTrue(result.isAppLinkEnabled());
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Remove `appLinkEnabled` from PayPalRequest - app link is now required for PayPal

### Checklist

 - [X] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

