### PR TITLE
Add RBA Metadata request in the demo app and update doc strings

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -3,12 +3,20 @@ package com.braintreepayments.demo;
 import android.content.Context;
 
 import com.braintreepayments.api.core.PostalAddress;
+import com.braintreepayments.api.paypal.PayPalBillingCycle;
+import com.braintreepayments.api.paypal.PayPalBillingInterval;
+import com.braintreepayments.api.paypal.PayPalBillingPricing;
 import com.braintreepayments.api.paypal.PayPalCheckoutRequest;
 import com.braintreepayments.api.paypal.PayPalLandingPageType;
 import com.braintreepayments.api.paypal.PayPalPaymentIntent;
 import com.braintreepayments.api.paypal.PayPalPaymentUserAction;
-import com.braintreepayments.api.paypal.PayPalRequest;
+import com.braintreepayments.api.paypal.PayPalPricingModel;
+import com.braintreepayments.api.paypal.PayPalRecurringBillingDetails;
+import com.braintreepayments.api.paypal.PayPalRecurringBillingPlanType;
 import com.braintreepayments.api.paypal.PayPalVaultRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PayPalRequestFactory {
 
@@ -46,6 +54,42 @@ public class PayPalRequestFactory {
             postalAddress.setCountryCodeAlpha2("US");
 
             request.setShippingAddressOverride(postalAddress);
+        }
+
+        if (Settings.isRbaMetadataEnabled(context)) {
+            PayPalBillingPricing billingPricing = new PayPalBillingPricing(
+                PayPalPricingModel.FIXED,
+                "9.99",
+                "99.99"
+            );
+
+            PayPalBillingCycle billingCycle = new PayPalBillingCycle(
+                PayPalBillingInterval.MONTH,
+                1,
+                1,
+                1,
+                "2024-08-01",
+                false,
+                billingPricing
+            );
+
+            List<PayPalBillingCycle> billingCycles = new ArrayList<>();
+            billingCycles.add(billingCycle);
+            PayPalRecurringBillingDetails payPalRecurringBillingDetails = new PayPalRecurringBillingDetails(
+                billingCycles,
+                "32.56",
+                "USD",
+                "Vogue Magazine Subscription",
+                "9.99",
+                "Home delivery to Chicago, IL",
+                "19.99",
+                1,
+                "1.99",
+                "0.59"
+            );
+
+            request.setRecurringBillingDetails(payPalRecurringBillingDetails);
+            request.setRecurringBillingPlanType(PayPalRecurringBillingPlanType.SUBSCRIPTION);
         }
 
         return request;

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -200,6 +200,10 @@ public class Settings {
         return getPreferences(context).getBoolean("paypal_address_override", true);
     }
 
+    public static boolean isRbaMetadataEnabled(Context context) {
+        return getPreferences(context).getBoolean("paypal_rba_metadata", false);
+    }
+
     public static boolean isThreeDSecureEnabled(Context context) {
         return getPreferences(context).getBoolean("enable_three_d_secure", false);
     }

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -118,6 +118,8 @@
     <string name="paypal_useraction_commit_summary">Sets the Payment User Action to Commit for Express Checkout Transactions</string>
     <string name="paypal_address_override">Send a shipping address to PayPal</string>
     <string name="paypal_address_override_summary">Sends a shipping address as an override option to PayPal for any PayPal request</string>
+    <string name="paypal_rba_metadata">RBA Metadata flow</string>
+    <string name="paypal_rba_metadata_summary">Sets the recurring billing data on the PayPal Vault Request</string>
 
     <!-- VenmoActivity -->
     <string name="bt_descriptor_pay_with_venmo">Venmo</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -152,6 +152,12 @@
             android:summary="@string/paypal_address_override_summary"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+            android:key="paypal_rba_metadata"
+            android:title="@string/paypal_rba_metadata"
+            android:summary="@string/paypal_rba_metadata_summary"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
@@ -21,7 +21,7 @@ import org.json.JSONObject
  * example, sequence 1 could be a 3 month trial period, and sequence 2 could be a longer term full
  * rater cycle. Max value 100. All billing cycles should have unique sequence values.
  * @property startDate The date and time when the billing cycle starts, in Internet date and time
- * format `YYYY-MM-DDT00:00:00Z`. If not provided the billing cycle starts at the time of checkout.
+ * format `YYYY-MM-DD`. If not provided the billing cycle starts at the time of checkout.
  * If provided and the merchant wants the billing cycle to start at the time of checkout, provide
  * the current time. Otherwise the [startDate] can be in future.
  * @property isTrial The tenure type of the billing cycle. In case of a plan having trial cycle,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRecurringBillingDetails.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRecurringBillingDetails.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
  * @property totalAmount
  * @property billingCycles A list of billing cycles for trial billing and regular billing. A plan
  * can have at most two trial cycles and only one regular cycle. Exceeding 3 items in this array
- * results in error.
+ * results in an error.
  * @property currencyISOCode The three-character ISO-4217 currency code that identifies the
  * currency.
  * @property productName The name of the plan to display at checkout.

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRecurringBillingDetails.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRecurringBillingDetails.kt
@@ -10,7 +10,8 @@ import org.json.JSONObject
  *
  * @property totalAmount
  * @property billingCycles A list of billing cycles for trial billing and regular billing. A plan
- * can have at most two trial cycles and only one regular cycle.
+ * can have at most two trial cycles and only one regular cycle. Exceeding 3 items in this array
+ * results in error.
  * @property currencyISOCode The three-character ISO-4217 currency code that identifies the
  * currency.
  * @property productName The name of the plan to display at checkout.


### PR DESCRIPTION
### Summary of changes

 - Add a setting in the demo app to send RBA Metadata in the PayPal Vault Request
 - Update property doc strings to match iOS

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

