### PR TITLE
Drop `android.` analytic name prefix to match iOS

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -207,7 +207,7 @@ internal class AnalyticsClient constructor(
 
     private fun mapAnalyticsEventToFPTIEventJSON(event: AnalyticsEvent): String {
         val json = JSONObject()
-            .put(FPTI_KEY_EVENT_NAME, "android.${event.name}")
+            .put(FPTI_KEY_EVENT_NAME, event.name)
             .put(FPTI_KEY_TIMESTAMP, event.timestamp)
             .put(FPTI_KEY_VENMO_INSTALLED, event.venmoInstalled)
             .put(FPTI_KEY_IS_VAULT, event.isVaultRequest)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
@@ -83,7 +83,7 @@ class AnalyticsClientUnitTest {
         // language=JSON
         val expectedJSON = """
         {
-          "event_name": "android.sample-event-name",
+          "event_name": "sample-event-name",
           "t": 123,
           "venmo_installed": false,
           "is_vault": false,
@@ -127,7 +127,7 @@ class AnalyticsClientUnitTest {
         // language=JSON
         val expectedJSON = """
         {
-          "event_name": "android.sample-event-name",
+          "event_name": "sample-event-name",
           "paypal_context_id": "fake-paypal-context-id",
           "link_type": "fake-link-type",
           "t": 456,
@@ -470,7 +470,7 @@ class AnalyticsClientUnitTest {
               },
               "event_params": [
                 {
-                    "event_name": "android.crash",
+                    "event_name": "crash",
                     "t": 123,
                     "tenant_name": "Braintree",
                     "venmo_installed": false,


### PR DESCRIPTION
JIRA DTMOBILES-893

### Summary of changes

 - Match iOS analytics by dropping `android.` prefix from each analytic event name
    - (Note: The `platform` metadata tag should be used instead to distinguish `iOS` from `Android` events)
    - This lets us more easily query & analyze our metrics cross-platform

### Checklist

 - ~Added a changelog entry~
 - [X] Relevant test coverage

### Authors
@scannillo