### PR TITLE
[Fix Configuration Loader] Prevent Race Condition

### DIFF
--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.core
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.braintreepayments.api.core.Authorization.Companion.fromString
 import com.braintreepayments.api.sharedutils.AuthorizationException
+import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.testutils.Fixtures
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -28,7 +29,8 @@ class BraintreeHttpClientTest {
         val braintreeHttpClient = BraintreeHttpClient()
 
         val path = "https://api.sandbox.braintreegateway.com/"
-        braintreeHttpClient.get(path, null, authorization) { _, httpError ->
+        val request = InternalHttpRequest(method = HttpMethod.GET, path = path)
+        braintreeHttpClient.sendRequest(request, authorization = authorization) { _, httpError ->
             // Make sure exception is due to authorization not SSL handshake
             assertTrue(httpError is AuthorizationException)
             countDownLatch.countDown()
@@ -44,7 +46,8 @@ class BraintreeHttpClientTest {
         val braintreeHttpClient = BraintreeHttpClient()
 
         val path = "https://gateway.qa.braintreepayments.com/"
-        braintreeHttpClient.get(path, null, authorization) { _, httpError ->
+        val request = InternalHttpRequest(method = HttpMethod.GET, path = path)
+        braintreeHttpClient.sendRequest(request, authorization = authorization) { _, httpError ->
             // Make sure http request to qa works to verify certificate pinning strategy
             assertNull(httpError)
             countDownLatch.countDown()
@@ -60,7 +63,8 @@ class BraintreeHttpClientTest {
         val braintreeHttpClient = BraintreeHttpClient()
 
         val path = "https://api.braintreegateway.com/"
-        braintreeHttpClient.get(path, null, authorization) { _, httpError ->
+        val request = InternalHttpRequest(method = HttpMethod.GET, path = path)
+        braintreeHttpClient.sendRequest(request, authorization = authorization) { _, httpError ->
             // Make sure exception is due to authorization not SSL handshake
             assertTrue(httpError is AuthorizationException)
             countDownLatch.countDown()

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -125,13 +125,14 @@ class BraintreeClient @VisibleForTesting internal constructor(
             callback.onResult(null, createAuthError())
             return
         }
-        configurationLoader.loadConfiguration(authorization) { configuration, configError, timing ->
+        configurationLoader.loadConfiguration(authorization) { response ->
+            val configuration = response.configuration
             if (configuration != null) {
                 callback.onResult(configuration, null)
             } else {
-                callback.onResult(null, configError)
+                callback.onResult(null, response.error)
             }
-            timing?.let { sendAnalyticsTimingEvent("/v1/configuration", it) }
+            response.timing?.let { sendAnalyticsTimingEvent("/v1/configuration", it) }
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
@@ -79,7 +79,7 @@ internal class BraintreeGraphQLClient(
             .addHeader("Authorization",
                 String.format(Locale.US, "Bearer %s", authorization.bearer))
             .addHeader("Braintree-Version", GraphQLConstants.Headers.API_VERSION)
-        return httpClient.sendRequest(request)
+        return httpClient.sendRequest(request).body ?: ""
     }
 
     companion object {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -108,7 +108,9 @@ internal class BraintreeHttpClient(
             result.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
         }
 
-        authorization?.bearer?.let { token -> result.addHeader("Authorization", "Bearer $token") }
+        if (method == HttpMethod.POST) {
+            authorization?.bearer?.let { token -> result.addHeader("Authorization", "Bearer $token") }
+        }
         additionalHeaders.forEach { (name, value) -> result.addHeader(name, value) }
         return result
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.HttpResponse
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import com.braintreepayments.api.sharedutils.TLSSocketFactory
 import org.json.JSONObject
@@ -49,7 +50,7 @@ internal class BraintreeHttpClient(
         request: InternalHttpRequest,
         configuration: Configuration?,
         authorization: Authorization?
-    ): String {
+    ): HttpResponse {
         val httpRequest = buildHttpRequest(request, configuration, authorization)
         return httpClient.sendRequest(httpRequest)
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -53,7 +53,7 @@ internal class ConfigurationLoader internal constructor(
     ): ConfigurationLoaderResponse? =
         configurationCache.getConfiguration(authorization, configUrl)?.let { configuration ->
             // NOTE: timing information is null when configuration comes from cache
-            return ConfigurationLoaderResponse(configuration, timing = null)
+            return ConfigurationLoaderResponse(configuration = configuration, timing = null)
         }
 
     @Suppress("TooGenericExceptionCaught")

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.WorkerThread
 import com.braintreepayments.api.sharedutils.HttpMethod
-import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.Scheduler
 import com.braintreepayments.api.sharedutils.ThreadScheduler
 import java.lang.ref.WeakReference

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -27,21 +27,21 @@ internal class ConfigurationLoader internal constructor(
     }
 
     private fun loadConfigurationInBackground(
-        auth: Authorization,
+        authorization: Authorization,
         callback: ConfigurationLoaderCallback
     ) {
-        val url = Uri.parse(auth.configUrl)
+        val url = Uri.parse(authorization.configUrl)
             .buildUpon()
             .appendQueryParameter("configVersion", "3")
             .build()
             .toString()
 
-        val cbRef = WeakReference(callback)
+        val callbackReference = WeakReference(callback)
         threadScheduler.runOnBackground {
-            val response = loadConfigFromCache(url, auth) ?: loadConfigFromNetwork(url, auth)
+            val response =
+                loadConfigFromCache(url, authorization) ?: loadConfigFromNetwork(url, authorization)
             threadScheduler.runOnMain {
-                val cb = cbRef.get()
-                cb?.onResult(response)
+                callbackReference.get()?.onResult(response)
             }
         }
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -12,7 +12,7 @@ import java.lang.ref.WeakReference
 internal class ConfigurationLoader internal constructor(
     private val httpClient: BraintreeHttpClient,
     private val configurationCache: ConfigurationCache,
-    private val threadScheduler: Scheduler = ThreadScheduler(THREAD_POOL_SIZE)
+    private val threadScheduler: Scheduler = ThreadScheduler(SERIAL_DISPATCH_QUEUE_POOL_SIZE)
 ) {
     constructor(context: Context, httpClient: BraintreeHttpClient) : this(
         httpClient, ConfigurationCache.getInstance(context)
@@ -95,6 +95,6 @@ internal class ConfigurationLoader internal constructor(
 
     companion object {
         // NOTE: a single thread pool makes the ThreadScheduler behave like a serial dispatch queue
-        const val THREAD_POOL_SIZE = 1
+        const val SERIAL_DISPATCH_QUEUE_POOL_SIZE = 1
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
@@ -1,7 +1,5 @@
 package com.braintreepayments.api.core
 
-import com.braintreepayments.api.sharedutils.HttpResponseTiming
-
 internal fun interface ConfigurationLoaderCallback {
-    fun onResult(result: Configuration?, error: Exception?, timing: HttpResponseTiming?)
+    fun onResult(response: ConfigurationLoaderResponse)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResponse.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResponse.kt
@@ -1,0 +1,9 @@
+package com.braintreepayments.api.core
+
+import com.braintreepayments.api.sharedutils.HttpResponseTiming
+
+data class ConfigurationLoaderResponse(
+    val configuration: Configuration? = null,
+    val error: Exception? = null,
+    val timing: HttpResponseTiming? = null
+)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
@@ -481,7 +481,7 @@ class BraintreeClientUnitTest {
             configurationLoader.loadConfiguration(authorization, capture(callbackSlot))
         }
 
-        callbackSlot.captured.onResult(configuration, null, null)
+        callbackSlot.captured.onResult(ConfigurationLoaderResponse(configuration))
 
         verify {
             analyticsClient.reportCrash(

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
@@ -4,6 +4,8 @@ import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.HttpResponse
+import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import io.mockk.every
 import io.mockk.mockk
@@ -84,7 +86,8 @@ class BraintreeGraphQLClientUnitTest {
     @Throws(Exception::class)
     fun post_withPathAndDataAndConfiguration_sendsHttpRequest() {
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns "sample response"
+        val httpResponse = HttpResponse(body = "sample response", HttpResponseTiming(123L, 456L))
+        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns httpResponse
 
         val sut = BraintreeGraphQLClient(httpClient)
         val result = sut.post("sample/path", "data", configuration, authorization)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
@@ -3,6 +3,8 @@ package com.braintreepayments.api.core
 import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.HttpResponse
+import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.testutils.FixturesHelper
@@ -173,7 +175,8 @@ class BraintreeHttpClientUnitTest {
         every { configuration.clientApiUrl } returns "https://example.com"
 
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns "sample result"
+        val httpResponse = HttpResponse(body = "sample result", HttpResponseTiming(123L, 456L))
+        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns httpResponse
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -182,7 +185,7 @@ class BraintreeHttpClientUnitTest {
             data = "{}"
         )
         val result = sut.sendRequestSync(request, configuration, tokenizationKey)
-        assertEquals("sample result", result)
+        assertEquals("sample result", result.body)
 
         val httpRequest = httpRequestSlot.captured
         val headers = httpRequest.headers
@@ -207,7 +210,8 @@ class BraintreeHttpClientUnitTest {
         every { configuration.clientApiUrl } returns "https://example.com"
 
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns "sample result"
+        val httpResponse = HttpResponse(body = "sample result", HttpResponseTiming(123L, 456L))
+        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns httpResponse
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(
@@ -216,7 +220,7 @@ class BraintreeHttpClientUnitTest {
             data = "{}"
         )
         val result = sut.sendRequestSync(request, configuration, clientToken)
-        assertEquals("sample result", result)
+        assertEquals("sample result", result.body)
 
         val httpRequest = httpRequestSlot.captured
         val headers = httpRequest.headers
@@ -261,7 +265,8 @@ class BraintreeHttpClientUnitTest {
         ) as ClientToken
 
         val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns ""
+        val httpResponse = HttpResponse(body = "", HttpResponseTiming(123L, 456L))
+        every { httpClient.sendRequest(capture(httpRequestSlot)) } returns httpResponse
 
         val sut = BraintreeHttpClient(httpClient)
         val request = InternalHttpRequest(

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -1,9 +1,8 @@
 package com.braintreepayments.api.core
 
+import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpResponse
 import com.braintreepayments.api.sharedutils.HttpResponseTiming
-import com.braintreepayments.api.sharedutils.NetworkResponseCallback
-import com.braintreepayments.api.sharedutils.Scheduler
 import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.testutils.MockThreadScheduler
 import io.mockk.every
@@ -14,6 +13,7 @@ import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +27,7 @@ class ConfigurationLoaderUnitTest {
     private lateinit var braintreeHttpClient: BraintreeHttpClient
     private lateinit var callback: ConfigurationLoaderCallback
     private lateinit var authorization: Authorization
-    private lateinit var threadScheduler: Scheduler
+    private lateinit var threadScheduler: MockThreadScheduler
 
     @Before
     fun beforeEach() {
@@ -39,32 +39,46 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_loadsConfigurationForTheCurrentEnvironment() {
+    fun loadConfiguration_loadsConfigurationOnBackgroundThread() {
         every { authorization.configUrl } returns "https://example.com/config"
         every { configurationCache.getConfiguration(any(), any()) } returns null
 
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
-        val httpRequestSlot = slot<InternalHttpRequest>()
-        val callbackSlot = slot<NetworkResponseCallback>()
+        // no http calls should be made on main thread
+        verify(exactly = 0) { braintreeHttpClient.sendRequestSync(any(), any(), any()) }
+        threadScheduler.flushBackgroundThread()
+
+        val requestSlot = slot<InternalHttpRequest>()
         verify {
-            braintreeHttpClient.sendRequest(
-                capture(httpRequestSlot),
-                null,
-                authorization,
-                capture(callbackSlot)
-            )
+            braintreeHttpClient.sendRequestSync(capture(requestSlot), null, authorization)
         }
 
-        val expectedConfigUrl = "https://example.com/config?configVersion=3"
-        assertEquals(expectedConfigUrl, httpRequestSlot.captured.path)
+        val httpRequest = requestSlot.captured
+        assertEquals(HttpMethod.GET, httpRequest.method)
+        assertEquals("https://example.com/config?configVersion=3", httpRequest.path)
+    }
 
-        val httpResponseCallback = callbackSlot.captured
-        httpResponseCallback.onResult(
-            HttpResponse(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, HttpResponseTiming(0, 0)), null
-        )
+    @Test
+    fun loadConfiguration_onSuccess_callsBackConfigurationOnMainThread() {
+        every { authorization.configUrl } returns "https://example.com/config"
+        every { configurationCache.getConfiguration(any(), any()) } returns null
 
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
+        sut.loadConfiguration(authorization, callback)
+
+        val httpResponse =
+            HttpResponse(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, HttpResponseTiming(0, 0))
+        every {
+            braintreeHttpClient.sendRequestSync(any(), null, authorization)
+        } returns httpResponse
+
+        threadScheduler.flushBackgroundThread()
+        // call back should happen on main thread
+        verify(exactly = 0) { callback.onResult(any()) }
+
+        threadScheduler.flushMainThread()
         val responseSlot = slot<ConfigurationLoaderResponse>()
         verify { callback.onResult(capture(responseSlot)) }
 
@@ -76,89 +90,70 @@ class ConfigurationLoaderUnitTest {
 
     @Test
     fun loadConfiguration_savesFetchedConfigurationToCache() {
-        every { configurationCache.getConfiguration(any(), any()) } returns null
         every { authorization.configUrl } returns "https://example.com/config"
-        every { authorization.bearer } returns "bearer"
+        every { configurationCache.getConfiguration(any(), any()) } returns null
 
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
-        val callbackSlot = slot<NetworkResponseCallback>()
-        verify {
-            braintreeHttpClient.sendRequest(
-                any(),
-                null,
-                authorization,
-                capture(callbackSlot)
-            )
-        }
+        val httpResponse =
+            HttpResponse(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, HttpResponseTiming(0, 0))
+        every {
+            braintreeHttpClient.sendRequestSync(any(), null, authorization)
+        } returns httpResponse
+        threadScheduler.flushBackgroundThread()
 
-        val httpResponseCallback = callbackSlot.captured
-        httpResponseCallback.onResult(
-            HttpResponse(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN, HttpResponseTiming(0, 0)), null
-        )
-
+        val expectedConfigUrl = "https://example.com/config?configVersion=3"
         verify {
-            configurationCache.putConfiguration(
-                any<Configuration>(),
-                authorization,
-                "https://example.com/config?configVersion=3"
-            )
+            configurationCache.putConfiguration(any(), authorization, expectedConfigUrl)
         }
     }
 
     @Test
     fun loadConfiguration_onJSONParsingError_forwardsExceptionToErrorResponseListener() {
-        every { configurationCache.getConfiguration(any(), any()) } returns null
         every { authorization.configUrl } returns "https://example.com/config"
+        every { configurationCache.getConfiguration(any(), any()) } returns null
 
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
-        val callbackSlot = slot<NetworkResponseCallback>()
-        verify {
-            braintreeHttpClient.sendRequest(
-                any(),
-                null,
-                authorization,
-                capture(callbackSlot)
-            )
-        }
+        val httpResponse = HttpResponse("not json", HttpResponseTiming(0, 0))
+        every {
+            braintreeHttpClient.sendRequestSync(any(), null, authorization)
+        } returns httpResponse
 
-        val httpResponseCallback = callbackSlot.captured
-        httpResponseCallback.onResult(HttpResponse("not json", HttpResponseTiming(0, 0)), null)
+        threadScheduler.flushBackgroundThread()
+        // call back should happen on main thread
+        verify(exactly = 0) { callback.onResult(any()) }
 
+        threadScheduler.flushMainThread()
         val responseSlot = slot<ConfigurationLoaderResponse>()
         verify { callback.onResult(capture(responseSlot)) }
 
         val response = responseSlot.captured
         assertNull(response.configuration)
-        assertTrue(response.error is JSONException)
+        assertTrue(response.error?.cause is JSONException)
         assertNull(response.timing)
     }
 
     @Test
     fun loadConfiguration_onHttpError_forwardsExceptionToErrorResponseListener() {
-        every { configurationCache.getConfiguration(any(), any()) } returns null
         every { authorization.configUrl } returns "https://example.com/config"
+        every { configurationCache.getConfiguration(any(), any()) } returns null
 
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
-        val callbackSlot = slot<NetworkResponseCallback>()
-        verify {
-            braintreeHttpClient.sendRequest(
-                any(),
-                null,
-                authorization,
-                capture(callbackSlot)
-            )
-        }
-
-        val httpResponseCallback = callbackSlot.captured
         val httpError = Exception("http error")
-        httpResponseCallback.onResult(null, httpError)
+        every {
+            braintreeHttpClient.sendRequestSync(any(), null, authorization)
+        } throws httpError
 
+        threadScheduler.flushBackgroundThread()
+        // call back should happen on main thread
+        verify(exactly = 0) { callback.onResult(any()) }
+
+        threadScheduler.flushMainThread()
         val responseSlot = slot<ConfigurationLoaderResponse>()
         verify { callback.onResult(capture(responseSlot)) }
 
@@ -174,7 +169,7 @@ class ConfigurationLoaderUnitTest {
     @Test
     fun loadConfiguration_whenInvalidToken_forwardsExceptionToCallback() {
         val authorization: Authorization = InvalidAuthorization("invalid", "token invalid")
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
         val responseSlot = slot<ConfigurationLoaderResponse>()
@@ -193,19 +188,26 @@ class ConfigurationLoaderUnitTest {
     fun loadConfiguration_whenCachedConfigurationAvailable_loadsConfigurationFromCache() {
         every { authorization.configUrl } returns "https://example.com/config"
         every { authorization.bearer } returns "bearer"
-        every {
-            configurationCache.getConfiguration(authorization, "https://example.com/config")
-        } returns Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
 
-        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache)
+        val cachedConfiguration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
+        every {
+            configurationCache.getConfiguration(authorization, "https://example.com/config?configVersion=3")
+        } returns cachedConfiguration
+
+        val sut = ConfigurationLoader(braintreeHttpClient, configurationCache, threadScheduler)
         sut.loadConfiguration(authorization, callback)
 
+        threadScheduler.flushBackgroundThread()
+        // call back should happen on main thread
+        verify(exactly = 0) { callback.onResult(any()) }
+
+        threadScheduler.flushMainThread()
         val responseSlot = slot<ConfigurationLoaderResponse>()
         verify { callback.onResult(capture(responseSlot)) }
 
         verify(exactly = 0) { braintreeHttpClient.sendRequestSync(any(), null, authorization) }
         val response = responseSlot.captured
-        assertNotNull(response.configuration)
+        assertSame(cachedConfiguration, response.configuration)
         assertNull(response.error)
         assertNull(response.timing)
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -3,7 +3,9 @@ package com.braintreepayments.api.core
 import com.braintreepayments.api.sharedutils.HttpResponse
 import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
+import com.braintreepayments.api.sharedutils.Scheduler
 import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.MockThreadScheduler
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -25,6 +27,7 @@ class ConfigurationLoaderUnitTest {
     private lateinit var braintreeHttpClient: BraintreeHttpClient
     private lateinit var callback: ConfigurationLoaderCallback
     private lateinit var authorization: Authorization
+    private lateinit var threadScheduler: Scheduler
 
     @Before
     fun beforeEach() {
@@ -32,6 +35,7 @@ class ConfigurationLoaderUnitTest {
         braintreeHttpClient = mockk(relaxed = true)
         callback = mockk(relaxed = true)
         authorization = mockk(relaxed = true)
+        threadScheduler = MockThreadScheduler()
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/MockkConfigurationLoaderBuilder.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/MockkConfigurationLoaderBuilder.kt
@@ -23,9 +23,9 @@ internal class MockkConfigurationLoaderBuilder {
         every { configurationLoader.loadConfiguration(any(), any()) } answers {
             val callback = secondArg<ConfigurationLoaderCallback>()
             if (configuration != null) {
-                callback.onResult(configuration, null, null)
+                callback.onResult(ConfigurationLoaderResponse(configuration = configuration))
             } else if (configurationError != null) {
-                callback.onResult(null, configurationError, null)
+                callback.onResult(ConfigurationLoaderResponse(error = configurationError))
             }
         }
         return configurationLoader

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation libs.androidx.test.core
     testImplementation libs.mockito.core
     testImplementation libs.robolectric
+    testImplementation project(':TestUtils')
 
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.junit

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
@@ -8,12 +8,15 @@ import javax.net.ssl.SSLSocketFactory;
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class HttpClient {
 
+    // NOTE: a single thread pool makes the ThreadScheduler behave like a serial dispatch queue
+    private static final int THREAD_POOL_SIZE = 1;
+
     private final Scheduler scheduler;
     private final SynchronousHttpClient syncHttpClient;
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public HttpClient(SSLSocketFactory socketFactory, HttpResponseParser httpResponseParser) {
-        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler(1));
+        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler(THREAD_POOL_SIZE));
     }
 
     @VisibleForTesting

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
@@ -9,14 +9,14 @@ import javax.net.ssl.SSLSocketFactory;
 public class HttpClient {
 
     // NOTE: a single thread pool makes the ThreadScheduler behave like a serial dispatch queue
-    private static final int THREAD_POOL_SIZE = 1;
+    private static final int SERIAL_DISPATCH_QUEUE_POOL_SIZE = 1;
 
     private final Scheduler scheduler;
     private final SynchronousHttpClient syncHttpClient;
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public HttpClient(SSLSocketFactory socketFactory, HttpResponseParser httpResponseParser) {
-        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler(THREAD_POOL_SIZE));
+        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler(SERIAL_DISPATCH_QUEUE_POOL_SIZE));
     }
 
     @VisibleForTesting

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.java
@@ -13,7 +13,7 @@ public class HttpClient {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public HttpClient(SSLSocketFactory socketFactory, HttpResponseParser httpResponseParser) {
-        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler());
+        this(new SynchronousHttpClient(socketFactory, httpResponseParser), new ThreadScheduler(1));
     }
 
     @VisibleForTesting
@@ -23,8 +23,8 @@ public class HttpClient {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public String sendRequest(HttpRequest request) throws Exception {
-        return syncHttpClient.request(request).getBody();
+    public HttpResponse sendRequest(HttpRequest request) throws Exception {
+        return syncHttpClient.request(request);
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Scheduler.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Scheduler.java
@@ -1,6 +1,9 @@
 package com.braintreepayments.api.sharedutils;
 
-interface Scheduler {
+import androidx.annotation.RestrictTo;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public interface Scheduler {
     void runOnMain(Runnable runnable);
     void runOnBackground(Runnable runnable);
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/ThreadScheduler.java
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/ThreadScheduler.java
@@ -3,18 +3,20 @@ package com.braintreepayments.api.sharedutils;
 import android.os.Handler;
 import android.os.Looper;
 
+import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-class ThreadScheduler implements Scheduler {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public class ThreadScheduler implements Scheduler {
 
     private final Handler mainThreadHandler;
     private final ExecutorService backgroundThreadService;
 
-    ThreadScheduler() {
-        this(new Handler(Looper.getMainLooper()), Executors.newCachedThreadPool());
+    public ThreadScheduler(int threadPoolSize) {
+        this(new Handler(Looper.getMainLooper()), Executors.newFixedThreadPool(threadPoolSize));
     }
 
     @VisibleForTesting

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
@@ -109,7 +109,7 @@ public class HttpClientUnitTest {
 
         when(syncHttpClient.request(httpRequest)).thenReturn(response);
 
-        String result = sut.sendRequest(httpRequest);
-        assertEquals("response body", result);
+        HttpResponse result = sut.sendRequest(httpRequest);
+        assertEquals("response body", result.getBody());
     }
 }

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/HttpClientUnitTest.java
@@ -5,10 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+
+import com.braintreepayments.api.testutils.MockThreadScheduler;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockThreadScheduler.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockThreadScheduler.java
@@ -1,16 +1,16 @@
-package com.braintreepayments.api.sharedutils;
+package com.braintreepayments.api.testutils;
 
 import com.braintreepayments.api.sharedutils.Scheduler;
 
 import java.util.ArrayList;
 import java.util.List;
 
-class MockThreadScheduler implements Scheduler {
+public class MockThreadScheduler implements Scheduler {
 
     private final List<Runnable> mainThreadRunnables;
     private final List<Runnable> backgroundThreadRunnables;
 
-    MockThreadScheduler() {
+    public MockThreadScheduler() {
         mainThreadRunnables = new ArrayList<>();
         backgroundThreadRunnables = new ArrayList<>();
     }
@@ -25,11 +25,11 @@ class MockThreadScheduler implements Scheduler {
         backgroundThreadRunnables.add(runnable);
     }
 
-    void flushMainThread() {
+    public void flushMainThread() {
         List<Runnable> remainingRunnables = new ArrayList<>(mainThreadRunnables);
         mainThreadRunnables.clear();
 
-        for (Runnable runnable: remainingRunnables) {
+        for (Runnable runnable : remainingRunnables) {
             runnable.run();
         }
         if (mainThreadRunnables.size() > 0) {
@@ -37,11 +37,11 @@ class MockThreadScheduler implements Scheduler {
         }
     }
 
-    void flushBackgroundThread() {
+    public void flushBackgroundThread() {
         List<Runnable> remainingRunnables = new ArrayList<>(backgroundThreadRunnables);
         backgroundThreadRunnables.clear();
 
-        for (Runnable runnable: remainingRunnables) {
+        for (Runnable runnable : remainingRunnables) {
             runnable.run();
         }
         if (backgroundThreadRunnables.size() > 0) {


### PR DESCRIPTION
**Note:** This PR is Part 4 in a series of refactoring PRs to eliminate `ConfigurationLoader` race conditions.
Previous PR: [#1129 [Fix ConfigurationLoader] Improve ConfigurationCache Encapsulation](https://github.com/braintree/braintree_android/pull/1129)

### Summary of changes

 - This PR moves multi-threading logic into `ConfigurationLoader` to guard against race conditions related to `ConfigurationCache` access
 - We create a background thread to perform synchronous HTTP requests and write to the cache in one atomic cycle
 - Internally we use a single-thread thread pool to behave as a serial dispatch queue
 - Only one request for `Configuration` is processed at a time. Subsequent requests are blocked until the currently active request finishes
 - This results in a single HTTP config request that is cached on success before responding to other config requests 

### Checklist

 - [ ] ~Added a changelog entry~
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire