### PR TITLE
Fix isSimulator analytics param

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/DeviceInspector.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/DeviceInspector.kt
@@ -63,10 +63,23 @@ internal class DeviceInspector(
     }
 
     private val isDeviceEmulator: Boolean
-        get() = "google_sdk".equals(Build.PRODUCT, ignoreCase = true) ||
-                "sdk".equals(Build.PRODUCT, ignoreCase = true) ||
-                "Genymotion".equals(Build.MANUFACTURER, ignoreCase = true) ||
-                Build.FINGERPRINT.contains("generic")
+        get() = Build.BRAND.startsWith("generic") &&
+            Build.DEVICE.startsWith("generic") ||
+            Build.FINGERPRINT.startsWith("generic") ||
+            Build.FINGERPRINT.startsWith("unknown") ||
+            Build.HARDWARE.contains("goldfish") ||
+            Build.HARDWARE.contains("ranchu") ||
+            Build.MODEL.contains("google_sdk") ||
+            Build.MODEL.contains("Emulator") ||
+            Build.MODEL.contains("Android SDK built for x86") ||
+            Build.MANUFACTURER.contains("Genymotion") ||
+            Build.PRODUCT.contains("sdk_google") ||
+            Build.PRODUCT.contains("google_sdk") ||
+            Build.PRODUCT.contains("sdk") ||
+            Build.PRODUCT.contains("sdk_x86") ||
+            Build.PRODUCT.contains("vbox86p") ||
+            Build.PRODUCT.contains("emulator") ||
+            Build.PRODUCT.contains("simulator")
 
     private fun getAppName(context: Context?): String =
         getApplicationInfo(context)?.let { appInfo ->

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
@@ -158,6 +158,87 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildFingerpintContainsGeneric_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "FINGERPRINT", "generic")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildFingerpintContainsUnknown_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "FINGERPRINT", "unknown")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenHardwareContainsGoldfish_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "HARDWARE", "goldfish")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenHardwareContainsRanchu_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "HARDWARE", "ranchu")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenHardwareModelGoogleSDK_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "google_sdk")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenHardwareModelEmulator_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Emulator")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenHardwareModelAndroidSDKBuiltForX86_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Android SDK built for x86")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildManufacturerIsGenymotion_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Genymotion")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildProductIsSdkGoogle_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "sdk_google")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
     fun getDeviceMetadata_whenBuildProductIsGoogleSdk_returnsTrueForIsSimulator() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "google_sdk")
         val metadata =
@@ -176,8 +257,8 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildManufacturerIsGenymotion_returnsTrueForIsSimulator() {
-        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Genymotion")
+    fun getDeviceMetadata_whenBuildProductIssdkx86_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "sdk_x86")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertTrue(metadata.isSimulator)
@@ -185,8 +266,26 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildFingerpintContainsGeneric_returnsTrueForIsSimulator() {
-        ReflectionHelpers.setStaticField(Build::class.java, "FINGERPRINT", "generic")
+    fun getDeviceMetadata_whenBuildProductIsVbox86p_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "vbox86p")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildProductIsEmulator_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "emulator")
+        val metadata =
+            sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
+        assertTrue(metadata.isSimulator)
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun getDeviceMetadata_whenBuildProductIsSimulator_returnsTrueForIsSimulator() {
+        ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "simulator")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertTrue(metadata.isSimulator)


### PR DESCRIPTION
### Summary of changes

 - Update the logic for the `isSimulator` analytics param - the logic was grabbed from this flutter plugin: https://github.com/fluttercommunity/plus_plugins/blob/bfcd3e19cb457178c5f69c5cf146a8fd8b2dec44/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt#L110-L125

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

