### PR TITLE
Update API where getParcelableExtra method is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* GooglePay
+  * Fixing a crash on API 33 devices. It is recommended that merchants not use 5.1.0 for GooglePay.
 * Shopper Insights (BETA)
   * For analytics, send `experiment` as a parameter to `getRecommendedPaymentMethods` method
   * For analytics, send `experiment` and `paymentMethodsDisplayed` analytic metrics to FPTI via the button presented event methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * GooglePay
-  * Fixing a crash on API 33 devices. It is recommended that merchants not use 5.1.0 for GooglePay.
+  * Fix a crash being caused on API 33 devices. It is recommended that merchants not use 5.1.0 for GooglePay.
 * Shopper Insights (BETA)
   * For analytics, send `experiment` as a parameter to `getRecommendedPaymentMethods` method
   * For analytics, send `experiment` and `paymentMethodsDisplayed` analytic metrics to FPTI via the button presented event methods

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/IntentExtensions.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/IntentExtensions.kt
@@ -10,24 +10,27 @@ import java.io.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object IntentExtensions {
-
+    /** Although the newer getParcelableExtra(key, T::class.java) was introduced in Tiramisu (API 33),
+    there seems to be an issue that throws NPE. See: https://issuetracker.google.com/issues/240585930#comment6
+     Suggestion is to use the older API for Tiramisu (API 33) instead.
+    */
     inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
-        SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableExtra(key, T::class.java)
+        SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getParcelableExtra(key, T::class.java)
         else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
     }
 
     inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
-        SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelable(key, T::class.java)
+        SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getParcelable(key, T::class.java)
         else -> @Suppress("DEPRECATION") getParcelable(key) as? T
     }
 
     inline fun <reified T : Serializable> Intent.serializable(key: String): T? = when {
-        SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializableExtra(key, T::class.java)
+        SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getSerializableExtra(key, T::class.java)
         else -> @Suppress("DEPRECATION") getSerializableExtra(key) as? T
     }
 
     inline fun <reified T : Serializable> Bundle.serializable(key: String): T? = when {
-        SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializable(key, T::class.java)
+        SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getSerializable(key, T::class.java)
         else -> @Suppress("DEPRECATION") getSerializable(key) as? T
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/IntentExtensions.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/IntentExtensions.kt
@@ -11,8 +11,8 @@ import java.io.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object IntentExtensions {
     /** Although the newer getParcelableExtra(key, T::class.java) was introduced in Tiramisu (API 33),
-    there seems to be an issue that throws NPE. See: https://issuetracker.google.com/issues/240585930#comment6
-     Suggestion is to use the older API for Tiramisu (API 33) instead.
+     * there seems to be an issue that throws NPE. See: https://issuetracker.google.com/issues/240585930#comment6
+     * Suggestion is to use the older APIs for Tiramisu (API 33) instead.
     */
     inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
         SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> getParcelableExtra(key, T::class.java)


### PR DESCRIPTION
### Summary of changes

 - Fixing a crash caused by a call to `Intent.getParcelableExtra` on API 33.
 - Suggestion on [Google Issue Tracker](https://issuetracker.google.com/issues/240585930) is to use older APIs for 33 to avoid the crash.

### Checklist

 - [x] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> @saperi22 

