### PR TITLE
[App Switch] Add Toast when email is not set

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -55,7 +55,7 @@ public class PayPalFragment extends BaseFragment {
             FragmentActivity activity = getActivity();
 
             if (Settings.isPayPalAppSwithEnabled(activity) && buyerEmailEditText.getText().toString().isEmpty()) {
-                Toast.makeText(activity, "Email cannot be nil for App Switch flow", Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, "Email is required for the App Switch flow", Toast.LENGTH_SHORT).show();
                 return;
             }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -51,6 +52,13 @@ public class PayPalFragment extends BaseFragment {
             launchPayPal(false, buyerEmailEditText.getText().toString());
         });
         billingAgreementButton.setOnClickListener(v -> {
+            FragmentActivity activity = getActivity();
+
+            if (Settings.isPayPalAppSwithEnabled(activity) && buyerEmailEditText.getText().toString().isEmpty()) {
+                Toast.makeText(activity, "Email cannot be nil for App Switch flow", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             launchPayPal(true, buyerEmailEditText.getText().toString());
         });
 


### PR DESCRIPTION
### Summary of changes

 - When `Enable PayPal App Switch `checkbox is enabled, display an error message if email is not set

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors

- @richherrera 

