### PR TITLE
Fix analytic event timestamps

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -123,7 +123,7 @@ internal class AnalyticsClient(
                         )
                         val analyticsRequest =
                             createFPTIPayload(authorization, eventBlobs, metadata)
-                        
+
                         httpClient.post(
                             FPTI_ANALYTICS_URL,
                             analyticsRequest.toString(),

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
@@ -2,11 +2,11 @@ package com.braintreepayments.api.core
 
 internal data class AnalyticsEvent(
     val name: String,
+    val timestamp: Long,
     val payPalContextId: String? = null,
     val linkType: String? = null,
     val isVaultRequest: Boolean = false,
     val startTime: Long? = null,
     val endTime: Long? = null,
-    val endpoint: String? = null,
-    val timestamp: Long = System.currentTimeMillis(),
+    val endpoint: String? = null
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import com.braintreepayments.api.sharedutils.HttpResponseCallback
 import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.ManifestValidator
+import com.braintreepayments.api.sharedutils.Time
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -38,6 +39,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
     private val graphQLClient: BraintreeGraphQLClient,
     private val configurationLoader: ConfigurationLoader,
     private val manifestValidator: ManifestValidator,
+    private val time: Time,
     private val returnUrlScheme: String,
     private val braintreeDeepLinkReturnUrlScheme: String,
     /**
@@ -50,7 +52,10 @@ class BraintreeClient @VisibleForTesting internal constructor(
     private var launchesBrowserSwitchAsNewTask: Boolean = false
 
     // NOTE: this constructor is used to make dependency injection easy
-    internal constructor(params: BraintreeClientParams) : this(
+    internal constructor(
+        params: BraintreeClientParams,
+        time: Time = Time()
+    ) : this(
         applicationContext = params.applicationContext,
         integrationType = params.integrationType,
         authorization = params.authorization,
@@ -59,6 +64,7 @@ class BraintreeClient @VisibleForTesting internal constructor(
         graphQLClient = params.graphQLClient,
         configurationLoader = params.configurationLoader,
         manifestValidator = params.manifestValidator,
+        time = time,
         returnUrlScheme = params.returnUrlScheme,
         braintreeDeepLinkReturnUrlScheme = params.braintreeReturnUrlScheme,
         appLinkReturnUri = params.appLinkReturnUri
@@ -132,15 +138,17 @@ class BraintreeClient @VisibleForTesting internal constructor(
         eventName: String,
         params: AnalyticsEventParams = AnalyticsEventParams()
     ) {
+        val timestamp = time.currentTime
         getConfiguration { configuration, _ ->
             val event = AnalyticsEvent(
-                eventName,
-                params.payPalContextId,
-                params.linkType,
-                params.isVaultRequest,
-                params.startTime,
-                params.endTime,
-                params.endpoint
+                name = eventName,
+                timestamp = timestamp,
+                payPalContextId = params.payPalContextId,
+                linkType = params.linkType,
+                isVaultRequest = params.isVaultRequest,
+                startTime = params.startTime,
+                endTime = params.endTime,
+                endpoint = params.endpoint,
             )
             sendAnalyticsEvent(event, configuration, authorization)
         }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
@@ -8,6 +8,7 @@ import com.braintreepayments.api.core.AnalyticsClient.Companion.WORK_INPUT_KEY_S
 import com.braintreepayments.api.core.AnalyticsClient.Companion.WORK_NAME_ANALYTICS_UPLOAD
 import com.braintreepayments.api.core.Authorization.Companion.fromString
 import com.braintreepayments.api.core.Configuration.Companion.fromJson
+import com.braintreepayments.api.sharedutils.Time
 import com.braintreepayments.api.testutils.Fixtures
 import io.mockk.*
 import org.json.JSONException
@@ -30,6 +31,7 @@ class AnalyticsClientUnitTest {
     private lateinit var httpClient: BraintreeHttpClient
     private lateinit var deviceInspector: DeviceInspector
     private lateinit var analyticsParamRepository: AnalyticsParamRepository
+    private lateinit var time: Time
     private lateinit var eventName: String
     private lateinit var sessionId: String
     private lateinit var payPalContextId: String
@@ -38,6 +40,8 @@ class AnalyticsClientUnitTest {
     private lateinit var workManager: WorkManager
     private lateinit var analyticsDatabase: AnalyticsDatabase
     private lateinit var analyticsEventBlobDao: AnalyticsEventBlobDao
+
+    private lateinit var sut: AnalyticsClient
 
     private var timestamp: Long = 0
 
@@ -59,9 +63,22 @@ class AnalyticsClientUnitTest {
         analyticsDatabase = mockk(relaxed = true)
         analyticsEventBlobDao = mockk(relaxed = true)
         workManager = mockk(relaxed = true)
+        time = mockk(relaxed = true)
 
         every { analyticsDatabase.analyticsEventBlobDao() } returns analyticsEventBlobDao
         every { analyticsParamRepository.sessionId } returns sessionId
+
+        every { time.currentTime } returns 123
+
+        sut = AnalyticsClient(
+            context = context,
+            httpClient = httpClient,
+            analyticsDatabase = analyticsDatabase,
+            workManager = workManager,
+            deviceInspector = deviceInspector,
+            analyticsParamRepository = analyticsParamRepository,
+            time = time
+        )
     }
 
     @Test
@@ -77,13 +94,7 @@ class AnalyticsClientUnitTest {
         } returns mockk()
 
         val event = AnalyticsEvent(eventName, timestamp = 123)
-        val sut = AnalyticsClient(
-            context = context,
-            httpClient = httpClient,
-            analyticsDatabase = analyticsDatabase,
-            workManager = workManager,
-            deviceInspector = deviceInspector
-        )
+
         sut.sendEvent(configuration, event, integration, authorization)
 
         val workSpec = workRequestSlot.captured.workSpec
@@ -120,8 +131,7 @@ class AnalyticsClientUnitTest {
             isVaultRequest = true,
             timestamp = 456
         )
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
+
         sut.sendEvent(configuration, event, integration, authorization)
 
         val workSpec = workRequestSlot.captured.workSpec
@@ -156,8 +166,6 @@ class AnalyticsClientUnitTest {
             .putString(WORK_INPUT_KEY_ANALYTICS_JSON, JSONObject().toString())
             .putString(WORK_INPUT_KEY_SESSION_ID, JSONObject().toString())
             .build()
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsWrite(inputData)
         assertTrue(result is ListenableWorker.Result.Success)
     }
@@ -165,8 +173,6 @@ class AnalyticsClientUnitTest {
     @Test
     fun writeAnalytics_whenAnalyticsJSONIsMissing_returnsSuccess() {
         val inputData = Data.Builder().build()
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsWrite(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
     }
@@ -181,8 +187,7 @@ class AnalyticsClientUnitTest {
             .putString(WORK_INPUT_KEY_ANALYTICS_JSON, json)
             .putString(WORK_INPUT_KEY_SESSION_ID, sessionId)
             .build()
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
+
         sut.performAnalyticsWrite(inputData)
 
         val blob = analyticsEventBlobSlot.captured
@@ -238,8 +243,6 @@ class AnalyticsClientUnitTest {
             )
         }
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         sut.performAnalyticsUpload(inputData)
 
         // language=JSON
@@ -285,8 +288,6 @@ class AnalyticsClientUnitTest {
             .putString(AnalyticsClient.WORK_INPUT_KEY_INTEGRATION, integration.stringValue)
             .build()
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsUpload(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
 
@@ -303,8 +304,6 @@ class AnalyticsClientUnitTest {
             .putString(AnalyticsClient.WORK_INPUT_KEY_INTEGRATION, integration.stringValue)
             .build()
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsUpload(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
 
@@ -340,8 +339,6 @@ class AnalyticsClientUnitTest {
         val analyticsJSONSlot = slot<String>()
         every { httpClient.post(any(), capture(analyticsJSONSlot), any(), any()) }
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         sut.performAnalyticsUpload(inputData)
 
         val analyticsJson = JSONObject(analyticsJSONSlot.captured)
@@ -360,8 +357,6 @@ class AnalyticsClientUnitTest {
             .putString(AnalyticsClient.WORK_INPUT_KEY_INTEGRATION, integration.stringValue)
             .build()
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsUpload(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
 
@@ -378,8 +373,6 @@ class AnalyticsClientUnitTest {
             .putString(AnalyticsClient.WORK_INPUT_KEY_SESSION_ID, sessionId)
             .build()
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsUpload(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
 
@@ -410,8 +403,6 @@ class AnalyticsClientUnitTest {
         )
         every { analyticsEventBlobDao.getBlobsBySessionId(sessionId) } returns blobs
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         sut.performAnalyticsUpload(inputData)
 
         verify { analyticsEventBlobDao.deleteEventBlobs(blobs) }
@@ -442,8 +433,6 @@ class AnalyticsClientUnitTest {
         val httpError = Exception("error")
         every { httpClient.post(any(), any(), any(), any()) } throws httpError
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
         val result = sut.performAnalyticsUpload(inputData)
         assertTrue(result is ListenableWorker.Result.Failure)
     }
@@ -469,15 +458,7 @@ class AnalyticsClientUnitTest {
             )
         } returns Unit
 
-        val sut = AnalyticsClient(
-            context = context,
-            httpClient = httpClient,
-            analyticsDatabase = analyticsDatabase,
-            workManager = workManager,
-            deviceInspector = deviceInspector,
-            analyticsParamRepository = analyticsParamRepository
-        )
-        sut.reportCrash(context, configuration, integration, 123, authorization)
+        sut.reportCrash(context, configuration, integration, authorization)
 
         // language=JSON
         val expectedJSON = """
@@ -527,12 +508,10 @@ class AnalyticsClientUnitTest {
             deviceInspector.getDeviceMetadata(context, configuration, sessionId, integration)
         } returns metadata
 
-        val sut =
-            AnalyticsClient(context, httpClient, analyticsDatabase, workManager, deviceInspector)
-        val event = AnalyticsEvent(eventName)
+        val event = AnalyticsEvent(eventName, timestamp)
         sut.sendEvent(configuration, event, integration, authorization)
 
-        sut.reportCrash(context, configuration, integration, 123, null)
+        sut.reportCrash(context, configuration, integration, null)
 
         // or confirmVerified(httpClient)
         verify { httpClient wasNot Called }
@@ -540,16 +519,7 @@ class AnalyticsClientUnitTest {
 
     @Test
     fun `sendEvent enqueues work to upload analytic events with sessionId in the name`() {
-        val sut = AnalyticsClient(
-            context = context,
-            httpClient = httpClient,
-            analyticsDatabase = analyticsDatabase,
-            workManager = workManager,
-            deviceInspector = deviceInspector,
-            analyticsParamRepository = analyticsParamRepository
-        )
-
-        sut.sendEvent(configuration, AnalyticsEvent("event-name"), integration, authorization)
+        sut.sendEvent(configuration, AnalyticsEvent("event-name", timestamp), integration, authorization)
 
         verify {
             workManager.enqueueUniqueWork(

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Time.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Time.kt
@@ -1,0 +1,13 @@
+package com.braintreepayments.api.sharedutils
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class Time {
+
+    /**
+     * Returns the current time in milliseconds
+     */
+    val currentTime: Long
+        get() = System.currentTimeMillis()
+}


### PR DESCRIPTION
### Summary of changes

 - There was an issue where the timestamps sent with analytic events were not accurate due to the timestamp being generated inside of a callback. This change generates the timestamp right when `sendAnalyticsEvent()` is called.

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

