### PR TITLE
Fix `os_version` and `enablePayPalAppSwitch`

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -44,8 +44,8 @@ internal class PayPalInternalClient(
                 val url = "/v1/$endpoint"
                 val appLinkReturn = if (isBillingAgreement) appLink else null
 
-                if (isBillingAgreement) {
-                    (payPalRequest as PayPalVaultRequest).enablePayPalAppSwitch = isPayPalInstalled(context)
+                if (isBillingAgreement && (payPalRequest as PayPalVaultRequest).enablePayPalAppSwitch) {
+                    payPalRequest.enablePayPalAppSwitch = isPayPalInstalled(context)
                 }
 
                 val requestBody = payPalRequest.createRequestBody(

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -89,7 +89,7 @@ class PayPalVaultRequest
 
         if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
             parameters.put(ENABLE_APP_SWITCH_KEY, enablePayPalAppSwitch)
-            parameters.put(OS_VERSION_KEY, Build.VERSION.RELEASE)
+            parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT.toString())
             parameters.put(OS_TYPE_KEY, "Android")
             parameters.put(MERCHANT_APP_RETURN_URL_KEY, appLink)
         }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -89,7 +89,7 @@ class PayPalVaultRequest
 
         if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
             parameters.put(ENABLE_APP_SWITCH_KEY, enablePayPalAppSwitch)
-            parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT)
+            parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT.toString())
             parameters.put(OS_TYPE_KEY, "Android")
             parameters.put(MERCHANT_APP_RETURN_URL_KEY, appLink)
         }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -89,7 +89,7 @@ class PayPalVaultRequest
 
         if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
             parameters.put(ENABLE_APP_SWITCH_KEY, enablePayPalAppSwitch)
-            parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT.toString())
+            parameters.put(OS_VERSION_KEY, Build.VERSION.RELEASE)
             parameters.put(OS_TYPE_KEY, "Android")
             parameters.put(MERCHANT_APP_RETURN_URL_KEY, appLink)
         }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -139,7 +139,7 @@ public class PayPalVaultRequestUnitTest {
 
         assertTrue(requestBody.contains("\"launch_paypal_app\":true"));
         assertTrue(requestBody.contains("\"os_type\":" + "\"Android\""));
-        assertTrue(requestBody.contains("\"os_version\":" + versionSDK));
+        assertTrue(requestBody.contains("\"os_version\":" + "\"" + versionSDK + "\""));
         assertTrue(requestBody.contains("\"merchant_app_return_url\":" + "\"universal_url\""));
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -123,7 +123,7 @@ public class PayPalVaultRequestUnitTest {
 
     @Test
     public void createRequestBody_sets_enablePayPalSwitch_and_userAuthenticationEmail_not_null() throws JSONException {
-        int versionSDK = Build.VERSION.SDK_INT;
+        String versionSDK = String.valueOf(Build.VERSION.SDK_INT);
         String payerEmail = "payer_email@example.com";
         PayPalVaultRequest request = new PayPalVaultRequest(true);
 


### PR DESCRIPTION
Thank you for your contribution to Braintree. 
### Summary of changes

 - Fix the `os_version` so it’s sent as a String instead of an integer. This is to follow the same approach as iOS.
 - Fix the overwriting of `payPalVaultRequest.enablePayPalAppSwitch`. Previously, it only checked if it was a vault request, and if the PayPal app was installed, the value was being overwritten, causing incorrect behavior.

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage

### Authors

* @richherrera 
