### PR TITLE
Add email2 property for non-null guarantees

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.kt
@@ -21,6 +21,7 @@ import org.json.JSONObject
  * @property lastName The last name associated with the PayPal account.
  * @property phone The phone number associated with the PayPal account.
  * @property email The email address associated with this PayPal account
+ * @property email2 Same as [email] - but as a non-null String
  * @property payerId The Payer ID provided in checkout flows.
  * @property creditFinancing The credit financing details. This property will only be present when
  * the customer pays with PayPal Credit.
@@ -39,6 +40,8 @@ data class PayPalAccountNonce internal constructor(
     val lastName: String,
     val phone: String,
     val email: String?, /* NEXT_MAJOR_VERSION - update this to be non-null */
+    /** Same as [email] - adding for non-null guarantees  */
+    val email2: String,
     val payerId: String,
     val creditFinancing: PayPalCreditFinancing?,
     val authenticateUrl: String?,
@@ -109,6 +112,7 @@ data class PayPalAccountNonce internal constructor(
             var lastName = ""
             var phone = ""
             var payerId = ""
+            var email2 = ""
             try {
                 if (details.has(CREDIT_FINANCING_KEY)) {
                     val creditFinancing = details.getJSONObject(CREDIT_FINANCING_KEY)
@@ -132,6 +136,7 @@ data class PayPalAccountNonce internal constructor(
                 if (email == null) {
                     email = Json.optString(payerInfo, EMAIL_KEY, null)
                 }
+                email2 = details.getString(EMAIL_KEY) ?: payerInfo.getString(EMAIL_KEY) ?: ""
             } catch (e: JSONException) {
                 billingAddress = PostalAddress()
                 shippingAddress = PostalAddress()
@@ -156,6 +161,7 @@ data class PayPalAccountNonce internal constructor(
                 lastName = lastName,
                 phone = phone,
                 email = email,
+                email2 = email2,
                 payerId = payerId,
                 creditFinancing = payPalCreditFinancing,
                 authenticateUrl = authenticateUrl

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAccountNonceUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAccountNonceUnitTest.java
@@ -28,6 +28,7 @@ public class PayPalAccountNonceUnitTest {
         assertEquals("fake-authenticate-url", payPalAccountNonce.getAuthenticateUrl());
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", payPalAccountNonce.getString());
         assertEquals("paypalaccount@example.com", payPalAccountNonce.getEmail());
+        assertEquals("paypalaccount@example.com", payPalAccountNonce.getEmail2());
         assertEquals("123 Fake St.", payPalAccountNonce.getBillingAddress().getStreetAddress());
         assertEquals("Apt. 3", payPalAccountNonce.getBillingAddress().getExtendedAddress());
         assertEquals("Oakland", payPalAccountNonce.getBillingAddress().getLocality());
@@ -59,6 +60,7 @@ public class PayPalAccountNonceUnitTest {
         assertNotNull(payPalAccountNonce);
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", payPalAccountNonce.getString());
         assertEquals("paypalaccount@example.com", payPalAccountNonce.getEmail());
+        assertEquals("paypalaccount@example.com", payPalAccountNonce.getEmail2());
         assertEquals("123 Fake St.", payPalAccountNonce.getBillingAddress().getStreetAddress());
         assertEquals("Apt. 3", payPalAccountNonce.getBillingAddress().getExtendedAddress());
         assertEquals("Oakland", payPalAccountNonce.getBillingAddress().getLocality());
@@ -91,6 +93,7 @@ public class PayPalAccountNonceUnitTest {
 
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", parceled.getString());
         assertEquals("paypalaccount@example.com", parceled.getEmail());
+        assertEquals("paypalaccount@example.com", parceled.getEmail2());
         assertEquals("fake-authenticate-url", parceled.getAuthenticateUrl());
 
         assertEquals("123 Fake St.", parceled.getBillingAddress().getStreetAddress());
@@ -129,6 +132,7 @@ public class PayPalAccountNonceUnitTest {
 
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", parceled.getString());
         assertEquals("paypalaccount@example.com", parceled.getEmail());
+        assertEquals("paypalaccount@example.com", parceled.getEmail2());
         assertEquals("123 Fake St.", parceled.getBillingAddress().getStreetAddress());
         assertEquals("Apt. 3", parceled.getBillingAddress().getExtendedAddress());
         assertEquals("Oakland", parceled.getBillingAddress().getLocality());


### PR DESCRIPTION
### Summary of changes

 - We had exposed `PayPalAccountNonce.email` as an optional String. Since we've just released the v5 version and we aren't sure on the timelines of v6, I am adding an additional property that has the same value as `email`, but gives the non-null guarantee.

 - Do we want to expose this for merchants to use a non-null property? I'd like to hear opinions on whether this change adds any value or causes more confusion that merchants being able to handle the null themselves.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

