### PR TITLE
Remove throwing exceptions in LocalPaymentNonce when fields are missing

### DIFF
--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentNonce.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentNonce.kt
@@ -106,11 +106,11 @@ data class LocalPaymentNonce internal constructor(
                 clientMetadataId = clientMetadataId,
                 billingAddress = billingAddress,
                 shippingAddress = shippingAddress,
-                givenName = givenName ?: throw JSONException("givenName is null"),
-                surname = surname ?: throw JSONException("surname is null"),
-                phone = phone ?: throw JSONException("phone is null"),
+                givenName = givenName ?: "",
+                surname = surname ?: "",
+                phone = phone ?: "",
                 email = email,
-                payerId = payerId ?: throw JSONException("payerId is null"),
+                payerId = payerId ?: "",
             )
         }
     }

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentNonceUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentNonceUnitTest.java
@@ -68,25 +68,19 @@ public class LocalPaymentNonceUnitTest {
             new JSONObject(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_MISSING_FIELDS_RESPONSE)
         );
 
-        Parcel parcel = Parcel.obtain();
-        result.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-
-        LocalPaymentNonce parceled = LocalPaymentNonce.CREATOR.createFromParcel(parcel);
-
-        assertNotNull(parceled);
-        assertEquals("141b7583-2922-1ce6-1f2e-f352b69115d6", parceled.getString());
-        assertNull(parceled.getEmail());
-        assertNull(parceled.getShippingAddress().getStreetAddress());
-        assertNull(parceled.getShippingAddress().getExtendedAddress());
-        assertNull(parceled.getShippingAddress().getLocality());
-        assertNull(parceled.getShippingAddress().getRegion());
-        assertNull(parceled.getShippingAddress().getPostalCode());
-        assertNull(parceled.getShippingAddress().getCountryCodeAlpha2());
-        assertNull(parceled.getShippingAddress().getRecipientName());
-        assertEquals("", parceled.getGivenName());
-        assertEquals("", parceled.getSurname());
-        assertEquals("", parceled.getPayerId());
-        assertEquals("c7ce54e0cde5406785b13c99086a9f4c", parceled.getClientMetadataId());
+        assertNotNull(result);
+        assertEquals("141b7583-2922-1ce6-1f2e-f352b69115d6", result.getString());
+        assertNull(result.getEmail());
+        assertNull(result.getShippingAddress().getStreetAddress());
+        assertNull(result.getShippingAddress().getExtendedAddress());
+        assertNull(result.getShippingAddress().getLocality());
+        assertNull(result.getShippingAddress().getRegion());
+        assertNull(result.getShippingAddress().getPostalCode());
+        assertNull(result.getShippingAddress().getCountryCodeAlpha2());
+        assertNull(result.getShippingAddress().getRecipientName());
+        assertEquals("", result.getGivenName());
+        assertEquals("", result.getSurname());
+        assertEquals("", result.getPayerId());
+        assertEquals("c7ce54e0cde5406785b13c99086a9f4c", result.getClientMetadataId());
     }
 }

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentNonceUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentNonceUnitTest.java
@@ -10,6 +10,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 
 import com.braintreepayments.api.testutils.Fixtures;
 
@@ -59,5 +60,33 @@ public class LocalPaymentNonceUnitTest {
         assertEquals("Doe", parceled.getSurname());
         assertEquals("9KQSUZTL7YZQ4", parceled.getPayerId());
         assertEquals("084afbf1db15445587d30bc120a23b09", parceled.getClientMetadataId());
+    }
+
+    @Test
+    public void when_fromJSON_is_called_missing_fields_default_to_an_empty_string() throws JSONException {
+        LocalPaymentNonce result = LocalPaymentNonce.fromJSON(
+            new JSONObject(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_MISSING_FIELDS_RESPONSE)
+        );
+
+        Parcel parcel = Parcel.obtain();
+        result.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        LocalPaymentNonce parceled = LocalPaymentNonce.CREATOR.createFromParcel(parcel);
+
+        assertNotNull(parceled);
+        assertEquals("141b7583-2922-1ce6-1f2e-f352b69115d6", parceled.getString());
+        assertNull(parceled.getEmail());
+        assertNull(parceled.getShippingAddress().getStreetAddress());
+        assertNull(parceled.getShippingAddress().getExtendedAddress());
+        assertNull(parceled.getShippingAddress().getLocality());
+        assertNull(parceled.getShippingAddress().getRegion());
+        assertNull(parceled.getShippingAddress().getPostalCode());
+        assertNull(parceled.getShippingAddress().getCountryCodeAlpha2());
+        assertNull(parceled.getShippingAddress().getRecipientName());
+        assertEquals("", parceled.getGivenName());
+        assertEquals("", parceled.getSurname());
+        assertEquals("", parceled.getPayerId());
+        assertEquals("c7ce54e0cde5406785b13c99086a9f4c", parceled.getClientMetadataId());
     }
 }

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
@@ -1589,6 +1589,23 @@ object Fixtures {
         }
     """
 
+    // language=JSON
+    const val PAYMENT_METHODS_LOCAL_PAYMENT_MISSING_FIELDS_RESPONSE = """
+        {
+           "paypalAccounts": [
+              {
+                 "consumed": false,
+                 "description": "PayPal",
+                 "details": {
+                    "correlationId": "c7ce54e0cde5406785b13c99086a9f4c"
+                 },
+                 "nonce": "141b7583-2922-1ce6-1f2e-f352b69115d6",
+                 "type": "PayPalAccount"
+              }
+           ]
+        }
+    """
+
     const val LOCAL_PAYMENT_PLAIN_OBJECT = """
         {
           "type": "PayPalAccount",


### PR DESCRIPTION
### Summary of changes

 - `JSONException("givenName is null")` was getting thrown in the demo app since the response didn't contain a givenName.
 - Insetead of throwing an exception, the non-null fields are set to an empty string.

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

