### PR TITLE
Rename handleReturnToAppFromBrowser to handleReturnToApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@
   * PayPal
     * Make `PayPalPaymentAuthRequestParams` internal
     * Remove `PayPalPaymentAuthResultInfo`
+    * Rename `PayPalLauncher.handleReturnToAppFromBrowser()` to `PayPalLauncher.handleReturnToApp()`
   * SEPADirectDebit
     * Make `SEPADirectDebitPaymentAuthRequestParams` internal
     * Remove `SEPADirectDebitPaymentAuthResultInfo`
+    * Rename `SEPADirectDebitLauncher.handleReturnToAppFromBrowser()` to `SEPADirectDebitLauncher.handleReturnToApp()`
   * ThreeDSecure
     * Make `ThreeDSecureParams` internal
     * Make `ThreeDSecurePaymentAuthResult` parameters internal
@@ -33,6 +35,7 @@
   * LocalPayment
     * Remove `LocalPaymentAuthResultInfo`
     * Make `LocalPaymentAuthRequestParams` internal
+    * Rename `LocalPaymentLauncher.handleReturnToAppFromBrowser()` to `LocalPaymentLauncher.handleReturnToApp()`
 
 ## 5.0.0-beta2 (2024-08-28)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/LocalPaymentFragment.java
