### PR TITLE
[Fix Configuration Loader] Migrate Thread Scheduling Logic into BraintreeClient

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -228,6 +228,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     @WorkerThread
     private fun sendHttpRequestSync(
         request: InternalHttpRequest,
@@ -266,6 +267,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
     /**
      * @suppress
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun sendGraphQLPOSTSync(
         json: JSONObject?,
         configuration: Configuration

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClientParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClientParams.kt
@@ -21,7 +21,7 @@ internal data class BraintreeClientParams(
     val uuidHelper: UUIDHelper = UUIDHelper(),
     val configurationLoader: ConfigurationLoader = ConfigurationLoader(context, httpClient),
     val integrationType: IntegrationType,
-    val threadScheduler: Scheduler = ThreadScheduler(1)
+    val threadScheduler: Scheduler = ThreadScheduler(SERIAL_DISPATCH_QUEUE_POOL_SIZE)
 ) {
 
     constructor(options: BraintreeOptions) : this(
@@ -38,6 +38,9 @@ internal data class BraintreeClientParams(
         "${getAppPackageNameWithoutUnderscores(context)}.braintree.deeplinkhandler"
 
     companion object {
+        // NOTE: a single thread pool makes the ThreadScheduler behave like a serial dispatch queue
+        const val SERIAL_DISPATCH_QUEUE_POOL_SIZE = 1
+
         private fun createUniqueSessionId() = UUIDHelper().formattedUUID
 
         private fun getAppPackageNameWithoutUnderscores(context: Context) =

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClientParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClientParams.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.Uri
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.sharedutils.ManifestValidator
+import com.braintreepayments.api.sharedutils.Scheduler
+import com.braintreepayments.api.sharedutils.ThreadScheduler
 
 internal data class BraintreeClientParams(
     val context: Context,
@@ -19,6 +21,7 @@ internal data class BraintreeClientParams(
     val uuidHelper: UUIDHelper = UUIDHelper(),
     val configurationLoader: ConfigurationLoader = ConfigurationLoader(context, httpClient),
     val integrationType: IntegrationType,
+    val threadScheduler: Scheduler = ThreadScheduler(1)
 ) {
 
     constructor(options: BraintreeOptions) : this(

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.core
 import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpMethod
 import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.HttpResponse
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
 import com.braintreepayments.api.sharedutils.TLSSocketFactory
 import java.util.Locale
@@ -65,7 +66,7 @@ internal class BraintreeGraphQLClient(
         data: String?,
         configuration: Configuration,
         authorization: Authorization
-    ): String {
+    ): HttpResponse {
         if (authorization is InvalidAuthorization) {
             val message = authorization.errorMessage
             throw BraintreeException(message)
@@ -79,7 +80,7 @@ internal class BraintreeGraphQLClient(
             .addHeader("Authorization",
                 String.format(Locale.US, "Bearer %s", authorization.bearer))
             .addHeader("Braintree-Version", GraphQLConstants.Headers.API_VERSION)
-        return httpClient.sendRequest(request).body ?: ""
+        return httpClient.sendRequest(request)
     }
 
     companion object {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import org.json.JSONException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -91,7 +92,7 @@ class BraintreeGraphQLClientUnitTest {
 
         val sut = BraintreeGraphQLClient(httpClient)
         val result = sut.post("sample/path", "data", configuration, authorization)
-        assertEquals("sample response", result)
+        assertSame(httpResponse, result)
 
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://example-graphql.com/graphql/sample/path"), httpRequest.url)


### PR DESCRIPTION
**Note:** This PR is Part 5 in a series of refactoring PRs to eliminate `ConfigurationLoader` race conditions.
Previous PR: [#1133 [Fix Configuration Loader] Prevent Race Condition](https://github.com/braintree/braintree_android/pull/1133)

### Summary of changes

 - This PR migrates multi-threading logic into BraintreeClient to set up an eventual easy migration to coroutines
 - In the future, we can leverage co-routines to reduce the SDK's responsibility to create background threads.
 - Upcoming Tasks to finish Fix Configuration Loader PR series:
   - Remove `HttpClient` and make all networking clients thread synchronous by default
   - Implement retry logic in `ConfigurationLoader`

### Checklist

 - [ ] ~Added a changelog entry~
 - [x] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire