### PR TITLE
JvmOverloads and Internal Docs Cleanup

### DIFF
--- a/AmericanExpress/src/main/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalance.kt
+++ b/AmericanExpress/src/main/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalance.kt
@@ -20,7 +20,7 @@ import org.json.JSONObject
  * @property rewardsUnit - The rewards unit associated with the rewards balance
  */
 @Parcelize
-data class AmericanExpressRewardsBalance(
+data class AmericanExpressRewardsBalance @JvmOverloads constructor(
     var errorCode: String? = null,
     var errorMessage: String? = null,
     var conversionRate: String? = null,

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/AnalyticsClientTest.kt
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/AnalyticsClientTest.kt
@@ -41,7 +41,7 @@ class AnalyticsClientTest {
         val event = AnalyticsEvent("event.started")
         val sut = AnalyticsClient(context)
         val workSpecId =
-            sut.sendEvent(configuration, event, "sessionId", IntegrationType.CUSTOM, authorization)
+            sut.sendEvent(configuration, event, IntegrationType.CUSTOM, authorization)
 
         val workInfoBeforeDelay =
             WorkManager.getInstance(context).getWorkInfoById(workSpecId).get()

--- a/Card/src/main/java/com/braintreepayments/api/card/Card.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/Card.kt
@@ -49,7 +49,7 @@ import org.json.JSONObject
  * Defaults to custom and does not need to ever be set.
  */
 @Parcelize
-data class Card(
+data class Card @JvmOverloads constructor(
     var merchantAccountId: String? = null,
     var isAuthenticationInsightRequested: Boolean = false,
     var shouldValidate: Boolean = false,

--- a/Card/src/main/java/com/braintreepayments/api/card/CardClient.kt
+++ b/Card/src/main/java/com/braintreepayments/api/card/CardClient.kt
@@ -16,7 +16,7 @@ import org.json.JSONObject
  * Used to tokenize credit or debit cards using a [Card]. For more information see the
  * [documentation](https://developer.paypal.com/braintree/docs/guides/credit-cards/overview)
  */
-class CardClient @VisibleForTesting internal constructor(
+class CardClient @VisibleForTesting @JvmOverloads internal constructor(
     private val braintreeClient: BraintreeClient,
     private val apiClient: ApiClient = ApiClient(braintreeClient),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance

--- a/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayPaymentAuthRequest.kt
+++ b/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayPaymentAuthRequest.kt
@@ -5,8 +5,11 @@ package com.braintreepayments.api.googlepay
  */
 sealed class GooglePayPaymentAuthRequest {
 
+    // TODO: make requestParams internal when GooglePayClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [GooglePayLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
     class ReadyToLaunch(val requestParams: GooglePayPaymentAuthRequestParams) : GooglePayPaymentAuthRequest()
 

--- a/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayRequest.kt
+++ b/GooglePay/src/main/java/com/braintreepayments/api/googlepay/GooglePayRequest.kt
@@ -59,7 +59,7 @@ import java.util.Locale
  */
 @Suppress("TooManyFunctions")
 @Parcelize
-class GooglePayRequest(
+class GooglePayRequest @JvmOverloads constructor(
     // NEXT_MAJOR_VERSION: allow merchants to set transaction info params individually and build
     // JSON object under the hood
     var transactionInfo: TransactionInfo? = null,

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentAuthRequest.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentAuthRequest.kt
@@ -5,8 +5,11 @@ package com.braintreepayments.api.localpayment
  */
 sealed class LocalPaymentAuthRequest {
 
+    // TODO: make requestParams internal when LocalPaymentClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [LocalPaymentLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
     class ReadyToLaunch(val requestParams: LocalPaymentAuthRequestParams) :
         LocalPaymentAuthRequest()

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthRequest.kt
@@ -5,11 +5,12 @@ package com.braintreepayments.api.paypal
  */
 sealed class PayPalPaymentAuthRequest {
 
+    // TODO: make requestParams internal when PayPalClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [PayPalLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
-    // TODO: requestParams should be internal but can't be until PayPalClientUnitTest is converted
-    //  to Kotlin (same for all modules with ReadyToLaunch request)
     class ReadyToLaunch(val requestParams: PayPalPaymentAuthRequestParams) :
         PayPalPaymentAuthRequest()
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequest.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthRequest.kt
@@ -5,8 +5,11 @@ package com.braintreepayments.api.sepadirectdebit
  */
 sealed class SEPADirectDebitPaymentAuthRequest {
 
+    // TODO: make requestParams internal when SEPADirectDebitClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [SEPADirectDebitLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
     class ReadyToLaunch(val requestParams: SEPADirectDebitPaymentAuthRequestParams) :
         SEPADirectDebitPaymentAuthRequest()

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequest.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequest.kt
@@ -16,7 +16,7 @@ import com.braintreepayments.api.core.PostalAddress
  * @see [Documentation](https://developer.paypal.com/reference/locale-codes/)
  * for possible values. Locale code should be supplied as a BCP-47 formatted locale code.
  */
-data class SEPADirectDebitRequest internal constructor(
+data class SEPADirectDebitRequest @JvmOverloads constructor(
     var accountHolderName: String? = null,
     var iban: String? = null,
     var customerId: String? = null,

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecurePaymentAuthRequest.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecurePaymentAuthRequest.kt
@@ -5,8 +5,11 @@ package com.braintreepayments.api.threedsecure
  */
 sealed class ThreeDSecurePaymentAuthRequest {
 
+    // TODO: make requestParams internal when ThreeDSecureClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [ThreeDSecureLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
     class ReadyToLaunch(val requestParams: ThreeDSecureParams) :
         ThreeDSecurePaymentAuthRequest()

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
@@ -50,7 +50,7 @@ import org.json.JSONObject
  * which trigger on certain values.
  */
 @Parcelize
-data class ThreeDSecureRequest(
+data class ThreeDSecureRequest @JvmOverloads constructor(
     var nonce: String? = null,
     var amount: String? = null,
     var mobilePhoneNumber: String? = null,

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoPaymentAuthRequest.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoPaymentAuthRequest.kt
@@ -5,8 +5,11 @@ package com.braintreepayments.api.venmo
  */
 sealed class VenmoPaymentAuthRequest {
 
+    // TODO: make requestParams internal when VenmoClientUnitTest is converted to Kotlin
     /**
      * The request was successfully created and is ready to be launched by [VenmoLauncher]
+     * @param requestParams this parameter is intended for internal use only. It is not covered by
+     * semantic versioning and may be changed or removed at any time.
      */
     class ReadyToLaunch(val requestParams: VenmoPaymentAuthRequestParams) : VenmoPaymentAuthRequest()
 


### PR DESCRIPTION
### Summary of changes

 - Add doc strings noting that `requestParams` are internal so that they can be made internal when we have completed Kotlin unit test conversion
 - Add JvmOverloads annotations to public request objects
 - Fix some broken integration tests

### Checklist

 - ~[ ] Added a changelog entry~
 - [x] Relevant test coverage

### Authors

@sarahkoop 