@@ -46,7 +46,7 @@ public class LocalPaymentFragment extends BaseFragment {
         LocalPaymentPendingRequest.Started pendingRequest = getPendingRequest();
         if (getPendingRequest() != null) {
             LocalPaymentAuthResult paymentAuthResult =
-                    localPaymentLauncher.handleReturnToAppFromBrowser(pendingRequest,
+                    localPaymentLauncher.handleReturnToApp(pendingRequest,
                             requireActivity().getIntent());
             if (paymentAuthResult instanceof LocalPaymentAuthResult.Success) {
                 localPaymentClient.tokenize(requireContext(),

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -26,7 +26,6 @@ import com.braintreepayments.api.paypal.PayPalPaymentAuthResult;
 import com.braintreepayments.api.paypal.PayPalPendingRequest;
 import com.braintreepayments.api.paypal.PayPalRequest;
 import com.braintreepayments.api.paypal.PayPalResult;
-import com.braintreepayments.api.sharedutils.AppHelper;
 import com.google.android.material.textfield.TextInputEditText;
 
 public class PayPalFragment extends BaseFragment {
@@ -71,7 +70,7 @@ public class PayPalFragment extends BaseFragment {
         super.onResume();
         PayPalPendingRequest.Started pendingRequest = getPendingRequest();
         if (pendingRequest != null) {
-            PayPalPaymentAuthResult paymentAuthResult = payPalLauncher.handleReturnToAppFromBrowser(pendingRequest, requireActivity().getIntent());
+            PayPalPaymentAuthResult paymentAuthResult = payPalLauncher.handleReturnToApp(pendingRequest, requireActivity().getIntent());
             if (paymentAuthResult instanceof PayPalPaymentAuthResult.Success) {
                 completePayPalFlow((PayPalPaymentAuthResult.Success) paymentAuthResult);
             } else {

--- a/Demo/src/main/java/com/braintreepayments/demo/SEPADirectDebitFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/SEPADirectDebitFragment.java
@@ -49,7 +49,7 @@ public class SEPADirectDebitFragment extends BaseFragment {
         SEPADirectDebitPendingRequest.Started pendingRequest = getPendingRequest();
         if (pendingRequest != null) {
             SEPADirectDebitPaymentAuthResult paymentAuthResult =
-                    sepaDirectDebitLauncher.handleReturnToAppFromBrowser(pendingRequest,
+                    sepaDirectDebitLauncher.handleReturnToApp(pendingRequest,
                             requireActivity().getIntent());
             if (paymentAuthResult instanceof SEPADirectDebitPaymentAuthResult.Success) {
                 completeSEPAFlow((SEPADirectDebitPaymentAuthResult.Success) paymentAuthResult);

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -106,7 +106,7 @@ class ShopperInsightsFragment : BaseFragment() {
     private fun handlePayPalReturnToApp() {
         if (this::paypalStartedPendingRequest.isInitialized) {
             val paypalPaymentAuthResult =
-                paypalLauncher.handleReturnToAppFromBrowser(paypalStartedPendingRequest, requireActivity().intent)
+                paypalLauncher.handleReturnToApp(paypalStartedPendingRequest, requireActivity().intent)
             if (paypalPaymentAuthResult is PayPalPaymentAuthResult.Success) {
                 payPalClient.tokenize(paypalPaymentAuthResult) {
                     when (it) {

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentAuthResult.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentAuthResult.kt
@@ -3,7 +3,7 @@ package com.braintreepayments.api.localpayment
 import com.braintreepayments.api.BrowserSwitchFinalResult
 
 /**
- * Result of the local payment web flow received from [LocalPaymentLauncher.handleReturnToAppFromBrowser].
+ * Result of the local payment web flow received from [LocalPaymentLauncher.handleReturnToApp].
  */
 sealed class LocalPaymentAuthResult {
 
@@ -22,7 +22,7 @@ sealed class LocalPaymentAuthResult {
 
     /**
      * If no matching result can be found for the [LocalPaymentPendingRequest.Started] passed to
-     * [LocalPaymentLauncher.handleReturnToAppFromBrowser]. This is expected if the user closed the
+     * [LocalPaymentLauncher.handleReturnToApp]. This is expected if the user closed the
      * browser to cancel the payment flow, or returns to the app without completing the
      * authentication flow.
      */

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentClient.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentClient.kt
@@ -151,13 +151,13 @@ class LocalPaymentClient internal constructor(
 
     /**
      * After receiving a result from the web authentication flow via
-     * [LocalPaymentLauncher.handleReturnToAppFromBrowser], pass the
+     * [LocalPaymentLauncher.handleReturnToApp], pass the
      * [LocalPaymentAuthResult.Success] returned to this method to tokenize the local
      * payment method and receive a [LocalPaymentNonce] on success.
      *
      * @param context Android Context
      * @param localPaymentAuthResult a [LocalPaymentAuthResult.Success] received from
-     * [LocalPaymentLauncher.handleReturnToAppFromBrowser]
+     * [LocalPaymentLauncher.handleReturnToApp]
      * @param callback [LocalPaymentInternalTokenizeCallback]
      */
     fun tokenize(

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentLauncher.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentLauncher.kt
@@ -24,9 +24,8 @@ class LocalPaymentLauncher internal constructor(private val browserSwitchClient:
      * [LocalPaymentClient.createPaymentAuthRequest]
      * @return [LocalPaymentPendingRequest] a [LocalPaymentPendingRequest.Started] should
      * be stored to complete the flow upon return to app in
-     * [LocalPaymentLauncher.handleReturnToAppFromBrowser],
-     * or a [LocalPaymentPendingRequest.Failure] with an error if the local payment flow was
-     * unable to be launched in a browser.
+     * [LocalPaymentLauncher.handleReturnToApp], or a [LocalPaymentPendingRequest.Failure]
+     * with an error if the local payment flow was unable to be launched in a browser.
      */
     fun launch(
         activity: ComponentActivity,
@@ -49,7 +48,7 @@ class LocalPaymentLauncher internal constructor(private val browserSwitchClient:
     }
 
     /**
-     * Captures and delivers the result of a the browser-based local payment authentication flow.
+     * Captures and delivers the result of a local payment authentication flow.
      *
      * For most integrations, this method should be invoked in the onResume method of the Activity
      * used to invoke [LocalPaymentLauncher.launch].
@@ -61,13 +60,12 @@ class LocalPaymentLauncher internal constructor(private val browserSwitchClient:
      * @param pendingRequest the [LocalPaymentPendingRequest.Started] stored after successfully
      * invoking [LocalPaymentLauncher.launch]
      * @param intent  the intent to return to your application containing a deep link result
-     * from the local payment browser flow
+     * from the local payment flow
      * @return a [LocalPaymentAuthResult.Success] that should be passed to
      * [LocalPaymentClient.tokenize] to complete the flow, or [LocalPaymentAuthResult.NoResult] if
-     * the user closed the browser to cancel the payment flow, or returned to the app without
-     * completing the authentication flow.
+     * the user canceled the payment flow, or returned to the app without completing the authentication flow.
      */
-    fun handleReturnToAppFromBrowser(
+    fun handleReturnToApp(
         pendingRequest: LocalPaymentPendingRequest.Started,
         intent: Intent
     ): LocalPaymentAuthResult {

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentPendingRequest.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentPendingRequest.kt
@@ -4,7 +4,7 @@ package com.braintreepayments.api.localpayment
  * A pending request for the local payment web-based authentication flow created by invoking
  * [LocalPaymentLauncher.launch]. This pending request should be stored locally within the app or
  * on-device and used to deliver a result of the browser flow in
- * [LocalPaymentLauncher.handleReturnToAppFromBrowser]
+ * [LocalPaymentLauncher.handleReturnToApp]
  */
 sealed class LocalPaymentPendingRequest {
 
@@ -12,7 +12,7 @@ sealed class LocalPaymentPendingRequest {
      * A pending request was successfully started.
      *
      * @property pendingRequestString - This String should be stored and passed to
-     * [LocalPaymentLauncher.handleReturnToAppFromBrowser].
+     * [LocalPaymentLauncher.handleReturnToApp].
      */
     class Started internal constructor(val pendingRequestString: String) : LocalPaymentPendingRequest()
 

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentLauncherUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentLauncherUnitTest.kt
@@ -68,7 +68,7 @@ class LocalPaymentLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser on BrowserSwitchResult returns result`() {
+    fun `handleReturnToApp on BrowserSwitchResult returns result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         val pendingRequest: LocalPaymentPendingRequest.Started =
             LocalPaymentPendingRequest.Started(pendingRequestString)
@@ -76,7 +76,7 @@ class LocalPaymentLauncherUnitTest {
             browserSwitchClient.completeRequest(eq(intent), eq(pendingRequestString))
         } returns browserSwitchFinalResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(pendingRequest, intent)
+        val paymentAuthResult = sut.handleReturnToApp(pendingRequest, intent)
 
         assertTrue(paymentAuthResult is LocalPaymentAuthResult.Success)
         assertSame(
@@ -86,14 +86,14 @@ class LocalPaymentLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser when no BrowserSwitchResult returns null`() {
+    fun `handleReturnToApp when no BrowserSwitchResult returns null`() {
         val pendingRequest: LocalPaymentPendingRequest.Started =
             LocalPaymentPendingRequest.Started(pendingRequestString)
         every {
             browserSwitchClient.completeRequest(eq(intent), eq(pendingRequestString))
         } returns BrowserSwitchFinalResult.NoResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(pendingRequest, intent)
+        val paymentAuthResult = sut.handleReturnToApp(pendingRequest, intent)
 
         assertTrue(paymentAuthResult is LocalPaymentAuthResult.NoResult)
     }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -143,12 +143,12 @@ class PayPalClient internal constructor(
 
     /**
      * After receiving a result from the PayPal web authentication flow via
-     * [PayPalLauncher.handleReturnToAppFromBrowser],
+     * [PayPalLauncher.handleReturnToApp],
      * pass the [PayPalPaymentAuthResult.Success] returned to this method to tokenize the PayPal
      * account and receive a [PayPalAccountNonce] on success.
      *
      * @param paymentAuthResult a [PayPalPaymentAuthResult.Success] received in the callback
-     * from  [PayPalLauncher.handleReturnToAppFromBrowser]
+     * from  [PayPalLauncher.handleReturnToApp]
      * @param callback          [PayPalTokenizeCallback]
      */
     @Suppress("SwallowedException")

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -25,7 +25,7 @@ class PayPalLauncher internal constructor(private val browserSwitchClient: Brows
      * calling [PayPalClient.createPaymentAuthRequest]
      * @return [PayPalPendingRequest] a [PayPalPendingRequest.Started] should be stored
      * to complete the flow upon return to app in
-     * [PayPalLauncher.handleReturnToAppFromBrowser],
+     * [PayPalLauncher.handleReturnToApp],
      * or a [PayPalPendingRequest.Failure] with an error if the PayPal flow was unable to be
      * launched in a browser.
      */
@@ -50,7 +50,7 @@ class PayPalLauncher internal constructor(private val browserSwitchClient: Brows
     }
 
     /**
-     * Captures and delivers the result of a the browser-based PayPal authentication flow.
+     * Captures and delivers the result of a PayPal authentication flow.
      *
      * For most integrations, this method should be invoked in the onResume method of the Activity
      * used to invoke
@@ -66,10 +66,10 @@ class PayPalLauncher internal constructor(private val browserSwitchClient: Brows
      * from the PayPal browser flow
      * @return a [PayPalPaymentAuthResult.Success] that should be passed to [PayPalClient.tokenize]
      * to complete the PayPal payment flow. Returns [PayPalPaymentAuthResult.NoResult] if the user
-     * closed the browser to cancel the payment flow, or returned to the app without completing the
-     * PayPal authentication flow.
+     * canceled the payment flow, or returned to the app without completing the PayPal
+     * authentication flow.
      */
-    fun handleReturnToAppFromBrowser(
+    fun handleReturnToApp(
         pendingRequest: PayPalPendingRequest.Started,
         intent: Intent
     ): PayPalPaymentAuthResult {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
@@ -3,7 +3,7 @@ package com.braintreepayments.api.paypal
 import com.braintreepayments.api.BrowserSwitchFinalResult
 
 /**
- * Result of the PayPal web flow received from [PayPalLauncher.handleReturnToAppFromBrowser].
+ * Result of the PayPal web flow received from [PayPalLauncher.handleReturnToApp].
  */
 sealed class PayPalPaymentAuthResult {
 
@@ -22,7 +22,7 @@ sealed class PayPalPaymentAuthResult {
 
     /**
      * If no matching result can be found for the [PayPalPendingRequest.Started] passed to
-     * [PayPalLauncher.handleReturnToAppFromBrowser]. This is expected if the user closed the
+     * [PayPalLauncher.handleReturnToApp]. This is expected if the user closed the
      * browser to cancel the payment flow, or returns to the app without completing the
      * authentication flow.
      */

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPendingRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPendingRequest.kt
@@ -4,7 +4,7 @@ package com.braintreepayments.api.paypal
  * A pending request for the PayPal web-based authentication flow created by invoking
  * [PayPalLauncher.launch]. This pending request should be stored locally within the app or
  * on-device and used to deliver a result of the browser flow in
- * [PayPalLauncher.handleReturnToAppFromBrowser]
+ * [PayPalLauncher.handleReturnToApp]
  */
 sealed class PayPalPendingRequest {
 
@@ -12,7 +12,7 @@ sealed class PayPalPendingRequest {
      * A pending request was successfully started.
      *
      * @property pendingRequestString - This String should be stored and passed to
-     * [PayPalLauncher.handleReturnToAppFromBrowser].
+     * [PayPalLauncher.handleReturnToApp].
      */
     class Started internal constructor(
         val pendingRequestString: String

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -92,7 +92,7 @@ class PayPalLauncherUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `handleReturnToAppFromBrowser when result exists returns result`() {
+    fun `handleReturnToApp when result exists returns result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         every {
             browserSwitchClient.completeRequest(
@@ -101,7 +101,7 @@ class PayPalLauncherUnitTest {
             )
         } returns browserSwitchFinalResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(
+        val paymentAuthResult = sut.handleReturnToApp(
             PayPalPendingRequest.Started(pendingRequestString), intent
         )
 
@@ -114,12 +114,12 @@ class PayPalLauncherUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `handleReturnToAppFromBrowser when result does not exist returns null`() {
+    fun `handleReturnToApp when result does not exist returns null`() {
         every {
             browserSwitchClient.completeRequest(intent, pendingRequestString)
         } returns BrowserSwitchFinalResult.NoResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(
+        val paymentAuthResult = sut.handleReturnToApp(
             PayPalPendingRequest.Started(pendingRequestString), intent
         )
 

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClient.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClient.kt
@@ -105,12 +105,12 @@ class SEPADirectDebitClient internal constructor(
     // TODO: - The wording in this docstring is confusing to me. Let's improve & align across all clients.
     /**
      * After receiving a result from the SEPA mandate web flow via
-     * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser] , pass the
+     * [SEPADirectDebitLauncher.handleReturnToApp] , pass the
      * [SEPADirectDebitPaymentAuthResult.Success] returned to this method to tokenize the SEPA
      * account and receive a [SEPADirectDebitNonce] on success.
      *
      * @param paymentAuthResult a [SEPADirectDebitPaymentAuthResult.Success] received from
-     * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser]
+     * [SEPADirectDebitLauncher.handleReturnToApp]
      * @param callback [SEPADirectDebitInternalTokenizeCallback]
      */
     fun tokenize(

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncher.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncher.kt
@@ -23,7 +23,7 @@ class SEPADirectDebitLauncher internal constructor(private val browserSwitchClie
      * [SEPADirectDebitClient.createPaymentAuthRequest]
      * @return [SEPADirectDebitPendingRequest] a [SEPADirectDebitPendingRequest.Started]
      * should be stored to complete the flow upon return to app in
-     * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser],
+     * [SEPADirectDebitLauncher.handleReturnToApp],
      * or a [SEPADirectDebitPendingRequest.Failure] with an error if the SEPA flow was unable
      * to be launched in a browser.
      */
@@ -44,7 +44,7 @@ class SEPADirectDebitLauncher internal constructor(private val browserSwitchClie
     }
 
     /**
-     * Captures and delivers the result of the browser-based SEPA mandate flow.
+     * Captures and delivers the result of the SEPA mandate flow.
      *
      * For most integrations, this method should be invoked in the onResume method of the Activity
      * used to invoke [SEPADirectDebitLauncher.launch].
@@ -59,10 +59,10 @@ class SEPADirectDebitLauncher internal constructor(private val browserSwitchClie
      * the SEPA mandate flow
      * @return a [SEPADirectDebitPaymentAuthResult.Success] that should be passed to
      * [SEPADirectDebitClient.tokenize] to complete the flow. Returns
-     * [SEPADirectDebitPaymentAuthResult.NoResult] if the user closed the browser to cancel the
-     * payment flow, or returned to the app without completing the authentication flow.
+     * [SEPADirectDebitPaymentAuthResult.NoResult] if the user canceled the payment flow, or
+     * returned to the app without completing the authentication flow.
      */
-    fun handleReturnToAppFromBrowser(
+    fun handleReturnToApp(
         pendingRequest: SEPADirectDebitPendingRequest.Started,
         intent: Intent
     ): SEPADirectDebitPaymentAuthResult {

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResult.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPaymentAuthResult.kt
@@ -3,7 +3,7 @@ package com.braintreepayments.api.sepadirectdebit
 import com.braintreepayments.api.BrowserSwitchFinalResult
 
 /**
- * Result of the SEPA Direct Debit web flow received from [SEPADirectDebitLauncher.handleReturnToAppFromBrowser].
+ * Result of the SEPA Direct Debit web flow received from [SEPADirectDebitLauncher.handleReturnToApp].
  */
 sealed class SEPADirectDebitPaymentAuthResult {
 
@@ -22,7 +22,7 @@ sealed class SEPADirectDebitPaymentAuthResult {
 
     /**
      * If no matching result can be found for the [SEPADirectDebitPendingRequest.Started] passed to
-     * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser]. This is expected if the user closed the
+     * [SEPADirectDebitLauncher.handleReturnToApp]. This is expected if the user closed the
      * browser to cancel the payment flow, or returns to the app without completing the
      * authentication flow.
      */

--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequest.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitPendingRequest.kt
@@ -4,7 +4,7 @@ package com.braintreepayments.api.sepadirectdebit
  * A pending request for the SEPA Direct Debit web-based authentication flow created by invoking
  * [SEPADirectDebitLauncher.launch]. This pending request should be stored locally within the app or
  * on-device and used to deliver a result of the browser flow in
- * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser]
+ * [SEPADirectDebitLauncher.handleReturnToApp]
  */
 sealed class SEPADirectDebitPendingRequest {
 
@@ -12,7 +12,7 @@ sealed class SEPADirectDebitPendingRequest {
      * A pending request was successfully started.
      *
      * @property pendingRequestString - This String should be stored and passed to
-     * [SEPADirectDebitLauncher.handleReturnToAppFromBrowser].
+     * [SEPADirectDebitLauncher.handleReturnToApp].
      */
     class Started internal constructor(val pendingRequestString: String) : SEPADirectDebitPendingRequest()
 

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherUnitTest.kt
@@ -70,7 +70,7 @@ class SEPADirectDebitLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser on browser switch result returns success result`() {
+    fun `handleReturnToApp on browser switch result returns success result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         val pendingRequest: SEPADirectDebitPendingRequest.Started =
             SEPADirectDebitPendingRequest.Started(pendingRequestString)
@@ -78,7 +78,7 @@ class SEPADirectDebitLauncherUnitTest {
             browserSwitchClient.completeRequest(eq(intent), eq(pendingRequestString))
         } returns browserSwitchFinalResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(pendingRequest, intent)
+        val paymentAuthResult = sut.handleReturnToApp(pendingRequest, intent)
 
         assertTrue(paymentAuthResult is SEPADirectDebitPaymentAuthResult.Success)
         assertSame(
@@ -88,15 +88,14 @@ class SEPADirectDebitLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser when no BrowserSwitchResult returns no result`() {
-        val browserSwitchPendingRequest = BrowserSwitchStartResult.Started(pendingRequestString)
+    fun `handleReturnToApp when no BrowserSwitchResult returns no result`() {
         val pendingRequest: SEPADirectDebitPendingRequest.Started =
             SEPADirectDebitPendingRequest.Started(pendingRequestString)
         every {
             browserSwitchClient.completeRequest(eq(intent), eq(pendingRequestString))
         } returns BrowserSwitchFinalResult.NoResult
 
-        val paymentAuthResult = sut.handleReturnToAppFromBrowser(pendingRequest, intent)
+        val paymentAuthResult = sut.handleReturnToApp(pendingRequest, intent)
 
         assertTrue(paymentAuthResult is SEPADirectDebitPaymentAuthResult.NoResult)
     }

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
@@ -64,7 +64,7 @@ class VenmoLauncher internal constructor(
      * from the Venmo flow
      * @return a [VenmoPaymentAuthResult.Success] that should be passed to [VenmoClient.tokenize]
      * to complete the Venmo payment flow. Returns [VenmoPaymentAuthResult.NoResult] if the user
-     * closed the browser to cancel the payment flow, or returned to the app without completing the
+     * canceled payment flow, or returned to the app without completing the
      * Venmo authentication flow.
      */
     fun handleReturnToApp(

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
@@ -93,7 +93,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser when result exists returns result`() {
+    fun `handleReturnToApp when result exists returns result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         every {
             browserSwitchClient.completeRequest(
@@ -114,7 +114,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToAppFromBrowser when result does not exist returns null`() {
+    fun `handleReturnToApp when result does not exist returns null`() {
         every {
             browserSwitchClient.completeRequest(
                 intent,

--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -159,15 +159,15 @@ class MyActivity : FragmentActivity() {
     
     // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
     override fun onNewIntent(intent: Intent) {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
     // ALL OTHER ACTIVITY LAUNCH MODES 
     override fun onResume() {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
-    private fun handleReturnToAppFromBrowser(intent: Intent) {
+    private fun handleReturnToApp(intent: Intent) {
        // fetch stored VenmoPendingRequest.Success 
 +       fetchPendingRequestFromPersistantStore()?.let {
 +          when (val paymentAuthResult = venmoLauncher.handleReturnToApp(VenmoPendingRequest.Started(it), intent)) {
@@ -405,18 +405,18 @@ class MyActivity : FragmentActivity() {
     
     // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
     override fun onNewIntent(intent: Intent) {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
     // ALL OTHER ACTIVITY LAUNCH MODES 
     override fun onResume() {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
-    private fun handleReturnToAppFromBrowser(intent: Intent) {
+    private fun handleReturnToApp(intent: Intent) {
        // fetch stored PayPalPendingRequest.Success 
 +       fetchPendingRequestFromPersistantStore()?.let {
-+          when (val paymentAuthResult = payPalLauncher.handleReturnToAppFromBrowser(PayPalPendingRequest.Started(it), intent)) {
++          when (val paymentAuthResult = payPalLauncher.handleReturnToApp(PayPalPendingRequest.Started(it), intent)) {
 +               is PayPalPaymentAuthResult.Success -> {
 +                   completePayPalFlow(paymentAuthResult)
 +                   // clear stored PayPalPendingRequest.Success
@@ -508,18 +508,18 @@ class MyActivity : FragmentActivity() {
 
     // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
     override fun onNewIntent(intent: Intent) {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
     // ALL OTHER ACTIVITY LAUNCH MODES 
     override fun onResume() {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
-    private fun handleReturnToAppFromBrowser(intent: Intent) {
+    private fun handleReturnToApp(intent: Intent) {
        // fetch stored LocalPaymentPendingRequest.Success 
 +       fetchPendingRequestFromPersistantStore()?.let {
-+          when (val paymentAuthResult = localPaymentLauncher.handleReturnToAppFromBrowser(LocalPaymentPendingRequest.Started(it), intent)) {
++          when (val paymentAuthResult = localPaymentLauncher.handleReturnToApp(LocalPaymentPendingRequest.Started(it), intent)) {
 +               is LocalPaymentAuthResult.Success -> {
 +                   completeLocalPaymentFlow(paymentAuthResult)
 +                   // clear stored LocalPaymentPendingRequest.Success
@@ -603,18 +603,18 @@ class MyActivity : FragmentActivity() {
 
     // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
     override fun onNewIntent(intent: Intent) {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
 
     // ALL OTHER ACTIVITY LAUNCH MODES 
     override fun onResume() {
-+       handleReturnToAppFromBrowser(intent)
++       handleReturnToApp(intent)
     }
     
-    private fun handleReturnToAppFromBrowser(intent: Intent) {
+    private fun handleReturnToApp(intent: Intent) {
        // fetch stored SEPADirectDebitPendingRequest.Success 
 +       fetchPendingRequestFromPersistantStore()?.let {
-+          when (val paymentAuthResult = sepaDirectDebitLauncher.handleReturnToAppFromBrowser(SEPADirectDebitPendingRequest.Started(it), intent)) {
++          when (val paymentAuthResult = sepaDirectDebitLauncher.handleReturnToApp(SEPADirectDebitPendingRequest.Started(it), intent)) {
 +               is SEPADirectDebitPaymentAuthResult.Success -> {
 +                   completSEPAFlow(paymentAuthResult)
 +                   // clear stored SEPADirectDebitPendingRequest.Success


### PR DESCRIPTION
### Summary of changes

 - Rename `handleReturnToAppFromBrowser()` to `handleReturnToApp()` in the PayPal, SEPA, and LocalPayment modules

### Checklist

 - [x] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

