### PR TITLE
Add Shipping Callback URL to PayPalRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Add `shippingCallbackURL` to `PayPalRequest`
+  
 ## 5.0.0 (2024-09-30)
 
 * PayPal

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal
 
+import android.net.Uri
 import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
 import com.braintreepayments.api.core.ClientToken
@@ -75,6 +76,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var riskCorrelationId: String? = null,
     override var userAuthenticationEmail: String? = null,
     override var lineItems: List<PayPalLineItem> = emptyList(),
+    override var shippingCallbackUrl: Uri? = null,
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -87,7 +89,8 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     merchantAccountId = merchantAccountId,
     riskCorrelationId = riskCorrelationId,
     userAuthenticationEmail = userAuthenticationEmail,
-    lineItems = lineItems
+    lineItems = lineItems,
+    shippingCallbackUrl = shippingCallbackUrl,
 ) {
 
     @Throws(JSONException::class)
@@ -103,6 +106,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             .put(RETURN_URL_KEY, successUrl)
             .put(CANCEL_URL_KEY, cancelUrl)
             .put(OFFER_PAY_LATER_KEY, shouldOfferPayLater)
+            .putOpt(SHIPPING_CALLBACK_URL_KEY, shippingCallbackUrl.toString())
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -106,7 +106,10 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             .put(RETURN_URL_KEY, successUrl)
             .put(CANCEL_URL_KEY, cancelUrl)
             .put(OFFER_PAY_LATER_KEY, shouldOfferPayLater)
-            .putOpt(SHIPPING_CALLBACK_URL_KEY, shippingCallbackUrl.toString())
+
+        shippingCallbackUrl?.let {
+            if (it.toString().isNotEmpty()) parameters.put(SHIPPING_CALLBACK_URL_KEY, it)
+        }
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal
 
+import android.net.Uri
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.braintreepayments.api.core.Authorization
@@ -71,6 +72,9 @@ import org.json.JSONException
  * @property userAuthenticationEmail User email to initiate a quicker authentication flow in cases
  * where the user has a PayPal Account with the same email.
  * @property lineItems The line items for this transaction. It can include up to 249 line items.
+ * @property shippingCallbackUrl Server side shipping callback URL to be notified when a customer
+ * updates their shipping address or options. A callback request will be sent to the merchant server
+ * at this URL.
  */
 abstract class PayPalRequest internal constructor(
     open val hasUserLocationConsent: Boolean,
@@ -84,7 +88,8 @@ abstract class PayPalRequest internal constructor(
     open var merchantAccountId: String? = null,
     open var riskCorrelationId: String? = null,
     open var userAuthenticationEmail: String? = null,
-    open var lineItems: List<PayPalLineItem> = emptyList()
+    open var lineItems: List<PayPalLineItem> = emptyList(),
+    open var shippingCallbackUrl: Uri? = null,
 ) : Parcelable {
 
     @Throws(JSONException::class)
@@ -126,5 +131,6 @@ abstract class PayPalRequest internal constructor(
         internal const val OS_VERSION_KEY: String = "os_version"
         internal const val OS_TYPE_KEY: String = "os_type"
         internal const val MERCHANT_APP_RETURN_URL_KEY: String = "merchant_app_return_url"
+        internal const val SHIPPING_CALLBACK_URL_KEY: String = "shipping_callback_url"
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -76,7 +76,10 @@ class PayPalVaultRequest
             .put(RETURN_URL_KEY, successUrl)
             .put(CANCEL_URL_KEY, cancelUrl)
             .put(OFFER_CREDIT_KEY, shouldOfferCredit)
-            .putOpt(SHIPPING_CALLBACK_URL_KEY, shippingCallbackUrl.toString())
+
+        shippingCallbackUrl?.let {
+            if (it.toString().isNotEmpty()) parameters.put(SHIPPING_CALLBACK_URL_KEY, it)
+        }
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal
 
+import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
@@ -45,6 +46,7 @@ class PayPalVaultRequest
     override var riskCorrelationId: String? = null,
     override var userAuthenticationEmail: String? = null,
     override var lineItems: List<PayPalLineItem> = emptyList(),
+    override var shippingCallbackUrl: Uri? = null,
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -57,7 +59,8 @@ class PayPalVaultRequest
     merchantAccountId = merchantAccountId,
     riskCorrelationId = riskCorrelationId,
     userAuthenticationEmail = userAuthenticationEmail,
-    lineItems = lineItems
+    lineItems = lineItems,
+    shippingCallbackUrl = shippingCallbackUrl,
 ) {
 
     @Throws(JSONException::class)
@@ -73,6 +76,7 @@ class PayPalVaultRequest
             .put(RETURN_URL_KEY, successUrl)
             .put(CANCEL_URL_KEY, cancelUrl)
             .put(OFFER_CREDIT_KEY, shouldOfferCredit)
+            .putOpt(SHIPPING_CALLBACK_URL_KEY, shippingCallbackUrl.toString())
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal;
 
+import android.net.Uri;
 import android.os.Parcel;
 
 import com.braintreepayments.api.core.Authorization;
@@ -7,6 +8,7 @@ import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.PostalAddress;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -154,5 +156,58 @@ public class PayPalCheckoutRequestUnitTest {
         );
 
         assertFalse(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
+    }
+
+    @Test
+    public void createRequestBody_sets_shippingCallbackUri_when_not_null() throws JSONException {
+        String urlString = "https://www.example.com/path";
+        Uri uri = Uri.parse(urlString);
+
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+        request.setShippingCallbackUrl(uri);
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertEquals(urlString, jsonObject.getString("shipping_callback_url"));
+    }
+
+    @Test
+    public void createRequestBody_does_not_set_shippingCallbackUri_when_null() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertFalse(jsonObject.has("shipping_callback_url"));
+    }
+
+    @Test
+    public void createRequestBody_does_not_set_shippingCallbackUri_when_empty() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+        request.setShippingCallbackUrl(Uri.parse(""));
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertFalse(jsonObject.has("shipping_callback_url"));
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal;
 
+import android.net.Uri;
 import android.os.Build;
 import android.os.Parcel;
 
@@ -8,6 +9,7 @@ import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.PostalAddress;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -141,5 +143,58 @@ public class PayPalVaultRequestUnitTest {
         assertTrue(requestBody.contains("\"os_type\":" + "\"Android\""));
         assertTrue(requestBody.contains("\"os_version\":" + "\"" + versionSDK + "\""));
         assertTrue(requestBody.contains("\"merchant_app_return_url\":" + "\"universal_url\""));
+    }
+
+    @Test
+    public void createRequestBody_sets_shippingCallbackUri_when_not_null() throws JSONException {
+        String urlString = "https://www.example.com/path";
+        Uri uri = Uri.parse(urlString);
+
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
+        request.setShippingCallbackUrl(uri);
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertEquals(urlString, jsonObject.getString("shipping_callback_url"));
+    }
+
+    @Test
+    public void createRequestBody_does_not_set_shippingCallbackUri_when_null() throws JSONException {
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertFalse(jsonObject.has("shipping_callback_url"));
+    }
+
+    @Test
+    public void createRequestBody_does_not_set_shippingCallbackUri_when_empty() throws JSONException {
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
+        request.setShippingCallbackUrl(Uri.parse(""));
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertFalse(jsonObject.has("shipping_callback_url"));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Add a new property to the `PayPalRequest` and pass it to support server-side shipping callbacks

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors

- @richherrera 

