### PR TITLE
[QL] Make Amount Optional in `PayPalBillingPricing`

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingPricing.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingPricing.kt
@@ -14,14 +14,14 @@ import org.json.JSONObject
 @Parcelize
 data class PayPalBillingPricing @JvmOverloads constructor(
     val pricingModel: PayPalPricingModel,
-    val amount: String,
+    val amount: String? = null,
     var reloadThresholdAmount: String? = null
 ) : Parcelable {
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
             put(KEY_PRICING_MODEL, pricingModel.name)
-            put(KEY_AMOUNT, amount)
+            putOpt(KEY_AMOUNT, amount)
             putOpt(KEY_RELOAD_THRESHOLD_AMOUNT, reloadThresholdAmount)
         }
     }


### PR DESCRIPTION
### Summary of changes

 - End to end testing revealed that there are cases where amount is not required for RBA metadata in the `BTPayPalBillingPricing` - updated and tested that this can be omitted without error

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors

@jaxdesmarais 