### PR TITLE
Remove HttpClient.RetryStrategy

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -7,6 +7,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.ListenableWorker
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
+import com.braintreepayments.api.sharedutils.HttpMethod
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -113,12 +114,13 @@ internal class AnalyticsClient(
                         IntegrationType.fromString(integration)
                     )
                     val analyticsRequest = createFPTIPayload(authorization, eventBlobs, metadata)
-                    httpClient.post(
-                        FPTI_ANALYTICS_URL,
-                        analyticsRequest.toString(),
-                        configuration,
-                        authorization
+
+                    val request = InternalHttpRequest(
+                        method = HttpMethod.POST,
+                        path = FPTI_ANALYTICS_URL,
+                        data = analyticsRequest.toString()
                     )
+                    httpClient.sendRequestSync(request, configuration, authorization)
                     analyticsEventBlobDao.deleteEventBlobs(eventBlobs)
                 }
                 ListenableWorker.Result.success()
@@ -164,13 +166,12 @@ internal class AnalyticsClient(
         val eventBlobs = listOf(AnalyticsEventBlob(eventJSON))
         try {
             val analyticsRequest = createFPTIPayload(authorization, eventBlobs, metadata)
-            httpClient.post(
+            val request = InternalHttpRequest(
+                method = HttpMethod.POST,
                 path = FPTI_ANALYTICS_URL,
-                data = analyticsRequest.toString(),
-                configuration = null,
-                authorization = authorization,
-                callback = null
+                data = analyticsRequest.toString()
             )
+            httpClient.sendRequest(request, authorization = authorization, callback = null)
         } catch (e: JSONException) { /* ignored */
         }
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.core
 
 import com.braintreepayments.api.sharedutils.HttpClient
+import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import com.braintreepayments.api.sharedutils.TLSSocketFactory
@@ -24,7 +25,7 @@ internal class BraintreeGraphQLClient(
             return
         }
         val request = HttpRequest()
-            .method("POST")
+            .method(HttpMethod.POST)
             .path(path)
             .data(data)
             .baseUrl(configuration.graphQLUrl)
@@ -47,7 +48,7 @@ internal class BraintreeGraphQLClient(
             return
         }
         val request = HttpRequest()
-            .method("POST")
+            .method(HttpMethod.POST)
             .path("")
             .data(data)
             .baseUrl(configuration.graphQLUrl)
@@ -70,7 +71,7 @@ internal class BraintreeGraphQLClient(
             throw BraintreeException(message)
         }
         val request = HttpRequest()
-            .method("POST")
+            .method(HttpMethod.POST)
             .path(path)
             .data(data)
             .baseUrl(configuration.graphQLUrl)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -31,7 +31,7 @@ internal class BraintreeHttpClient(
     ) {
         try {
             val httpRequest = buildHttpRequest(request, configuration, authorization)
-            httpClient.sendRequest(httpRequest, request.retryStrategy, callback)
+            httpClient.sendRequest(httpRequest, callback)
         } catch (error: Exception) {
             // forward errors
             callback?.onResult(null, error)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -2,11 +2,10 @@ package com.braintreepayments.api.core
 
 import android.net.Uri
 import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpClient.RetryStrategy
+import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import com.braintreepayments.api.sharedutils.TLSSocketFactory
-import org.json.JSONException
 import org.json.JSONObject
 import javax.net.ssl.SSLException
 
@@ -18,164 +17,99 @@ internal class BraintreeHttpClient(
 ) {
 
     /**
-     * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
-     * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via GET
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param callback [NetworkResponseCallback]
+     * Make an asynchronous Braintree authenticated HTTP request.
+     *
+     * @param request the http request.
+     * @param callback See [NetworkResponseCallback].
      */
-    operator fun get(
-        path: String,
-        configuration: Configuration?,
-        authorization: Authorization?,
-        callback: NetworkResponseCallback
-    ) = get(path, configuration, authorization, HttpClient.NO_RETRY, callback)
+    @Suppress("TooGenericExceptionCaught")
+    fun sendRequest(
+        request: InternalHttpRequest,
+        configuration: Configuration? = null,
+        authorization: Authorization? = null,
+        callback: NetworkResponseCallback?
+    ) {
+        try {
+            val httpRequest = buildHttpRequest(request, configuration, authorization)
+            httpClient.sendRequest(httpRequest, request.retryStrategy, callback)
+        } catch (error: Exception) {
+            // forward errors
+            callback?.onResult(null, error)
+        }
+    }
 
     /**
-     * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
-     * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via GET
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param retryStrategy retry strategy
-     * @param callback [NetworkResponseCallback]
+     * Make a synchronous Braintree authenticated HTTP request. This method is useful when
+     * mutli-threading logic is managed by another entity e.g. WorkManager, ExecutorService.
+     *
+     * @param request the braintree http request.
      */
-    operator fun get(
-        path: String,
+    @Throws(Exception::class)
+    fun sendRequestSync(
+        request: InternalHttpRequest,
+        configuration: Configuration?,
+        authorization: Authorization?
+    ): String {
+        val httpRequest = buildHttpRequest(request, configuration, authorization)
+        return httpClient.sendRequest(httpRequest)
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun buildHttpRequest(
+        request: InternalHttpRequest,
         configuration: Configuration?,
         authorization: Authorization?,
-        @RetryStrategy retryStrategy: Int,
-        callback: NetworkResponseCallback
-    ) {
+    ): HttpRequest = request.run {
         if (authorization is InvalidAuthorization) {
             val message = authorization.errorMessage
-            callback.onResult(null, BraintreeException(message))
-            return
+            throw BraintreeException(message)
         }
         val isRelativeURL = !path.startsWith("http")
         if (configuration == null && isRelativeURL) {
             val message =
-                "Braintree HTTP GET request without configuration cannot have a relative path."
-            val relativeURLNotAllowedError = BraintreeException(message)
-            callback.onResult(null, relativeURLNotAllowedError)
-            return
+                "Braintree HTTP $method request without configuration cannot have a relative path."
+            throw BraintreeException(message)
         }
-        val targetPath = if (authorization is ClientToken) {
-            Uri.parse(path).buildUpon()
+
+        val targetPath = if (method == HttpMethod.GET && authorization is ClientToken) {
+            Uri.parse(path)
+                .buildUpon()
                 .appendQueryParameter(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)
                 .toString()
         } else {
             path
         }
-        val request = HttpRequest().method("GET").path(targetPath)
-            .addHeader(USER_AGENT_HEADER, "braintree/android/" + BuildConfig.VERSION_NAME)
-        if (isRelativeURL && configuration != null) {
-            request.baseUrl(configuration.clientApiUrl)
-        }
-        if (authorization is TokenizationKey) {
-            request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
-        }
-        httpClient.sendRequest(request, retryStrategy, callback)
-    }
 
-    /**
-     * Make a HTTP POST request to Braintree.
-     * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via HTTP POST
-     * @param data The body of the POST request
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param callback [NetworkResponseCallback]
-     */
-    @Suppress("CyclomaticComplexMethod")
-    fun post(
-        path: String,
-        data: String,
-        configuration: Configuration?,
-        authorization: Authorization?,
-        additionalHeaders: Map<String, String> = emptyMap(),
-        callback: NetworkResponseCallback?
-    ) {
-        if (authorization is InvalidAuthorization) {
-            val message = authorization.errorMessage
-            callback?.onResult(null, BraintreeException(message))
-            return
-        }
-        val isRelativeURL = !path.startsWith("http")
-        if (configuration == null && isRelativeURL) {
-            val message =
-                "Braintree HTTP GET request without configuration cannot have a relative path."
-            val relativeURLNotAllowedError = BraintreeException(message)
-            callback?.onResult(null, relativeURLNotAllowedError)
-            return
-        }
-        val requestData = if (authorization is ClientToken) {
-            try {
-                JSONObject(data).put(
+        val requestData = if (method == HttpMethod.POST) {
+            if (authorization is ClientToken) {
+                JSONObject(data ?: "{}").put(
                     AUTHORIZATION_FINGERPRINT_KEY,
                     authorization.authorizationFingerprint
                 ).toString()
-            } catch (e: JSONException) {
-                callback?.onResult(null, e)
-                return
+            } else {
+                data
             }
         } else {
-            data
+            null
         }
-        val request = HttpRequest().method("POST").path(path).data(requestData)
-            .addHeader(USER_AGENT_HEADER, "braintree/android/" + BuildConfig.VERSION_NAME)
-        if (isRelativeURL && configuration != null) {
-            request.baseUrl(configuration.clientApiUrl)
-        }
-        if (authorization is TokenizationKey) {
-            request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
-        }
-        authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token") }
-        additionalHeaders.forEach { (name, value) -> request.addHeader(name, value) }
-        httpClient.sendRequest(request, callback)
-    }
 
-    /**
-     * Makes a synchronous HTTP POST request to Braintree.
-     *
-     * @param path the path or url to request from the server via HTTP POST
-     * @param data the body of the post request
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @return the HTTP response body
-     */
-    @Throws(Exception::class)
-    fun post(
-        path: String, data: String, configuration: Configuration?, authorization: Authorization?
-    ): String {
-        if (authorization is InvalidAuthorization) {
-            val message = authorization.errorMessage
-            throw BraintreeException(message)
-        }
-        val isRelativeURL = !path.startsWith("http")
-        if (configuration == null && isRelativeURL) {
-            val message =
-                "Braintree HTTP GET request without configuration cannot have a relative path."
-            throw BraintreeException(message)
-        }
-        val requestData = if (authorization is ClientToken) {
-            JSONObject(data).put(
-                AUTHORIZATION_FINGERPRINT_KEY,
-                authorization.authorizationFingerprint
-            ).toString()
-        } else {
-            data
-        }
-        val request = HttpRequest().method("POST").path(path).data(requestData)
+        val result = HttpRequest()
+            .method(method)
+            .path(targetPath)
+            .data(requestData ?: "")
             .addHeader(USER_AGENT_HEADER, "braintree/android/" + BuildConfig.VERSION_NAME)
+
         if (isRelativeURL && configuration != null) {
-            request.baseUrl(configuration.clientApiUrl)
+            result.baseUrl(configuration.clientApiUrl)
         }
+
         if (authorization is TokenizationKey) {
-            request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
+            result.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
-        return httpClient.sendRequest(request)
+
+        authorization?.bearer?.let { token -> result.addHeader("Authorization", "Bearer $token") }
+        additionalHeaders.forEach { (name, value) -> result.addHeader(name, value) }
+        return result
     }
 
     companion object {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import com.braintreepayments.api.sharedutils.HttpClient
+import com.braintreepayments.api.sharedutils.HttpMethod
 import org.json.JSONException
 
 internal class ConfigurationLoader internal constructor(
@@ -31,8 +32,14 @@ internal class ConfigurationLoader internal constructor(
         cachedConfig?.let {
             callback.onResult(cachedConfig, null, null)
         } ?: run {
-            httpClient.get(
-                configUrl, null, authorization, HttpClient.RETRY_MAX_3_TIMES
+            val request = InternalHttpRequest(
+                method = HttpMethod.GET,
+                path = configUrl,
+                retryStrategy = HttpClient.RETRY_MAX_3_TIMES
+            )
+            httpClient.sendRequest(
+                request = request,
+                authorization = authorization
             ) { response, httpError ->
                 val responseBody = response?.body
                 val timing = response?.timing

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -32,11 +32,7 @@ internal class ConfigurationLoader internal constructor(
         cachedConfig?.let {
             callback.onResult(cachedConfig, null, null)
         } ?: run {
-            val request = InternalHttpRequest(
-                method = HttpMethod.GET,
-                path = configUrl,
-                retryStrategy = HttpClient.RETRY_MAX_3_TIMES
-            )
+            val request = InternalHttpRequest(method = HttpMethod.GET, path = configUrl)
             httpClient.sendRequest(
                 request = request,
                 authorization = authorization

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/InternalHttpRequest.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/InternalHttpRequest.kt
@@ -1,8 +1,6 @@
 package com.braintreepayments.api.core
 
 import androidx.annotation.RestrictTo
-import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpClient.RetryStrategy
 import com.braintreepayments.api.sharedutils.HttpMethod
 
 /**
@@ -14,5 +12,4 @@ data class InternalHttpRequest(
     val path: String,
     val data: String? = null,
     val additionalHeaders: Map<String, String> = emptyMap(),
-    @RetryStrategy val retryStrategy: Int = HttpClient.NO_RETRY
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/InternalHttpRequest.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/InternalHttpRequest.kt
@@ -1,0 +1,18 @@
+package com.braintreepayments.api.core
+
+import androidx.annotation.RestrictTo
+import com.braintreepayments.api.sharedutils.HttpClient
+import com.braintreepayments.api.sharedutils.HttpClient.RetryStrategy
+import com.braintreepayments.api.sharedutils.HttpMethod
+
+/**
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class InternalHttpRequest(
+    val method: HttpMethod,
+    val path: String,
+    val data: String? = null,
+    val additionalHeaders: Map<String, String> = emptyMap(),
+    @RetryStrategy val retryStrategy: Int = HttpClient.NO_RETRY
+)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.core
 
 import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.sharedutils.HttpClient
+import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import io.mockk.every
@@ -49,7 +50,7 @@ class BraintreeGraphQLClientUnitTest {
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://example-graphql.com/graphql/sample/path"), httpRequest.url)
         assertEquals("data", String(httpRequest.data, StandardCharsets.UTF_8))
-        assertEquals("POST", httpRequest.method)
+        assertEquals(HttpMethod.POST, httpRequest.method)
 
         val headers = httpRequest.headers
         assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
@@ -71,7 +72,7 @@ class BraintreeGraphQLClientUnitTest {
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://example-graphql.com/graphql"), httpRequest.url)
         assertEquals("data", String(httpRequest.data, StandardCharsets.UTF_8))
-        assertEquals("POST", httpRequest.method)
+        assertEquals(HttpMethod.POST, httpRequest.method)
 
         val headers = httpRequest.headers
         assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
@@ -92,7 +93,7 @@ class BraintreeGraphQLClientUnitTest {
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://example-graphql.com/graphql/sample/path"), httpRequest.url)
         assertEquals("data", String(httpRequest.data, StandardCharsets.UTF_8))
-        assertEquals("POST", httpRequest.method)
+        assertEquals(HttpMethod.POST, httpRequest.method)
 
         val headers = httpRequest.headers
         assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
@@ -1,11 +1,11 @@
 package com.braintreepayments.api.core
 
-import com.braintreepayments.api.testutils.Fixtures
-import com.braintreepayments.api.testutils.FixturesHelper
 import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
+import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.FixturesHelper
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -17,7 +17,6 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyInt
 import org.robolectric.RobolectricTestRunner
 import java.net.MalformedURLException
 import java.net.URISyntaxException
@@ -68,7 +67,7 @@ class BraintreeHttpClientUnitTest {
 
         val httpRequestSlot = slot<HttpRequest>()
         every {
-            httpClient.sendRequest(capture(httpRequestSlot), HttpClient.NO_RETRY, callback)
+            httpClient.sendRequest(capture(httpRequestSlot), callback)
         } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
@@ -92,7 +91,7 @@ class BraintreeHttpClientUnitTest {
         val httpRequestSlot = slot<HttpRequest>()
         val callback = mockk<NetworkResponseCallback>()
         every {
-            httpClient.sendRequest(capture(httpRequestSlot), HttpClient.NO_RETRY, callback)
+            httpClient.sendRequest(capture(httpRequestSlot), callback)
         } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
@@ -121,7 +120,7 @@ class BraintreeHttpClientUnitTest {
         val httpRequestSlot = slot<HttpRequest>()
         val callback = mockk<NetworkResponseCallback>()
         every {
-            httpClient.sendRequest(capture(httpRequestSlot), HttpClient.NO_RETRY, callback)
+            httpClient.sendRequest(capture(httpRequestSlot), callback)
         } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
@@ -305,7 +304,7 @@ class BraintreeHttpClientUnitTest {
 
         val callback = mockk<NetworkResponseCallback>()
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), anyInt(), callback) } returns Unit
+        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -336,7 +335,7 @@ class BraintreeHttpClientUnitTest {
 
         val callback = mockk<NetworkResponseCallback>()
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), anyInt(), callback) } returns Unit
+        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -393,7 +392,7 @@ class BraintreeHttpClientUnitTest {
         // NOTE: duplicate of sendRequest_withNullConfigurationAndAbsoluteURL_doesNotSetABaseURLOnTheRequest
         val httpRequestSlot = slot<HttpRequest>()
         val callback = mockk<NetworkResponseCallback>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), anyInt(), callback) } returns Unit
+        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -464,7 +463,7 @@ class BraintreeHttpClientUnitTest {
         every { tokenizationKey.bearer } returns token
 
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), anyInt(), any()) } just runs
+        every { httpClient.sendRequest(capture(httpRequestSlot), any()) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -489,7 +488,7 @@ class BraintreeHttpClientUnitTest {
         every { tokenizationKey.bearer } returns null
 
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), anyInt(), any()) } just runs
+        every { httpClient.sendRequest(capture(httpRequestSlot), any()) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -531,7 +530,7 @@ class BraintreeHttpClientUnitTest {
             httpClient.sendRequest(withArg {
                 assertEquals(it.headers["name1"], "value1")
                 assertEquals(it.headers["name2"], "value2")
-            }, anyInt(), callback)
+            }, callback)
         }
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -29,17 +29,20 @@ class ConfigurationLoaderUnitTest {
         val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
         sut.loadConfiguration(authorization, callback)
 
-        val expectedConfigUrl = "https://example.com/config?configVersion=3"
+        val httpRequestSlot = slot<InternalHttpRequest>()
         val callbackSlot = slot<NetworkResponseCallback>()
         verify {
-            braintreeHttpClient.get(
-                    expectedConfigUrl,
-                    null,
-                    authorization,
-                    HttpClient.RETRY_MAX_3_TIMES,
-                    capture(callbackSlot)
+            braintreeHttpClient.sendRequest(
+                capture(httpRequestSlot),
+                null,
+                authorization,
+                capture(callbackSlot)
             )
         }
+
+        val expectedConfigUrl = "https://example.com/config?configVersion=3"
+        assertEquals(expectedConfigUrl, httpRequestSlot.captured.path)
+        assertEquals(HttpClient.RETRY_MAX_3_TIMES, httpRequestSlot.captured.retryStrategy)
 
         val httpResponseCallback = callbackSlot.captured
         httpResponseCallback.onResult(
@@ -57,15 +60,13 @@ class ConfigurationLoaderUnitTest {
         val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
         sut.loadConfiguration(authorization, callback)
 
-        val expectedConfigUrl = "https://example.com/config?configVersion=3"
         val callbackSlot = slot<NetworkResponseCallback>()
         verify {
-            braintreeHttpClient.get(
-                    expectedConfigUrl,
-                    null,
-                    authorization,
-                    HttpClient.RETRY_MAX_3_TIMES,
-                    capture(callbackSlot)
+            braintreeHttpClient.sendRequest(
+                any(),
+                null,
+                authorization,
+                capture(callbackSlot)
             )
         }
 
@@ -91,14 +92,14 @@ class ConfigurationLoaderUnitTest {
 
         val callbackSlot = slot<NetworkResponseCallback>()
         verify {
-            braintreeHttpClient.get(
-                    ofType(String::class),
-                    null,
-                    authorization,
-                    HttpClient.RETRY_MAX_3_TIMES,
-                    capture(callbackSlot)
+            braintreeHttpClient.sendRequest(
+                any(),
+                null,
+                authorization,
+                capture(callbackSlot)
             )
         }
+
         val httpResponseCallback = callbackSlot.captured
         httpResponseCallback.onResult(HttpResponse("not json", HttpResponseTiming(0, 0)), null)
         verify {
@@ -113,14 +114,12 @@ class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(authorization, callback)
 
         val callbackSlot = slot<NetworkResponseCallback>()
-
         verify {
-            braintreeHttpClient.get(
-                    ofType(String::class),
-                    null,
-                    authorization,
-                    HttpClient.RETRY_MAX_3_TIMES,
-                    capture(callbackSlot)
+            braintreeHttpClient.sendRequest(
+                any(),
+                null,
+                authorization,
+                capture(callbackSlot)
             )
         }
 
@@ -167,12 +166,11 @@ class ConfigurationLoaderUnitTest {
         sut.loadConfiguration(authorization, callback)
 
         verify(exactly = 0) {
-            braintreeHttpClient.get(
-                    ofType(String::class),
-                    null,
-                    authorization,
-                    ofType(Int::class),
-                    ofType(NetworkResponseCallback::class)
+            braintreeHttpClient.sendRequest(
+                any(),
+                null,
+                authorization,
+                any()
             )
         }
         verify { callback.onResult(ofType(Configuration::class), null, null) }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -42,7 +42,6 @@ class ConfigurationLoaderUnitTest {
 
         val expectedConfigUrl = "https://example.com/config?configVersion=3"
         assertEquals(expectedConfigUrl, httpRequestSlot.captured.path)
-        assertEquals(HttpClient.RETRY_MAX_3_TIMES, httpRequestSlot.captured.retryStrategy)
 
         val httpResponseCallback = callbackSlot.captured
         httpResponseCallback.onResult(

--- a/SharedUtils/src/androidTest/java/com/braintreepayments/api/sharedutils/HttpClientTest.java
+++ b/SharedUtils/src/androidTest/java/com/braintreepayments/api/sharedutils/HttpClientTest.java
@@ -26,7 +26,7 @@ public class HttpClientTest {
         HttpClient sut = new HttpClient(null, new BaseHttpResponseParser());
 
         HttpRequest httpRequest = new HttpRequest()
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://bad.endpoint")
                 .path("bad/path");
 

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
@@ -1,39 +1,15 @@
 package com.braintreepayments.api.sharedutils;
 
-import androidx.annotation.IntDef;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class HttpClient {
 
-    @IntDef({NO_RETRY, RETRY_MAX_3_TIMES})
-    @Retention(RetentionPolicy.SOURCE)
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public @interface RetryStrategy {
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public static final int NO_RETRY = 0;
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public static final int RETRY_MAX_3_TIMES = 1;
-
-    static final int MAX_RETRY_ATTEMPTS = 3;
-
     private final Scheduler scheduler;
     private final SynchronousHttpClient syncHttpClient;
-
-    private final Map<URL, Integer> retryCountMap;
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public HttpClient(SSLSocketFactory socketFactory, HttpResponseParser httpResponseParser) {
@@ -44,7 +20,6 @@ public class HttpClient {
     HttpClient(SynchronousHttpClient syncHttpClient, Scheduler scheduler) {
         this.syncHttpClient = syncHttpClient;
         this.scheduler = scheduler;
-        this.retryCountMap = new HashMap<>();
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -54,76 +29,18 @@ public class HttpClient {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public void sendRequest(HttpRequest request, NetworkResponseCallback callback) {
-        sendRequest(request, HttpClient.NO_RETRY, callback);
+        scheduleRequest(request, callback);
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public void sendRequest(HttpRequest request, @RetryStrategy int retryStrategy,
-                            NetworkResponseCallback callback) {
-        scheduleRequest(request, retryStrategy, callback);
-    }
-
-    private void scheduleRequest(final HttpRequest request, @RetryStrategy final int retryStrategy,
-                                 final NetworkResponseCallback callback) {
-        resetRetryCount(request);
-
+    private void scheduleRequest(final HttpRequest request, final NetworkResponseCallback callback) {
         scheduler.runOnBackground(() -> {
             try {
                 HttpResponse httpResponse = syncHttpClient.request(request);
                 notifySuccessOnMainThread(callback, httpResponse);
             } catch (Exception e) {
-                switch (retryStrategy) {
-                    case HttpClient.NO_RETRY:
-                        notifyErrorOnMainThread(callback, e);
-                        break;
-                    case HttpClient.RETRY_MAX_3_TIMES:
-                        retryGet(request, retryStrategy, callback);
-                        break;
-                }
+                notifyErrorOnMainThread(callback, e);
             }
         });
-    }
-
-    private void retryGet(final HttpRequest request, @RetryStrategy final int retryStrategy,
-                          final NetworkResponseCallback callback) {
-        URL url = null;
-        try {
-            url = request.getURL();
-        } catch (MalformedURLException | URISyntaxException ignore) {
-        }
-
-        if (url != null) {
-            int retryCount = getNumRetriesSoFar(url);
-            boolean shouldRetry = ((retryCount + 1) < MAX_RETRY_ATTEMPTS);
-            if (shouldRetry) {
-                scheduleRequest(request, retryStrategy, callback);
-                retryCountMap.put(url, retryCount + 1);
-            } else {
-                String message = "Retry limit has been exceeded. Try again later.";
-                HttpClientException retryLimitException = new HttpClientException(message);
-                notifyErrorOnMainThread(callback, retryLimitException);
-            }
-        }
-    }
-
-    private int getNumRetriesSoFar(URL url) {
-        Integer retryCount = retryCountMap.get(url);
-        if (retryCount == null) {
-            return 0;
-        }
-        return retryCount;
-    }
-
-    private void resetRetryCount(HttpRequest request) {
-        URL url = null;
-        try {
-            url = request.getURL();
-        } catch (MalformedURLException | URISyntaxException ignore) {
-        }
-
-        if (url != null) {
-            retryCountMap.remove(url);
-        }
     }
 
     private void notifySuccessOnMainThread(final NetworkResponseCallback callback,

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpMethod.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpMethod.java
@@ -1,0 +1,8 @@
+package com.braintreepayments.api.sharedutils;
+
+import androidx.annotation.RestrictTo;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public enum HttpMethod {
+    GET, POST
+}

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpRequest.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpRequest.java
@@ -23,7 +23,7 @@ public class HttpRequest {
     private String baseUrl;
 
     private byte[] data;
-    private String method;
+    private HttpMethod method;
 
     private final int readTimeout;
     private final int connectTimeout;
@@ -64,7 +64,7 @@ public class HttpRequest {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public HttpRequest method(String method) {
+    public HttpRequest method(HttpMethod method) {
         this.method = method;
         return this;
     }
@@ -92,7 +92,7 @@ public class HttpRequest {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public String getMethod() {
+    public HttpMethod getMethod() {
         return method;
     }
 

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/SynchronousHttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/SynchronousHttpClient.java
@@ -51,8 +51,8 @@ class SynchronousHttpClient {
             ((HttpsURLConnection) connection).setSSLSocketFactory(socketFactory);
         }
 
-        String requestMethod = httpRequest.getMethod();
-        connection.setRequestMethod(requestMethod);
+        HttpMethod requestMethod = httpRequest.getMethod();
+        connection.setRequestMethod(requestMethod.name());
 
         connection.setReadTimeout(httpRequest.getReadTimeout());
         connection.setConnectTimeout(httpRequest.getConnectTimeout());
@@ -63,7 +63,7 @@ class SynchronousHttpClient {
             connection.setRequestProperty(entry.getKey(), entry.getValue());
         }
 
-        if (requestMethod != null && requestMethod.equals("POST")) {
+        if (requestMethod == HttpMethod.POST) {
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setDoOutput(true);
 

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
@@ -2,10 +2,8 @@ package com.braintreepayments.api.sharedutils;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 public class HttpClientUnitTest {
 
@@ -103,69 +100,6 @@ public class HttpClientUnitTest {
 
         threadScheduler.flushBackgroundThread();
         verify(threadScheduler, never()).runOnMain(any(Runnable.class));
-    }
-
-    @Test
-    public void sendRequest_whenRetryMax3TimesEnabled_retriesRequest3Times() throws Exception {
-        HttpClient sut = new HttpClient(syncHttpClient, threadScheduler);
-
-        Exception exception = new Exception("error");
-        when(syncHttpClient.request(httpRequest)).thenThrow(exception);
-
-        NetworkResponseCallback callback = mock(NetworkResponseCallback.class);
-        sut.sendRequest(httpRequest, HttpClient.RETRY_MAX_3_TIMES, callback);
-
-        threadScheduler.flushBackgroundThread();
-        verify(syncHttpClient, times(3)).request(httpRequest);
-    }
-
-    @Test
-    public void sendRequest_whenRetryMax3TimesEnabled_notifiesMaxRetriesLimitExceededOnForegroundThread()
-            throws Exception {
-        HttpClient sut = new HttpClient(syncHttpClient, threadScheduler);
-
-        Exception exception = new Exception("error");
-        when(syncHttpClient.request(httpRequest)).thenThrow(exception);
-
-        NetworkResponseCallback callback = mock(NetworkResponseCallback.class);
-        sut.sendRequest(httpRequest, HttpClient.RETRY_MAX_3_TIMES, callback);
-
-        threadScheduler.flushBackgroundThread();
-        verify(callback, never()).onResult((HttpResponse) isNull(), any(Exception.class));
-
-        threadScheduler.flushMainThread();
-
-        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
-        verify(callback).onResult((HttpResponse) isNull(), captor.capture());
-
-        HttpClientException httpClientException = (HttpClientException) captor.getValue();
-        String expectedMessage = "Retry limit has been exceeded. Try again later.";
-        assertEquals(expectedMessage, httpClientException.getMessage());
-    }
-
-    @Test
-    public void sendRequest_whenRetryMax3TimesEnabled_futureRequestsAreAllowed() throws Exception {
-        HttpClient sut = new HttpClient(syncHttpClient, threadScheduler);
-        HttpResponse response = new HttpResponse("response body", new HttpResponseTiming(123, 456));
-
-        Exception exception = new Exception("error");
-        when(syncHttpClient.request(httpRequest)).thenThrow(exception);
-
-        NetworkResponseCallback callback = mock(NetworkResponseCallback.class);
-        sut.sendRequest(httpRequest, HttpClient.RETRY_MAX_3_TIMES, callback);
-
-        threadScheduler.flushBackgroundThread();
-
-        reset(syncHttpClient);
-        when(syncHttpClient.request(httpRequest))
-                .thenThrow(exception)
-                .thenReturn(response);
-        sut.sendRequest(httpRequest, HttpClient.RETRY_MAX_3_TIMES, callback);
-
-        threadScheduler.flushBackgroundThread();
-        threadScheduler.flushMainThread();
-
-        verify(callback).onResult(response, null);
     }
 
     @Test

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpRequestUnitTest.java
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpRequestUnitTest.java
@@ -60,9 +60,9 @@ public class HttpRequestUnitTest {
         @Test
         public void getMethod_returnsMethod() {
             HttpRequest sut = HttpRequest.newInstance()
-                    .method("GET");
+                    .method(HttpMethod.GET);
 
-            assertEquals("GET", sut.getMethod());
+            assertEquals(HttpMethod.GET, sut.getMethod());
         }
 
         @Test

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/SynchronousHttpClientUnitTest.java
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/SynchronousHttpClientUnitTest.java
@@ -42,7 +42,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_whenHttpRequestURLMalformed_throwsMalformedURLException() {
         final HttpRequest httpRequest = new HttpRequest()
                 .path("")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("/:/");
 
         final SynchronousHttpClient sut =
@@ -77,7 +77,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_setsRequestMethod() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -99,7 +99,7 @@ public class SynchronousHttpClientUnitTest {
             throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -120,7 +120,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_whenConnectionIsHttps_setsSSLSocketFactory() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -142,7 +142,7 @@ public class SynchronousHttpClientUnitTest {
             throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -171,7 +171,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_setsHttpReadTimeout() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         when(httpRequest.getReadTimeout()).thenReturn(123);
@@ -194,7 +194,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_setsHttpConnectionTimeout() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         when(httpRequest.getConnectTimeout()).thenReturn(456);
@@ -217,7 +217,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_setsHttpHeaders() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com")
                 .addHeader("Sample-Header", "Sample Value"));
 
@@ -239,7 +239,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_parsesResponseAndReturnsHttpBody() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -260,7 +260,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_onSuccess_closesUrlConnection() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -282,7 +282,7 @@ public class SynchronousHttpClientUnitTest {
             throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("GET")
+                .method(HttpMethod.GET)
                 .baseUrl("https://www.sample.com"));
 
         URL url = mock(URL.class);
@@ -309,7 +309,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_whenPost_addsContentTypeHeader() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("POST")
+                .method(HttpMethod.POST)
                 .data("test data")
                 .baseUrl("https://www.sample.com"));
 
@@ -333,7 +333,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_whenPost_writesAsciiCharactersToOutputStream() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("POST")
+                .method(HttpMethod.POST)
                 .data("test data")
                 .baseUrl("https://www.sample.com"));
 
@@ -363,7 +363,7 @@ public class SynchronousHttpClientUnitTest {
     public void request_whenPost_writesUTF8CharactersToOutputStream() throws Exception {
         final HttpRequest httpRequest = spy(new HttpRequest()
                 .path("sample/path")
-                .method("POST")
+                .method(HttpMethod.POST)
                 .data("Bjärne Stroustrüp")
                 .baseUrl("https://www.sample.com"));
 


### PR DESCRIPTION
### Summary of changes

 - This PR removes the `RetryStrategy` from `HttpClient` in `:SharedUtils`
 - The only class that uses `RETRY_MAX_3_TIMES` is `ConfigurationLoader`
 - We'll migrate the retry logic to `ConfigurationLoader` in a separate PR

### Checklist

 - [ ] ~Added a changelog entry~
 - [ ] ~Relevant test coverage~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire