### PR TITLE
PayPal Account Locked Error

### DIFF
--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLResponseParserUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLResponseParserUnitTest.kt
@@ -9,8 +9,11 @@ import io.mockk.mockk
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.net.HttpURLConnection
 
+@RunWith(RobolectricTestRunner::class)
 class BraintreeGraphQLResponseParserUnitTest {
 
     private lateinit var urlConnection: HttpURLConnection

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ErrorsWithResponseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ErrorsWithResponseUnitTest.kt
@@ -52,10 +52,21 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
+    fun constructor_parsesApiErrorResponseCorrectly() {
+        val response = Fixtures.ERRORS_BRAINTREE_API_ERROR_RESPONSE
+        val errorWithResponse = ErrorWithResponse(422, response)
+        assertEquals(
+            "The provided parameters are invalid; see details for field-specific error messages.",
+            errorWithResponse.message
+        )
+        assertEquals(422, errorWithResponse.statusCode)
+    }
+
+    @Test
     fun constructor_doesNotBlowUpParsingBadJson() {
         val badJson = Fixtures.RANDOM_JSON
         val errorWithResponse = ErrorWithResponse(422, badJson)
-        assertEquals("Parsing error response failed", errorWithResponse.message)
+        assertEquals(null, errorWithResponse.message)
     }
 
     @Test
@@ -117,10 +128,21 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
+    fun fromGraphQLJson_parsesApiErrorResponseCorrectly() {
+        val response = Fixtures.ERRORS_BRAINTREE_API_ERROR_RESPONSE
+        val errorWithResponse = ErrorWithResponse.fromGraphQLJson(response)
+        assertEquals(
+            "The provided parameters are invalid; see details for field-specific error messages.",
+            errorWithResponse.message
+        )
+        assertEquals(422, errorWithResponse.statusCode)
+    }
+
+    @Test
     fun fromGraphQLJson_doesNotBlowUpParsingBadJson() {
         val badJson = Fixtures.RANDOM_JSON
         val errorWithResponse = ErrorWithResponse.fromGraphQLJson(badJson)
-        assertEquals("Parsing error response failed", errorWithResponse.message)
+        assertEquals(null, errorWithResponse.message)
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Error : iOS received a proper USER_ACCOUNT_LOCKED error message, but on Android received a more generic "Parsing error response failed" message.
 - Handled error similar to iOS.
 - Used LoggingUtils to track exceptions
 - Return null if it's bad json.
 - Unit test cases for the existing fixture json response.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

