### PR TITLE
Support Android 15 Edge-to-Edge Display And Fix 3DS Activity Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 * BraintreeCore
   * Update `endpoint` syntax sent to FPTI for 3D Secure and Venmo flows
+* ThreeDSecure
+  * Update `ThreeDSecureActivity` theme attributes to prevent the Action Bar title from displaying and enforce transparency properly with AppCompat theme attributes
 * Breaking Changes
     * PayPal
         * Remove `appLinkEnabled` from `PayPalRequest` as Android app links are now required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
+* All Modules
+  * Android 15 Support
+    * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 35
 * BraintreeCore
   * Update `endpoint` syntax sent to FPTI for 3D Secure and Venmo flows
 * ThreeDSecure

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoActivity.java
@@ -3,25 +3,27 @@ package com.braintreepayments.demo;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.Window;
 import android.widget.ArrayAdapter;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsCompat.Type.InsetsType;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
-
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,6 +47,17 @@ public class DemoActivity extends AppCompatActivity implements ActivityCompat.On
         setProgressBarIndeterminateVisibility(true);
 
         registerSharedPreferencesListener();
+
+        // Support Edge-to-Edge layout in Android 15
+        // Ref: https://developer.android.com/develop/ui/views/layout/edge-to-edge#cutout-insets
+        View navHostView = findViewById(R.id.nav_host);
+        ViewCompat.setOnApplyWindowInsetsListener(navHostView, (v, insets) -> {
+            @InsetsType int insetTypeMask =
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout();
+            Insets bars = insets.getInsets(insetTypeMask);
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+            return WindowInsetsCompat.CONSUMED;
+        });
     }
 
     public void fetchAuthorization(BraintreeAuthorizationCallback callback) {

--- a/ThreeDSecure/src/main/res/values/themes.xml
+++ b/ThreeDSecure/src/main/res/values/themes.xml
@@ -9,9 +9,10 @@
         <item name="android:windowAnimationStyle">@null</item>
     </style>
 
+    <!-- Ref: https://stackoverflow.com/a/36355924 -->
     <style name="Theme.Translucent.NoTitleBar">
-        <item name="android:windowActionBar">false</item>
-        <item name="android:windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,11 @@ allprojects {
 version '5.0.0-beta2-SNAPSHOT'
 group 'com.braintreepayments'
 ext {
-    compileSdkVersion = 34
+    compileSdkVersion = 35
     minSdkVersion = 23
     minSdkVersionPayPalMessaging = 23
     versionCode = 194
-    targetSdkVersion = 34
+    targetSdkVersion = 35
     versionName = version
 }
 


### PR DESCRIPTION
### Summary of changes

 - This PR adjusts the bounds of the Demo app to support edge-to-edge displays (the default in Android 15)
 - This PR also effectively hides the action bar title for the `ThreeDSecureActivity` that encapsulates interaction with the Cardinal SDK

### Checklist

- [x] Added a changelog entry
- [ ] ~Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire