### PR TITLE
[QL] Update `interval` and `intervalCount`

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -64,12 +64,12 @@ public class PayPalRequestFactory {
             );
 
             PayPalBillingCycle billingCycle = new PayPalBillingCycle(
-                PayPalBillingInterval.MONTH,
+                    false,
                 1,
+                    PayPalBillingInterval.MONTH,
                 1,
                 1,
                 "2024-08-01",
-                false,
                 billingPricing
             );
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
@@ -31,10 +31,10 @@ import org.json.JSONObject
  */
 @Parcelize
 data class PayPalBillingCycle @JvmOverloads constructor(
-    var isTrial: Boolean,
+    val isTrial: Boolean,
     val numberOfExecutions: Int,
-    val interval: PayPalBillingInterval? = null,
-    val intervalCount: Int? = null,
+    var interval: PayPalBillingInterval? = null,
+    var intervalCount: Int? = null,
     var sequence: Int? = null,
     var startDate: String? = null,
     var pricing: PayPalBillingPricing? = null

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalBillingCycle.kt
@@ -7,16 +7,18 @@ import org.json.JSONObject
 /**
  * PayPal recurring billing cycle details.
  *
+ * @property isTrial The tenure type of the billing cycle. In case of a plan having trial cycle,
+ * only 2 trial cycles are allowed per plan.
+ * @property numberOfExecutions The number of times this billing cycle gets executed. Trial billing
+ * cycles can only be executed a finite number of times (value between 1 and 999). Regular billing
+ * cycles can be executed infinite times (value of 0) or a finite number of times (value between 1
+ * and 999).
  * @property interval The number of intervals after which a subscriber is charged or billed.
  * @property intervalCount The number of times this billing cycle gets executed. For example, if
  * the [intervalCount] is [PayPalBillingInterval.DAY] with an [intervalCount] of 2, the subscription
  * is billed once every two days. Maximum values [PayPalBillingInterval.DAY] -> 365,
  * [PayPalBillingInterval.WEEK] -> 52, [PayPalBillingInterval.MONTH] -> 12,
  * [PayPalBillingInterval.YEAR] -> 1.
- * @property numberOfExecutions The number of times this billing cycle gets executed. Trial billing
- * cycles can only be executed a finite number of times (value between 1 and 999). Regular billing
- * cycles can be executed infinite times (value of 0) or a finite number of times (value between 1
- * and 999).
  * @property sequence The sequence of the billing cycle. Used to identify unique billing cycles. For
  * example, sequence 1 could be a 3 month trial period, and sequence 2 could be a longer term full
  * rater cycle. Max value 100. All billing cycles should have unique sequence values.
@@ -24,30 +26,28 @@ import org.json.JSONObject
  * format `YYYY-MM-DD`. If not provided the billing cycle starts at the time of checkout.
  * If provided and the merchant wants the billing cycle to start at the time of checkout, provide
  * the current time. Otherwise the [startDate] can be in future.
- * @property isTrial The tenure type of the billing cycle. In case of a plan having trial cycle,
- * only 2 trial cycles are allowed per plan.
  * @property pricing The active pricing scheme for this billing cycle. Required if [isTrial] is
  * false. Optional if [isTrial] is true.
  */
 @Parcelize
 data class PayPalBillingCycle @JvmOverloads constructor(
-    val interval: PayPalBillingInterval,
-    val intervalCount: Int,
+    var isTrial: Boolean,
     val numberOfExecutions: Int,
+    val interval: PayPalBillingInterval? = null,
+    val intervalCount: Int? = null,
     var sequence: Int? = null,
     var startDate: String? = null,
-    var isTrial: Boolean = false,
     var pricing: PayPalBillingPricing? = null
 ) : Parcelable {
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put(KEY_INTERVAL, interval)
-            put(KEY_INTERVAL_COUNT, intervalCount)
+            put(KEY_TRIAL, isTrial)
             put(KEY_NUMBER_OF_EXECUTIONS, numberOfExecutions)
+            putOpt(KEY_INTERVAL, interval)
+            putOpt(KEY_INTERVAL_COUNT, intervalCount)
             putOpt(KEY_SEQUENCE, sequence)
             putOpt(KEY_START_DATE, startDate)
-            put(KEY_TRIAL, isTrial)
             pricing?.let {
                 put(KEY_PRICING, it.toJson())
             }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -58,7 +58,7 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(billingInterval, 1, 2);
+                new PayPalBillingCycle(false, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
         billingCycle.setTrial(true);
@@ -95,7 +95,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("11.00", request.getRecurringBillingDetails().getTotalAmount());
         PayPalBillingCycle requestBillingCycle = request.getRecurringBillingDetails().getBillingCycles().get(0);
         assertEquals(PayPalBillingInterval.MONTH, requestBillingCycle.getInterval());
-        assertEquals(1, requestBillingCycle.getIntervalCount());
+        assertSame(1, requestBillingCycle.getIntervalCount());
         assertEquals(2, requestBillingCycle.getNumberOfExecutions());
         assertEquals("2024-04-06T00:00:00Z", requestBillingCycle.getStartDate());
         assertSame(1, requestBillingCycle.getSequence());
@@ -130,7 +130,7 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(billingInterval, 1, 2);
+                new PayPalBillingCycle(false, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
         billingCycle.setTrial(true);
@@ -181,7 +181,7 @@ public class PayPalVaultRequestUnitTest {
         assertEquals("11.00", result.getRecurringBillingDetails().getTotalAmount());
         PayPalBillingCycle resultBillingCycle = result.getRecurringBillingDetails().getBillingCycles().get(0);
         assertEquals(PayPalBillingInterval.MONTH, resultBillingCycle.getInterval());
-        assertEquals(1, resultBillingCycle.getIntervalCount());
+        assertSame(1, resultBillingCycle.getIntervalCount());
         assertEquals(2, resultBillingCycle.getNumberOfExecutions());
         assertEquals("2024-04-06T00:00:00Z", resultBillingCycle.getStartDate());
         assertSame(1, resultBillingCycle.getSequence());
@@ -233,7 +233,7 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(billingInterval, 1, 2);
+                new PayPalBillingCycle(false, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
         billingCycle.setTrial(true);

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -58,10 +58,9 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(false, 2, billingInterval, 1);
+                new PayPalBillingCycle(true, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
-        billingCycle.setTrial(true);
         billingCycle.setPricing(billingPricing);
         PayPalRecurringBillingDetails billingDetails =
                 new PayPalRecurringBillingDetails(List.of(billingCycle), "11.00", "USD");
@@ -130,10 +129,9 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(false, 2, billingInterval, 1);
+                new PayPalBillingCycle(true, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
-        billingCycle.setTrial(true);
         billingCycle.setPricing(billingPricing);
         PayPalRecurringBillingDetails billingDetails =
                 new PayPalRecurringBillingDetails(List.of(billingCycle), "11.00", "USD");
@@ -233,10 +231,9 @@ public class PayPalVaultRequestUnitTest {
                 new PayPalBillingPricing(pricingModel, "1.00");
         billingPricing.setReloadThresholdAmount("6.00");
         PayPalBillingCycle billingCycle =
-                new PayPalBillingCycle(false, 2, billingInterval, 1);
+                new PayPalBillingCycle(true, 2, billingInterval, 1);
         billingCycle.setSequence(1);
         billingCycle.setStartDate("2024-04-06T00:00:00Z");
-        billingCycle.setTrial(true);
         billingCycle.setPricing(billingPricing);
         PayPalRecurringBillingDetails billingDetails =
                 new PayPalRecurringBillingDetails(List.of(billingCycle), "11.00", "USD");

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
@@ -2173,12 +2173,12 @@ object Fixtures {
       "plan_type": "RECURRING",
       "plan_metadata": {
         "billing_cycles": [{
+            "trial": true,
+            "number_of_executions": 2,
             "billing_frequency_unit": "MONTH",
             "billing_frequency": 1,
-            "number_of_executions": 2,
             "sequence": 1,
             "start_date": "2024-04-06T00:00:00Z",
-            "trial": true,
             "pricing_scheme": {
               "pricing_model": "VARIABLE",
               "price": "1.00",


### PR DESCRIPTION
### Summary of changes

- End to end testing revealed that there are cases where `billing_frequency` and `billing_frequency_unit` are not required for `unscheduled` cases for RBA metadata - updated and tested that these fields can be omitted without error when the `recurringBillingPlanType` is `.unscheduled` and the `pricingModel` is `.autoReload` per the test case
- Updated docstrings

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais