### PR TITLE
Update README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree Android SDK Release Notes
 
 ## 5.0.0 (2024-09-30)
+
 * PayPal
   * Add PayPal App Switch vault flow (BETA)
     * Add `enablePayPalAppSwitch` property to `PayPalVaultRequest` for App Switch support
@@ -8,7 +9,6 @@
     * Require `PayPalClient.appLinkReturnUrl` for App Switch support
     * Send `link_type` and `paypal_installed` in `event_params` when available to PayPal's analytics service (FPTI)
     * **Note:** This feature is currently in beta and may change or be removed in future releases.
-    
 * GooglePay
   * Upgrade `play-services-wallet` to `19.4.0`
 * Breaking Changes
@@ -43,6 +43,8 @@
     * Remove `LocalPaymentAuthResultInfo`
     * Make `LocalPaymentAuthRequestParams` internal
     * Rename `LocalPaymentLauncher.handleReturnToAppFromBrowser()` to `LocalPaymentLauncher.handleReturnToApp()`
+    
+**Note:** Includes all changes in [5.0.0-beta2](#500-beta2-2024-08-28) and [5.0.0-beta1](#500-beta1-2024-07-23)
 
 ## 5.0.0-beta2 (2024-08-28)
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ This SDK abides by our Client SDK Deprecation Policy. For more information on th
 
 | Major version number | Status | Released | Deprecated | Unsupported |
 |----------------------| -- | -------- | ---------- | ----------- |
-| 5.x.x                | Beta | TBA | TBA | TBA |
-| 4.x.x                | Active | June 2021 | TBA | TBA |
+| 5.x.x                | Active | October 2024 | TBA | TBA |
+| 4.x.x                | Inactive | June 2021 | October 2025 | October 2026 |
 | 3.x.x                | Unsupported | February 2019 | June 2022 | June 2023 |
 | 2.x.x                | Unsupported | November 2015 | March 2020 | March 2021 |
 


### PR DESCRIPTION
### Summary of changes

 - Update CHANGELOG to add link to v5 beta release notes in v5 GA
     - Also made this update in the release notes, but couldn't open a PR for that change: https://github.com/braintree/braintree_android/releases/tag/5.0.0
 - Update README to mark v4 as inactive and add deprecation dates 🥳 

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~

### Authors

@jaxdesmarais 