### PR TITLE
Move Shipping Callback URL to `PayPalCheckoutRequest` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * PayPal
-  * Add `shippingCallbackURL` to `PayPalRequest`
+  * Add `shippingCallbackURL` to `PayPalCheckoutRequest`
 
 ## 5.2.0 (2024-10-30)
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -55,6 +55,9 @@ import org.json.JSONObject
  *
  * @property shouldOfferPayLater Offers PayPal Pay Later if the customer qualifies. Defaults to
  * false.
+ * @property shippingCallbackUrl Server side shipping callback URL to be notified when a customer
+ * updates their shipping address or options. A callback request will be sent to the merchant server
+ * at this URL.
  */
 @Parcelize
 class PayPalCheckoutRequest @JvmOverloads constructor(
@@ -65,6 +68,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     var currencyCode: String? = null,
     var shouldRequestBillingAgreement: Boolean = false,
     var shouldOfferPayLater: Boolean = false,
+    var shippingCallbackUrl: Uri? = null,
     override var localeCode: String? = null,
     override var billingAgreementDescription: String? = null,
     override var isShippingAddressRequired: Boolean = false,
@@ -76,8 +80,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var riskCorrelationId: String? = null,
     override var userAuthenticationEmail: String? = null,
     override var userPhoneNumber: PayPalPhoneNumber? = null,
-    override var lineItems: List<PayPalLineItem> = emptyList(),
-    override var shippingCallbackUrl: Uri? = null,
+    override var lineItems: List<PayPalLineItem> = emptyList()
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -90,8 +93,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     merchantAccountId = merchantAccountId,
     riskCorrelationId = riskCorrelationId,
     userAuthenticationEmail = userAuthenticationEmail,
-    lineItems = lineItems,
-    shippingCallbackUrl = shippingCallbackUrl,
+    lineItems = lineItems
 ) {
 
     @Throws(JSONException::class)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -1,6 +1,5 @@
 package com.braintreepayments.api.paypal
 
-import android.net.Uri
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.braintreepayments.api.core.Authorization
@@ -91,8 +90,7 @@ abstract class PayPalRequest internal constructor(
     open var riskCorrelationId: String? = null,
     open var userAuthenticationEmail: String? = null,
     open var userPhoneNumber: PayPalPhoneNumber? = null,
-    open var lineItems: List<PayPalLineItem> = emptyList(),
-    open var shippingCallbackUrl: Uri? = null
+    open var lineItems: List<PayPalLineItem> = emptyList()
 ) : Parcelable {
 
     @Throws(JSONException::class)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -73,9 +73,6 @@ import org.json.JSONException
  * @property userPhoneNumber User phone number used to initiate a quicker authentication flow in
  * cases where the user has a PayPal Account with the phone number.
  * @property lineItems The line items for this transaction. It can include up to 249 line items.
- * @property shippingCallbackUrl Server side shipping callback URL to be notified when a customer
- * updates their shipping address or options. A callback request will be sent to the merchant server
- * at this URL.
  */
 abstract class PayPalRequest internal constructor(
     open val hasUserLocationConsent: Boolean,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -1,6 +1,5 @@
 package com.braintreepayments.api.paypal
 
-import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
@@ -50,8 +49,7 @@ class PayPalVaultRequest
     override var riskCorrelationId: String? = null,
     override var userAuthenticationEmail: String? = null,
     override var userPhoneNumber: PayPalPhoneNumber? = null,
-    override var lineItems: List<PayPalLineItem> = emptyList(),
-    override var shippingCallbackUrl: Uri? = null,
+    override var lineItems: List<PayPalLineItem> = emptyList()
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -65,7 +63,6 @@ class PayPalVaultRequest
     riskCorrelationId = riskCorrelationId,
     userAuthenticationEmail = userAuthenticationEmail,
     lineItems = lineItems,
-    shippingCallbackUrl = shippingCallbackUrl,
 ) {
 
     @Throws(JSONException::class)
@@ -81,10 +78,6 @@ class PayPalVaultRequest
             .put(RETURN_URL_KEY, successUrl)
             .put(CANCEL_URL_KEY, cancelUrl)
             .put(OFFER_CREDIT_KEY, shouldOfferCredit)
-
-        shippingCallbackUrl?.let {
-            if (it.toString().isNotEmpty()) parameters.put(SHIPPING_CALLBACK_URL_KEY, it)
-        }
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -7,7 +7,6 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
-import android.net.Uri;
 import android.os.Build;
 import android.os.Parcel;
 
@@ -17,7 +16,6 @@ import com.braintreepayments.api.core.PostalAddress;
 import com.braintreepayments.api.testutils.Fixtures;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -300,58 +298,5 @@ public class PayPalVaultRequestUnitTest {
         );
 
         assertTrue(requestBody.contains("\"phone_number\":{\"country_code\":\"1\",\"national_number\":\"1231231234\"}"));
-    }
-
-    @Test
-    public void createRequestBody_sets_shippingCallbackUri_when_not_null() throws JSONException {
-        String urlString = "https://www.example.com/path";
-        Uri uri = Uri.parse(urlString);
-
-        PayPalVaultRequest request = new PayPalVaultRequest(true);
-        request.setShippingCallbackUrl(uri);
-
-        String requestBody = request.createRequestBody(
-                mock(Configuration.class),
-                mock(Authorization.class),
-                "success_url",
-                "cancel_url",
-                null
-        );
-
-        JSONObject jsonObject = new JSONObject(requestBody);
-        assertEquals(urlString, jsonObject.getString("shipping_callback_url"));
-    }
-
-    @Test
-    public void createRequestBody_does_not_set_shippingCallbackUri_when_null() throws JSONException {
-        PayPalVaultRequest request = new PayPalVaultRequest(true);
-
-        String requestBody = request.createRequestBody(
-                mock(Configuration.class),
-                mock(Authorization.class),
-                "success_url",
-                "cancel_url",
-                null
-        );
-
-        JSONObject jsonObject = new JSONObject(requestBody);
-        assertFalse(jsonObject.has("shipping_callback_url"));
-    }
-
-    @Test
-    public void createRequestBody_does_not_set_shippingCallbackUri_when_empty() throws JSONException {
-        PayPalVaultRequest request = new PayPalVaultRequest(true);
-        request.setShippingCallbackUrl(Uri.parse(""));
-
-        String requestBody = request.createRequestBody(
-                mock(Configuration.class),
-                mock(Authorization.class),
-                "success_url",
-                "cancel_url",
-                null
-        );
-
-        JSONObject jsonObject = new JSONObject(requestBody);
-        assertFalse(jsonObject.has("shipping_callback_url"));
     }
 }


### PR DESCRIPTION
### Summary of changes

- Move the `shippingCallbackUrl` parameter to `PayPalCheckoutRequest`  to limit it to checkout flows. Shipping callbacks should only be available for PayPal checkout flows.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage

### Authors

- @richherrera 

