### PR TITLE
Fixup - add missing slash to FPTI `endpoint` tag for `v1/config` URL

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -130,7 +130,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
             } else {
                 callback.onResult(null, configError)
             }
-            timing?.let { sendAnalyticsTimingEvent("v1/configuration", it) }
+            timing?.let { sendAnalyticsTimingEvent("/v1/configuration", it) }
         }
     }
 


### PR DESCRIPTION
### Summary of changes

 - I was poking around FPTI when I noticed that one of the endpoint strings was missing the preceding slash `/`

![Screenshot 2024-08-13 at 4 07 23 PM](https://github.com/user-attachments/assets/359262be-0e8c-440e-9906-a5205d8c1714)

This fix also lets us aggregate with iOS metrics

### Checklist

 - ~Added a changelog entry~
 - ~Relevant test coverage~

### Authors
@scannillo 
