### PR TITLE
Fix `PayPalVaultEditPendingRequest.Started` constructor

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/vaultedit/PayPalVaultEditPendingRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/vaultedit/PayPalVaultEditPendingRequest.kt
@@ -14,7 +14,7 @@ sealed class PayPalVaultEditPendingRequest {
      * @property pendingRequestString - This String should be stored and passed to
      * [PayPalLauncher.handleReturnToApp].
      */
-    class Started internal constructor(val pendingRequestString: String) : PayPalVaultEditPendingRequest()
+    class Started(val pendingRequestString: String) : PayPalVaultEditPendingRequest()
 
     /**
      * An error occurred launching the PayPal browser flow. See [error] for details.


### PR DESCRIPTION
### Summary of changes

 - Update `PayPalVaultEditPendingRequest.Started` constructor to be public because it is needed to reconstruct the object from the stored pending request string

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~

### Authors
@sarahkoop 
