### PR TITLE
[QL] Add Error if Edit FI Authorization is Invalid

### DIFF
--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation libs.mockito.core
     testImplementation libs.mockk
     testImplementation project(':TestUtils')
+    testImplementation libs.androidx.test.core
 }
 
 // region signing and publishing

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -10,6 +10,7 @@ import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.BraintreeRequestCodes
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.core.TokenizationKey
 import com.braintreepayments.api.core.UserCanceledException
 import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
 import com.braintreepayments.api.paypal.vaultedit.PayPalEditAuthCallback
@@ -328,6 +329,15 @@ class PayPalClient internal constructor(
         payPalVaultEditRequest: PayPalVaultEditRequest,
         callback: PayPalEditAuthCallback
     ) {
+        if (braintreeClient.authorization is TokenizationKey) {
+            callback.onPayPalVaultEditAuthRequest(
+                PayPalVaultEditAuthRequest.Failure(
+                    BraintreeException("Invalid authorization. This feature can only be used with a client token.")
+                )
+            )
+            return
+        }
+
         internalPayPalClient.sendVaultEditRequest(context, payPalVaultEditRequest) { result, error ->
             if (error != null) {
                 callback.onPayPalVaultEditAuthRequest(PayPalVaultEditAuthRequest.Failure(error))

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -322,6 +322,8 @@ class PayPalClient internal constructor(
      * @param context an Android Context
      * @param payPalVaultEditRequest a [PayPalVaultEditRequest] containing the edit request
      * @param callback a [PayPalEditAuthCallback]
+     *
+     * This feature is currently only supported with client token authorization.
      */
     @ExperimentalBetaApi
     fun createEditAuthRequest(

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -9,16 +9,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import android.net.Uri;
 
 import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ApplicationProvider;
 
 import com.braintreepayments.api.BrowserSwitchFinalResult;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.core.AnalyticsEventParams;
+import com.braintreepayments.api.core.Authorization;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeRequestCodes;
 import com.braintreepayments.api.core.Configuration;
+import com.braintreepayments.api.paypal.vaultedit.PayPalEditAuthCallback;
+import com.braintreepayments.api.paypal.vaultedit.PayPalVaultEditAuthRequest;
+import com.braintreepayments.api.paypal.vaultedit.PayPalVaultEditRequest;
 import com.braintreepayments.api.testutils.Fixtures;
 import com.braintreepayments.api.testutils.MockBraintreeClientBuilder;
 
@@ -450,5 +456,33 @@ public class PayPalClientUnitTest {
         params.setPayPalContextId("EC-HERMES-SANDBOX-EC-TOKEN");
         params.setVaultRequest(false);
         verify(braintreeClient).sendAnalyticsEvent(PayPalAnalytics.TOKENIZATION_SUCCEEDED, params);
+    }
+
+    @Test
+    public void createEditAuthRequest_whenAuthorizationIsTokenizationKey_callsBackWithError() throws JSONException {
+        PayPalAccountNonce payPalAccountNonce = mock(PayPalAccountNonce.class);
+        PayPalInternalClient payPalInternalClient =
+                new MockPayPalInternalClientBuilder().tokenizeSuccess(payPalAccountNonce).build();
+        Context context = ApplicationProvider.getApplicationContext();
+
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
+                .build();
+
+        PayPalVaultEditRequest payPalVaultEditRequest = new PayPalVaultEditRequest("123abc");
+        PayPalEditAuthCallback editAuthCallback = mock(PayPalEditAuthCallback.class);
+
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient);
+
+        sut.createEditAuthRequest(context, payPalVaultEditRequest, editAuthCallback);
+
+        ArgumentCaptor<PayPalVaultEditAuthRequest> captor =
+                ArgumentCaptor.forClass(PayPalVaultEditAuthRequest.class);
+        verify(editAuthCallback).onPayPalVaultEditAuthRequest(captor.capture());
+
+        PayPalVaultEditAuthRequest request = captor.getValue();
+        assertTrue(request instanceof PayPalVaultEditAuthRequest.Failure);
+        assertEquals("Invalid authorization. This feature can only be used with a client token.",
+                ((PayPalVaultEditAuthRequest.Failure) request).getError().getMessage());
     }
 }


### PR DESCRIPTION
### Summary of changes

- Add new error if tokenization key is used and check authorization type in edit method
- Add warnings that authorization can only be client token with this feature
- Add unit test

### Checklist

 - ~[ ] Added a changelog entry~
 - [x] Relevant test coverage

### Authors

@jaxdesmarais 