### PR TITLE
Add MerchantRepository for holding BraintreeClient properties

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.RestrictTo
 
+/**
+ * An internal repository that holds properties set by the integrating merchant.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class MerchantRepository {
 
@@ -14,6 +17,10 @@ class MerchantRepository {
     var appLinkReturnUri: Uri? = null
 
     companion object {
+
+        /**
+         * Singleton instance of the MerchantRepository.
+         */
         val instance: MerchantRepository by lazy { MerchantRepository() }
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
@@ -1,0 +1,19 @@
+package com.braintreepayments.api.core
+
+import android.content.Context
+import android.net.Uri
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class MerchantRepository {
+
+    lateinit var applicationContext: Context
+    lateinit var integrationType: IntegrationType
+    lateinit var authorization: Authorization
+    lateinit var returnUrlScheme: String
+    var appLinkReturnUri: Uri? = null
+
+    companion object {
+        val instance: MerchantRepository by lazy { MerchantRepository() }
+    }
+}

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.java
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.java
@@ -23,6 +23,7 @@ import com.braintreepayments.api.core.Authorization;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.Configuration;
+import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.testutils.Fixtures;
 import com.braintreepayments.api.testutils.MockBraintreeClientBuilder;
 import com.braintreepayments.api.paypal.PayPalAccountNonce;
@@ -63,6 +64,8 @@ public class GooglePayClientUnitTest {
 
     private AnalyticsParamRepository analyticsParamRepository;
 
+    private MerchantRepository merchantRepository = mock(MerchantRepository.class);
+
     @Before
     public void beforeEach() {
         activity = mock(FragmentActivity.class);
@@ -93,7 +96,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient, 
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.isReadyToPay(activity, null, readyToPayCallback);
 
         ArgumentCaptor<IsReadyToPayRequest> captor =
@@ -125,7 +133,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient, 
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.isReadyToPay(activity, readyForGooglePayRequest, readyToPayCallback);
 
         ArgumentCaptor<IsReadyToPayRequest> captor =
@@ -147,15 +160,21 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
+        
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.TOKENIZATION_KEY));
 
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder()
                 .isReadyToPay(true)
                 .build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient, 
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         sut.isReadyToPay(activity, null, readyToPayCallback);
         verify(readyToPayCallback).onGooglePayReadinessResult(any(GooglePayReadinessResult.NotReadyToPay.class));
@@ -174,15 +193,21 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(configuration)
-            .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
             .activityInfo(activityInfo)
             .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.TOKENIZATION_KEY));
 
         GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder()
             .isReadyToPay(true)
             .build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         sut.createPaymentAuthRequest(mock(), mock());
 
@@ -203,9 +228,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = new GooglePayRequest("USD", "1.00", GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL);
         googlePayRequest.setAllowPrepaidCards(true);
@@ -219,7 +245,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(googlePayRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -329,16 +360,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.TOKENIZATION_KEY));
 
         GooglePayRequest googlePayRequest = new GooglePayRequest("USD", "1.00", GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL);
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(googlePayRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -375,16 +412,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN));
 
         GooglePayRequest googlePayRequest = new GooglePayRequest("USD", "1.00", GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL);
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(googlePayRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -421,16 +464,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = new GooglePayRequest("USD", "1.00", GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL);
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(googlePayRequest, intentDataCallback);
 
         InOrder order = inOrder(braintreeClient);
@@ -443,15 +492,21 @@ public class GooglePayClientUnitTest {
         Configuration configuration = new TestConfigurationBuilder().buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
                 .configuration(configuration)
                 .activityInfo(activityInfo)
                 .build();
 
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN));
+
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -483,14 +538,20 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -522,14 +583,20 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -562,16 +629,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         baseRequest.setGoogleMerchantName("google-merchant-name-override");
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -605,9 +678,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -615,7 +689,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -653,9 +732,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -664,7 +744,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -703,9 +788,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -713,7 +799,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -753,9 +844,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -763,7 +855,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -810,9 +907,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -820,7 +918,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -859,9 +962,10 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayRequest googlePayRequest = baseRequest;
         googlePayRequest.setGoogleMerchantName("google-merchant-name-override");
@@ -869,7 +973,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -908,14 +1017,20 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(null)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(baseRequest, intentDataCallback);
 
         ArgumentCaptor<GooglePayPaymentAuthRequest> captor = ArgumentCaptor.forClass(
@@ -952,16 +1067,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         PaymentData pd = PaymentData.fromJson(paymentDataJson);
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.tokenize(pd, activityResultCallback);
 
         ArgumentCaptor<GooglePayResult> captor =
@@ -990,16 +1111,22 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         PaymentData pd = PaymentData.fromJson(paymentDataJson);
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
         sut.tokenize(pd, activityResultCallback);
 
         ArgumentCaptor<GooglePayResult> captor =
@@ -1022,7 +1149,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         String paymentDataJson = Fixtures.RESPONSE_GOOGLE_PAY_CARD;
         PaymentData paymentData = PaymentData.fromJson(paymentDataJson);
@@ -1049,7 +1181,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         Exception error = new Exception("Error");
         GooglePayPaymentAuthResult
@@ -1072,7 +1209,12 @@ public class GooglePayClientUnitTest {
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         UserCanceledException userCanceledError =
                 new UserCanceledException("User canceled Google Pay.");
@@ -1102,14 +1244,20 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString("sandbox_tokenization_string"))
                 .activityInfo(activityInfo)
                 .build();
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString("sandbox_tokenization_string"));
 
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
 
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         Collection<Integer> allowedCardNetworks = sut.getAllowedCardNetworks(configuration);
 
@@ -1136,13 +1284,19 @@ public class GooglePayClientUnitTest {
         Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
+        when(merchantRepository.getAuthorization()).thenReturn(authorization);
+
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         Bundle tokenizationParameters =
                 sut.getTokenizationParameters(configuration, authorization).getParameters();
@@ -1169,13 +1323,19 @@ public class GooglePayClientUnitTest {
         Authorization authorization = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
+        when(merchantRepository.getAuthorization()).thenReturn(authorization);
+
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         Bundle tokenizationParameters =
                 sut.getTokenizationParameters(configuration, authorization).getParameters();
@@ -1194,13 +1354,18 @@ public class GooglePayClientUnitTest {
         Authorization authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(authorization)
                 .activityInfo(activityInfo)
                 .build();
 
-        GooglePayInternalClient internalGooglePayClient =
-                new MockGooglePayInternalClientBuilder().build();
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        when(merchantRepository.getAuthorization()).thenReturn(authorization);
+
+        GooglePayInternalClient internalGooglePayClient = new MockGooglePayInternalClientBuilder().build();
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient,
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         Bundle tokenizationParameters =
                 sut.getTokenizationParameters(configuration, authorization).getParameters();
@@ -1219,13 +1384,19 @@ public class GooglePayClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .configuration(configuration)
-                .authorizationSuccess(Authorization.fromString(Fixtures.TOKENIZATION_KEY))
                 .activityInfo(activityInfo)
                 .build();
 
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.TOKENIZATION_KEY));
+
         GooglePayInternalClient internalGooglePayClient =
                 new MockGooglePayInternalClientBuilder().build();
-        GooglePayClient sut = new GooglePayClient(braintreeClient, internalGooglePayClient, analyticsParamRepository);
+        GooglePayClient sut = new GooglePayClient(
+            braintreeClient,
+            internalGooglePayClient, 
+            analyticsParamRepository,
+            merchantRepository
+        );
 
         sut.getTokenizationParameters(tokenizationParameters -> {
             assertTrue(tokenizationParameters instanceof GooglePayTokenizationParameters.Success);

--- a/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentApi.kt
+++ b/LocalPayment/src/main/java/com/braintreepayments/api/localpayment/LocalPaymentApi.kt
@@ -2,13 +2,15 @@ package com.braintreepayments.api.localpayment
 
 import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.localpayment.LocalPaymentNonce.Companion.fromJSON
 import org.json.JSONException
 import org.json.JSONObject
 
 internal class LocalPaymentApi(
     private val braintreeClient: BraintreeClient,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
 
     fun createPaymentMethod(
@@ -66,7 +68,7 @@ internal class LocalPaymentApi(
 
             val metaData = JSONObject()
                 .put("source", "client")
-                .put("integration", braintreeClient.integrationType.stringValue)
+                .put("integration", merchantRepository.integrationType.stringValue)
                 .put("sessionId", analyticsParamRepository.sessionId)
             payload.put("_meta", metaData)
 

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.java
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.java
@@ -476,7 +476,6 @@ public class LocalPaymentClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(payPalEnabledConfig)
             .sendPOSTErrorResponse(postError)
-            .integration(IntegrationType.CUSTOM)
             .build();
 
         LocalPaymentApi localPaymentApi = new MockLocalPaymentApiBuilder()
@@ -522,7 +521,6 @@ public class LocalPaymentClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(payPalEnabledConfig)
-            .integration(IntegrationType.CUSTOM)
             .build();
         when(dataCollector.getClientMetadataId(activity, payPalEnabledConfig, false)).thenReturn(
             "sample-correlation-id");
@@ -553,7 +551,6 @@ public class LocalPaymentClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(payPalEnabledConfig)
-            .integration(IntegrationType.CUSTOM)
             .build();
         when(dataCollector.getClientMetadataId(any(Context.class),
             same(payPalEnabledConfig), eq(false))).thenReturn("client-metadata-id");
@@ -635,7 +632,6 @@ public class LocalPaymentClientUnitTest {
         Exception configError = new Exception("config error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configurationError(configError)
-            .integration(IntegrationType.CUSTOM)
             .build();
         when(dataCollector.getClientMetadataId(activity, payPalEnabledConfig, true)).thenReturn(
             "sample-correlation-id");
@@ -702,7 +698,6 @@ public class LocalPaymentClientUnitTest {
         when(browserSwitchResult.getReturnUrl()).thenReturn(Uri.parse(webUrl));
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(payPalEnabledConfig)
-            .integration(IntegrationType.CUSTOM)
             .build();
         when(dataCollector.getClientMetadataId(any(Context.class), same(payPalEnabledConfig), anyBoolean())).thenReturn("client-metadata-id");
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -10,6 +10,7 @@ import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.BraintreeRequestCodes
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.LinkType
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.UserCanceledException
 import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
 import com.braintreepayments.api.sharedutils.Json
@@ -22,6 +23,7 @@ import org.json.JSONObject
 class PayPalClient internal constructor(
     private val braintreeClient: BraintreeClient,
     private val internalPayPalClient: PayPalInternalClient = PayPalInternalClient(braintreeClient),
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
 
     /**
@@ -150,7 +152,7 @@ class PayPalClient internal constructor(
 
         return BrowserSwitchOptions()
             .requestCode(BraintreeRequestCodes.PAYPAL.code)
-            .appLinkUri(braintreeClient.appLinkReturnUri)
+            .appLinkUri(merchantRepository.appLinkReturnUri)
             .url(Uri.parse(paymentAuthRequest.approvalUrl))
             .launchAsNewTask(braintreeClient.launchesBrowserSwitchAsNewTask())
             .metadata(metadata)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -7,6 +7,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.DeviceInspector
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.datacollector.DataCollector
 import com.braintreepayments.api.datacollector.DataCollectorInternalRequest
 import com.braintreepayments.api.paypal.PayPalPaymentResource.Companion.fromJson
@@ -17,11 +18,12 @@ internal class PayPalInternalClient(
     private val braintreeClient: BraintreeClient,
     private val dataCollector: DataCollector = DataCollector(braintreeClient),
     private val apiClient: ApiClient = ApiClient(braintreeClient),
-    private val deviceInspector: DeviceInspector = DeviceInspector()
+    private val deviceInspector: DeviceInspector = DeviceInspector(),
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
-    private val cancelUrl = "${braintreeClient.appLinkReturnUri}://onetouch/v1/cancel"
-    private val successUrl = "${braintreeClient.appLinkReturnUri}://onetouch/v1/success"
-    private val appLink = braintreeClient.appLinkReturnUri?.toString()
+    private val cancelUrl = "${merchantRepository.appLinkReturnUri}://onetouch/v1/cancel"
+    private val successUrl = "${merchantRepository.appLinkReturnUri}://onetouch/v1/success"
+    private val appLink = merchantRepository.appLinkReturnUri?.toString()
 
     fun sendRequest(
         context: Context,
@@ -50,7 +52,7 @@ internal class PayPalInternalClient(
 
                 val requestBody = payPalRequest.createRequestBody(
                     configuration = configuration,
-                    authorization = braintreeClient.authorization,
+                    authorization = merchantRepository.authorization,
                     successUrl = successUrl,
                     cancelUrl = cancelUrl,
                     appLink = appLinkReturn
@@ -155,7 +157,7 @@ internal class PayPalInternalClient(
 
     fun isAppSwitchEnabled(payPalRequest: PayPalRequest): Boolean {
         return (payPalRequest is PayPalVaultRequest) &&
-                payPalRequest.enablePayPalAppSwitch
+            payPalRequest.enablePayPalAppSwitch
     }
 
     fun isPayPalInstalled(context: Context): Boolean {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -23,6 +23,7 @@ import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.ClientToken;
 import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.DeviceInspector;
+import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.core.PostalAddress;
 import com.braintreepayments.api.core.TokenizationKey;
 import com.braintreepayments.api.core.TokenizeCallback;
@@ -61,6 +62,8 @@ public class PayPalInternalClientUnitTest {
 
     PayPalInternalClientCallback payPalInternalClientCallback;
 
+    private MerchantRepository merchantRepository = mock(MerchantRepository.class);
+
     @Before
     public void beforeEach() throws JSONException {
         context = mock(Context.class);
@@ -77,13 +80,20 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalVaultRequest_sendsAllParameters() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .build();
+            .configuration(configuration)
+            .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PostalAddress shippingAddressOverride = new PostalAddress();
         shippingAddressOverride.setRecipientName("Brianna Tree");
@@ -119,26 +129,26 @@ public class PayPalInternalClientUnitTest {
         JSONObject actual = new JSONObject(result);
 
         JSONObject expected = new JSONObject()
-                .put("authorization_fingerprint", "client-token-bearer")
-                .put("return_url", "https://example.com://onetouch/v1/success")
-                .put("cancel_url", "https://example.com://onetouch/v1/cancel")
-                .put("offer_paypal_credit", true)
-                .put("description", "Billing Agreement Description")
-                .put("experience_profile", new JSONObject()
-                        .put("no_shipping", false)
-                        .put("landing_page_type", "billing")
-                        .put("brand_name", "sample-display-name")
-                        .put("locale_code", "US")
-                        .put("address_override", false))
-                .put("shipping_address", new JSONObject()
-                        .put("line1", "123 Fake St.")
-                        .put("line2", "Apt. v.0")
-                        .put("city", "Oakland")
-                        .put("state", "CA")
-                        .put("postal_code", "12345")
-                        .put("country_code", "US")
-                        .put("recipient_name", "Brianna Tree"))
-                .put("merchant_account_id", "sample-merchant-account-id");
+            .put("authorization_fingerprint", "client-token-bearer")
+            .put("return_url", "https://example.com://onetouch/v1/success")
+            .put("cancel_url", "https://example.com://onetouch/v1/cancel")
+            .put("offer_paypal_credit", true)
+            .put("description", "Billing Agreement Description")
+            .put("experience_profile", new JSONObject()
+                .put("no_shipping", false)
+                .put("landing_page_type", "billing")
+                .put("brand_name", "sample-display-name")
+                .put("locale_code", "US")
+                .put("address_override", false))
+            .put("shipping_address", new JSONObject()
+                .put("line1", "123 Fake St.")
+                .put("line2", "Apt. v.0")
+                .put("city", "Oakland")
+                .put("state", "CA")
+                .put("postal_code", "12345")
+                .put("country_code", "US")
+                .put("recipient_name", "Brianna Tree"))
+            .put("merchant_account_id", "sample-merchant-account-id");
 
         JSONAssert.assertEquals(expected, actual, true);
     }
@@ -146,14 +156,20 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalCheckoutRequest_sendsAllParameters() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .build();
+            .configuration(configuration)
+            .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
 
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
         PostalAddress shippingAddressOverride = new PostalAddress();
         shippingAddressOverride.setRecipientName("Brianna Tree");
         shippingAddressOverride.setStreetAddress("123 Fake St.");
@@ -202,40 +218,40 @@ public class PayPalInternalClientUnitTest {
         JSONObject actual = new JSONObject(result);
 
         JSONObject expected = new JSONObject()
-                .put("amount", "1.00")
-                .put("currency_iso_code", "USD")
-                .put("intent", "authorize")
-                .put("authorization_fingerprint", "client-token-bearer")
-                .put("return_url", "https://example.com://onetouch/v1/success")
-                .put("cancel_url", "https://example.com://onetouch/v1/cancel")
-                .put("offer_pay_later", true)
-                .put("request_billing_agreement", true)
-                .put("billing_agreement_details", new JSONObject()
-                        .put("description", "Billing Agreement Description"))
-                .put("line_items", new JSONArray()
-                        .put(new JSONObject()
-                                .put("kind", "debit")
-                                .put("name", "Item 0")
-                                .put("quantity", "1")
-                                .put("unit_amount", "2")
-                                .put("description", "A new item")
-                                .put("product_code", "abc-123")
-                                .put("unit_tax_amount", "1.50")
-                                .put("url", "http://example.com")))
-                .put("experience_profile", new JSONObject()
-                        .put("no_shipping", false)
-                        .put("landing_page_type", "login")
-                        .put("brand_name", "sample-display-name")
-                        .put("locale_code", "US")
-                        .put("address_override", false))
-                .put("line1", "123 Fake St.")
-                .put("line2", "Apt. v.0")
-                .put("city", "Oakland")
-                .put("state", "CA")
-                .put("postal_code", "12345")
-                .put("country_code", "US")
-                .put("recipient_name", "Brianna Tree")
-                .put("merchant_account_id", "sample-merchant-account-id");
+            .put("amount", "1.00")
+            .put("currency_iso_code", "USD")
+            .put("intent", "authorize")
+            .put("authorization_fingerprint", "client-token-bearer")
+            .put("return_url", "https://example.com://onetouch/v1/success")
+            .put("cancel_url", "https://example.com://onetouch/v1/cancel")
+            .put("offer_pay_later", true)
+            .put("request_billing_agreement", true)
+            .put("billing_agreement_details", new JSONObject()
+                .put("description", "Billing Agreement Description"))
+            .put("line_items", new JSONArray()
+                .put(new JSONObject()
+                    .put("kind", "debit")
+                    .put("name", "Item 0")
+                    .put("quantity", "1")
+                    .put("unit_amount", "2")
+                    .put("description", "A new item")
+                    .put("product_code", "abc-123")
+                    .put("unit_tax_amount", "1.50")
+                    .put("url", "http://example.com")))
+            .put("experience_profile", new JSONObject()
+                .put("no_shipping", false)
+                .put("landing_page_type", "login")
+                .put("brand_name", "sample-display-name")
+                .put("locale_code", "US")
+                .put("address_override", false))
+            .put("line1", "123 Fake St.")
+            .put("line2", "Apt. v.0")
+            .put("city", "Oakland")
+            .put("state", "CA")
+            .put("postal_code", "12345")
+            .put("country_code", "US")
+            .put("recipient_name", "Brianna Tree")
+            .put("merchant_account_id", "sample-merchant-account-id");
 
         JSONAssert.assertEquals(expected, actual, true);
     }
@@ -243,12 +259,18 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withTokenizationKey_sendsClientKeyParam() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
         when(tokenizationKey.getBearer()).thenReturn("tokenization-key-bearer");
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -270,13 +292,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withEmptyDisplayName_fallsBackToPayPalConfigurationDisplayName()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(false);
         payPalRequest.setDisplayName("");
@@ -294,17 +323,24 @@ public class PayPalInternalClientUnitTest {
         JSONObject actual = new JSONObject(result);
 
         assertEquals("paypal_merchant",
-                ((JSONObject) actual.get("experience_profile")).get("brand_name"));
+            ((JSONObject) actual.get("experience_profile")).get("brand_name"));
     }
 
     @Test
     public void sendRequest_withLocaleNotSpecified_omitsLocale() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setLocaleCode(null);
@@ -326,13 +362,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withMerchantAccountIdNotSpecified_omitsMerchantAccountId()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setMerchantAccountId(null);
@@ -354,13 +397,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withShippingAddressOverrideNotSpecified_sendsAddressOverrideFalse()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setShippingAddressOverride(null);
@@ -378,19 +428,25 @@ public class PayPalInternalClientUnitTest {
         JSONObject actual = new JSONObject(result);
 
         assertEquals(false,
-                ((JSONObject) actual.get("experience_profile")).get("address_override"));
+            ((JSONObject) actual.get("experience_profile")).get("address_override"));
     }
 
     @Test
     public void sendRequest_withShippingAddressSpecified_sendsAddressOverrideBasedOnShippingAdressEditability()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .build();
+            .configuration(configuration)
+            .build();
         when(clientToken.getBearer()).thenReturn("client-token-bearer");
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setShippingAddressEditable(false);
@@ -414,13 +470,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withPayPalVaultRequest_omitsEmptyBillingAgreementDescription()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setBillingAgreementDescription("");
@@ -442,13 +505,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withPayPalCheckoutRequest_fallsBackToPayPalConfigurationCurrencyCode()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR))
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR))
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -470,11 +540,18 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalCheckoutRequest_omitsEmptyLineItems() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setLineItems(new ArrayList<PayPalLineItem>());
@@ -499,12 +576,19 @@ public class PayPalInternalClientUnitTest {
         when(dataCollector.getClientMetadataId(same(context), any(), same(configuration))).thenReturn("sample-client-metadata-id");
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setRiskCorrelationId("risk-correlation-id");
@@ -512,7 +596,7 @@ public class PayPalInternalClientUnitTest {
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), isNull());
 
         PayPalPaymentAuthRequestParams payPalPaymentAuthRequestParams = captor.getValue();
@@ -524,19 +608,26 @@ public class PayPalInternalClientUnitTest {
         when(dataCollector.getClientMetadataId(same(context), any(), any())).thenReturn("sample-client-metadata-id");
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
 
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
         PayPalPaymentAuthRequestParams payPalPaymentAuthRequestParams = captor.getValue();
@@ -546,13 +637,20 @@ public class PayPalInternalClientUnitTest {
 
     @Test
     public void sendRequest_withPayPalCheckoutRequest_whenRequestBillingAgreementFalse_andBillingAgreementDescriptionSet_doesNotSettBillingAgreementDescription()
-            throws JSONException {
+        throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(tokenizationKey)
-                .build();
+            .configuration(configuration)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setShouldRequestBillingAgreement(false);
@@ -579,13 +677,20 @@ public class PayPalInternalClientUnitTest {
         when(dataCollector.getClientMetadataId(context, configuration, true)).thenReturn("sample-client-metadata-id");
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_BA_TOKEN_PARAM)
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_BA_TOKEN_PARAM)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setMerchantAccountId("sample-merchant-account-id");
@@ -594,11 +699,11 @@ public class PayPalInternalClientUnitTest {
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
         String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?ba_token=fake-ba-token&action=create_payment_resource&amount=1.00&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&currency_iso_code=USD&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&offer_paypal_credit=true&version=1";
+            "https://checkout.paypal.com/one-touch-login-sandbox/index.html?ba_token=fake-ba-token&action=create_payment_resource&amount=1.00&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&currency_iso_code=USD&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&offer_paypal_credit=true&version=1";
         PayPalPaymentAuthRequestParams payPalPaymentAuthRequestParams = captor.getValue();
         assertTrue(payPalPaymentAuthRequestParams.isBillingAgreement());
         assertEquals("sample-merchant-account-id", payPalPaymentAuthRequestParams.getMerchantAccountId());
@@ -611,13 +716,20 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalVaultRequest_callsBackPayPalResponseOnSuccess_returnsPayPalURL() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_PAYPAL_REDIRECT_URL)
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_PAYPAL_REDIRECT_URL)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setUserAuthenticationEmail("example@mail.com");
@@ -628,7 +740,7 @@ public class PayPalInternalClientUnitTest {
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
         PayPalPaymentAuthRequestParams payPalPaymentAuthRequestParams = captor.getValue();
@@ -646,20 +758,27 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalVaultRequest_callsBackPayPalResponseOnSuccess_returnsApprovalURL() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_APPROVAL_URL)
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_APPROVAL_URL)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
 
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
         String expectedUrl = "https://www.example.com/some?ba_token=fake-ba-token";
@@ -674,13 +793,20 @@ public class PayPalInternalClientUnitTest {
         when(dataCollector.getClientMetadataId(context, configuration, true)).thenReturn("sample-client-metadata-id");
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_TOKEN_PARAM)
-                .appLinkReturnUri(Uri.parse("https://example.com"))
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE_WITH_TOKEN_PARAM)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+        when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setIntent(PayPalPaymentIntent.AUTHORIZE);
@@ -691,11 +817,11 @@ public class PayPalInternalClientUnitTest {
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
-                PayPalPaymentAuthRequestParams.class);
+            PayPalPaymentAuthRequestParams.class);
         verify(payPalInternalClientCallback).onResult(captor.capture(), (Exception) isNull());
 
         String expectedUrl =
-                "https://checkout.paypal.com/one-touch-login-sandbox/index.html?token=fake-token&action=create_payment_resource&amount=1.00&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&currency_iso_code=USD&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&offer_paypal_credit=true&version=1";
+            "https://checkout.paypal.com/one-touch-login-sandbox/index.html?token=fake-token&action=create_payment_resource&amount=1.00&authorization_fingerprint=63cc461306c35080ce674a3372bffe1580b4130c7fd33d33968aa76bb93cdd06%7Ccreated_at%3D2015-10-13T18%3A49%3A48.371382792%2B0000%26merchant_id%3Ddcpspy2brwdjr3qn%26public_key%3D9wwrzqk3vr3t4nc8&cancel_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fcancel&controller=client_api%2Fpaypal_hermes&currency_iso_code=USD&experience_profile%5Baddress_override%5D=false&experience_profile%5Bno_shipping%5D=false&merchant_id=dcpspy2brwdjr3qn&return_url=com.braintreepayments.api.test.braintree%3A%2F%2Fonetouch%2Fv1%2Fsuccess&offer_paypal_credit=true&version=1";
         PayPalPaymentAuthRequestParams payPalPaymentAuthRequestParams = captor.getValue();
         assertFalse(payPalPaymentAuthRequestParams.isBillingAgreement());
         assertEquals(PayPalPaymentIntent.AUTHORIZE, payPalPaymentAuthRequestParams.getIntent());
@@ -710,12 +836,19 @@ public class PayPalInternalClientUnitTest {
     public void sendRequest_propagatesHttpErrors() {
         Exception httpError = new Exception("http error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTErrorResponse(httpError)
-                .build();
+            .configuration(configuration)
+            .sendPOSTErrorResponse(httpError)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -726,29 +859,43 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_propagatesMalformedJSONResponseErrors() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(configuration)
-                .authorizationSuccess(clientToken)
-                .sendPOSTSuccessfulResponse("{bad:")
-                .build();
+            .configuration(configuration)
+            .sendPOSTSuccessfulResponse("{bad:")
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
 
         verify(payPalInternalClientCallback).onResult((PayPalPaymentAuthRequestParams) isNull(),
-                any(JSONException.class));
+            any(JSONException.class));
     }
 
     @Test
     public void sendRequest_onConfigurationFailure_forwardsError() {
         Exception configurationError = new Exception("configuration error");
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .authorizationSuccess(clientToken)
-                .configurationError(configurationError)
-                .build();
+            .configurationError(configurationError)
+            .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
@@ -762,7 +909,13 @@ public class PayPalInternalClientUnitTest {
         PayPalAccount payPalAccount = mock(PayPalAccount.class);
         PayPalInternalTokenizeCallback callback = mock(PayPalInternalTokenizeCallback.class);
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         sut.tokenize(payPalAccount, callback);
 
@@ -773,22 +926,28 @@ public class PayPalInternalClientUnitTest {
     public void tokenize_onTokenizeResult_returnsAccountNonceToCallback() throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
         ApiClient apiClient = new MockApiClientBuilder()
-                .tokenizeRESTSuccess(
-                        new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE))
-                .build();
+            .tokenizeRESTSuccess(
+                new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE))
+            .build();
         PayPalAccount payPalAccount = mock(PayPalAccount.class);
         PayPalInternalTokenizeCallback callback = mock(PayPalInternalTokenizeCallback.class);
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         sut.tokenize(payPalAccount, callback);
 
         ArgumentCaptor<PayPalAccountNonce> captor =
-                ArgumentCaptor.forClass(PayPalAccountNonce.class);
+            ArgumentCaptor.forClass(PayPalAccountNonce.class);
         verify(callback).onResult(captor.capture(), (Exception) isNull());
 
         PayPalAccountNonce expectedNonce = PayPalAccountNonce.fromJSON(
-                new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE));
+            new JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE));
         PayPalAccountNonce result = captor.getValue();
         assertEquals(expectedNonce.getString(), result.getString());
     }
@@ -798,12 +957,18 @@ public class PayPalInternalClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
         Exception error = new Exception("error");
         ApiClient apiClient = new MockApiClientBuilder()
-                .tokenizeRESTError(error)
-                .build();
+            .tokenizeRESTError(error)
+            .build();
         PayPalAccount payPalAccount = mock(PayPalAccount.class);
         PayPalInternalTokenizeCallback callback = mock(PayPalInternalTokenizeCallback.class);
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         sut.tokenize(payPalAccount, callback);
 
@@ -815,12 +980,19 @@ public class PayPalInternalClientUnitTest {
         Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(configuration)
-            .authorizationSuccess(clientToken)
             .returnUrlScheme("sample-scheme")
             .sendPOSTSuccessfulResponse(Fixtures.PAYPAL_HERMES_RESPONSE)
             .build();
 
-        PayPalInternalClient sut = new PayPalInternalClient(braintreeClient, dataCollector, apiClient, deviceInspector);
+        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
+
+        PayPalInternalClient sut = new PayPalInternalClient(
+            braintreeClient,
+            dataCollector,
+            apiClient,
+            deviceInspector,
+            merchantRepository
+        );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setIntent(PayPalPaymentIntent.AUTHORIZE);

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -6,6 +6,7 @@ import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.TokenizationKey
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_FAILED
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_STARTED
@@ -30,6 +31,7 @@ class ShopperInsightsClient internal constructor(
     private val api: ShopperInsightsApi = ShopperInsightsApi(
         EligiblePaymentsApi(braintreeClient, analyticsParamRepository)
     ),
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
 
     /**
@@ -72,7 +74,7 @@ class ShopperInsightsClient internal constructor(
             return
         }
 
-        if (braintreeClient.authorization is TokenizationKey) {
+        if (merchantRepository.authorization is TokenizationKey) {
             callbackFailure(
                 callback = callback,
                 error = BraintreeException(

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockBraintreeClientBuilder.java
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockBraintreeClientBuilder.java
@@ -33,11 +33,8 @@ public class MockBraintreeClientBuilder {
     private Configuration configuration;
     private Exception configurationError;
 
-    private Authorization authorization;
 
-    private IntegrationType integration;
     private String returnUrlScheme;
-    private Uri appLinkReturnUri;
 
 
     private ActivityInfo activityInfo;
@@ -50,11 +47,6 @@ public class MockBraintreeClientBuilder {
 
     public MockBraintreeClientBuilder configurationError(Exception configurationError) {
         this.configurationError = configurationError;
-        return this;
-    }
-
-    public MockBraintreeClientBuilder authorizationSuccess(Authorization authorization) {
-        this.authorization = authorization;
         return this;
     }
 
@@ -93,11 +85,6 @@ public class MockBraintreeClientBuilder {
         return this;
     }
 
-    public MockBraintreeClientBuilder integration(IntegrationType integration) {
-        this.integration = integration;
-        return this;
-    }
-
     public MockBraintreeClientBuilder returnUrlScheme(String returnUrlScheme) {
         this.returnUrlScheme = returnUrlScheme;
         return this;
@@ -109,21 +96,12 @@ public class MockBraintreeClientBuilder {
         return this;
     }
 
-    public MockBraintreeClientBuilder appLinkReturnUri(
-            Uri appLinkReturnUri) {
-        this.appLinkReturnUri = appLinkReturnUri;
-        return this;
-    }
-
     public BraintreeClient build() {
         BraintreeClient braintreeClient = mock(BraintreeClient.class);
-        when(braintreeClient.getIntegrationType()).thenReturn(integration);
-        when(braintreeClient.getAuthorization()).thenReturn(authorization);
         when(braintreeClient.getReturnUrlScheme()).thenReturn(returnUrlScheme);
         when(braintreeClient.getManifestActivityInfo(any())).thenReturn(activityInfo);
         when(braintreeClient.launchesBrowserSwitchAsNewTask()).thenReturn(
                 launchesBrowserSwitchAsNewTask);
-        when(braintreeClient.getAppLinkReturnUri()).thenReturn(appLinkReturnUri);
 
         doAnswer((Answer<Void>) invocation -> {
             ConfigurationCallback callback = (ConfigurationCallback) invocation.getArguments()[0];

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
@@ -7,6 +7,7 @@ import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.BuildConfig
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.InvalidArgumentException
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.threedsecure.ThreeDSecureParams.Companion.fromJson
 import com.cardinalcommerce.cardinalmobilesdk.models.CardinalActionCode
 import org.json.JSONException
@@ -24,7 +25,8 @@ import org.json.JSONObject
 class ThreeDSecureClient internal constructor(
     private val braintreeClient: BraintreeClient,
     private val cardinalClient: CardinalClient = CardinalClient(),
-    private val api: ThreeDSecureAPI = ThreeDSecureAPI(braintreeClient)
+    private val api: ThreeDSecureAPI = ThreeDSecureAPI(braintreeClient),
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
     /**
      * Initializes a new [ThreeDSecureClient] instance
@@ -161,7 +163,7 @@ class ThreeDSecureClient internal constructor(
         val lookupJSON = JSONObject()
         try {
             lookupJSON
-                .put("authorizationFingerprint", braintreeClient.authorization.bearer)
+                .put("authorizationFingerprint", merchantRepository.authorization.bearer)
                 .put("braintreeLibraryVersion", "Android-${BuildConfig.VERSION_NAME}")
                 .put("nonce", request.nonce)
                 .put(

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.java
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.java
@@ -21,6 +21,7 @@ import com.braintreepayments.api.core.Authorization;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.Configuration;
+import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.testutils.Fixtures;
 import com.braintreepayments.api.sharedutils.HttpResponseCallback;
 import com.braintreepayments.api.testutils.MockBraintreeClientBuilder;
@@ -45,6 +46,7 @@ public class ThreeDSecureClientUnitTest {
 
     private FragmentActivity activity;
     private ThreeDSecureAPI threeDSecureAPI;
+    private MerchantRepository merchantRepository = mock(MerchantRepository.class);
 
     private ThreeDSecurePaymentAuthRequestCallback paymentAuthRequestCallback;
     private ThreeDSecureTokenizeCallback threeDSecureTokenizeCallback;
@@ -74,8 +76,9 @@ public class ThreeDSecureClientUnitTest {
         billingAddress.setGivenName("billing-given-name");
         basicRequest.setBillingAddress(billingAddress);
 
-        threeDSecureParams =
-            ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
+        threeDSecureParams = ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
+
+        when(merchantRepository.getAuthorization()).thenReturn(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN));
     }
 
     // region prepareLookup
@@ -88,13 +91,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
         sut.prepareLookup(activity, basicRequest, callback);
@@ -130,13 +135,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
         sut.prepareLookup(activity, basicRequest, callback);
@@ -170,13 +177,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
         sut.prepareLookup(activity, basicRequest, callback);
@@ -194,13 +203,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
         sut.prepareLookup(activity, basicRequest, callback);
@@ -220,13 +231,15 @@ public class ThreeDSecureClientUnitTest {
             .buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(configuration)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecurePrepareLookupCallback callback = mock(ThreeDSecurePrepareLookupCallback.class);
         sut.prepareLookup(activity, basicRequest, callback);
@@ -257,9 +270,12 @@ public class ThreeDSecureClientUnitTest {
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(activity, basicRequest, paymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(ThreeDSecureAnalytics.VERIFY_STARTED, new AnalyticsEventParams());
@@ -285,9 +301,12 @@ public class ThreeDSecureClientUnitTest {
         billingAddress.setGivenName("billing-given-name");
         request.setBillingAddress(billingAddress);
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(activity, request, paymentAuthRequestCallback);
 
         String expectedUrl = "/v1/payment_methods/a-nonce/three_d_secure/lookup";
@@ -322,9 +341,12 @@ public class ThreeDSecureClientUnitTest {
         billingAddress.setGivenName("billing-given-name");
         request.setBillingAddress(billingAddress);
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(activity, request, paymentAuthRequestCallback);
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
@@ -364,9 +386,12 @@ public class ThreeDSecureClientUnitTest {
         billingAddress.setGivenName("billing-given-name");
         request.setBillingAddress(billingAddress);
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         sut.createPaymentAuthRequest(activity, request, paymentAuthRequestCallback);
 
@@ -379,9 +404,12 @@ public class ThreeDSecureClientUnitTest {
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecureRequest request = new ThreeDSecureRequest();
         request.setAmount("5");
@@ -402,13 +430,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(activity, basicRequest, paymentAuthRequestCallback);
 
         verify(cardinalClient).initialize(same(activity), same(threeDSecureEnabledConfig),
@@ -424,13 +454,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         sut.createPaymentAuthRequest(activity, basicRequest, paymentAuthRequestCallback);
 
@@ -450,13 +482,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
         sut.createPaymentAuthRequest(activity, basicRequest, paymentAuthRequestCallback);
 
         verify(braintreeClient).sendAnalyticsEvent(ThreeDSecureAnalytics.VERIFY_STARTED, new AnalyticsEventParams());
@@ -472,13 +506,15 @@ public class ThreeDSecureClientUnitTest {
             .buildConfiguration();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(configuration)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         sut.createPaymentAuthRequest(activity, basicRequest, paymentAuthRequestCallback);
 
@@ -504,13 +540,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecureParams threeDSecureParams =
             ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
@@ -527,14 +565,16 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .returnUrlScheme("sample-return-url://")
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecureParams threeDSecureParams =
             ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE);
@@ -552,13 +592,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
 
         ThreeDSecureParams threeDSecureParams =
             ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE_NO_ACS_URL);
@@ -580,13 +622,15 @@ public class ThreeDSecureClientUnitTest {
             .build();
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .authorizationSuccess(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
             .configuration(threeDSecureEnabledConfig)
             .build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                new ThreeDSecureAPI(braintreeClient));
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            new ThreeDSecureAPI(braintreeClient),
+            merchantRepository
+        );
         ThreeDSecureParams threeDSecureParams =
             ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE);
 
@@ -609,9 +653,12 @@ public class ThreeDSecureClientUnitTest {
         CardinalClient cardinalClient = new MockCardinalClientBuilder().build();
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         Exception threeDSecureError = new Exception("3DS error.");
         ThreeDSecurePaymentAuthResult paymentAuthResult = new ThreeDSecurePaymentAuthResult(null, null, null, threeDSecureError);
@@ -634,9 +681,12 @@ public class ThreeDSecureClientUnitTest {
         when(validateResponse.getActionCode()).thenReturn(CardinalActionCode.TIMEOUT);
         when(validateResponse.getErrorDescription()).thenReturn("Error");
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecurePaymentAuthResult paymentAuthResult =
             new ThreeDSecurePaymentAuthResult("jwt", validateResponse, threeDSecureParams, null);
@@ -663,9 +713,12 @@ public class ThreeDSecureClientUnitTest {
         ValidateResponse validateResponse = mock(ValidateResponse.class);
         when(validateResponse.getActionCode()).thenReturn(CardinalActionCode.CANCEL);
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecurePaymentAuthResult paymentAuthResult =
             new ThreeDSecurePaymentAuthResult("jwt", validateResponse, threeDSecureParams, null);
@@ -696,9 +749,12 @@ public class ThreeDSecureClientUnitTest {
         }).when(threeDSecureAPI).authenticateCardinalJWT(any(ThreeDSecureParams.class), anyString(),
             any(ThreeDSecureResultCallback.class));
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecurePaymentAuthResult paymentAuthResult =
             new ThreeDSecurePaymentAuthResult("jwt", validateResponse, threeDSecureParams, null);
@@ -733,9 +789,12 @@ public class ThreeDSecureClientUnitTest {
         }).when(threeDSecureAPI).authenticateCardinalJWT(any(ThreeDSecureParams.class), anyString(),
             any(ThreeDSecureResultCallback.class));
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecurePaymentAuthResult paymentAuthResult =
             new ThreeDSecurePaymentAuthResult("jwt", validateResponse, threeDSecureParams, null);
@@ -771,9 +830,12 @@ public class ThreeDSecureClientUnitTest {
         }).when(threeDSecureAPI).authenticateCardinalJWT(any(ThreeDSecureParams.class), anyString(),
             any(ThreeDSecureResultCallback.class));
 
-        ThreeDSecureClient sut =
-            new ThreeDSecureClient(braintreeClient, cardinalClient,
-                threeDSecureAPI);
+        ThreeDSecureClient sut = new ThreeDSecureClient(
+            braintreeClient,
+            cardinalClient,
+            threeDSecureAPI,
+            merchantRepository
+        );
 
         ThreeDSecurePaymentAuthResult paymentAuthResult =
             new ThreeDSecurePaymentAuthResult("jwt", validateResponse, threeDSecureParams, null);

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoApi.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoApi.kt
@@ -5,6 +5,7 @@ import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.ApiClient
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
+import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.MetadataBuilder
 import com.braintreepayments.api.venmo.VenmoAccountNonce.Companion.fromJSON
 import org.json.JSONArray
@@ -14,7 +15,8 @@ import org.json.JSONObject
 internal class VenmoApi(
     private val braintreeClient: BraintreeClient,
     private val apiClient: ApiClient,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
 
     @Suppress("LongMethod")
@@ -82,7 +84,7 @@ internal class VenmoApi(
 
             val braintreeData = MetadataBuilder()
                 .sessionId(analyticsParamRepository.sessionId)
-                .integration(braintreeClient.integrationType)
+                .integration(merchantRepository.integrationType)
                 .version()
                 .build()
 

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.braintreepayments.api.core.AnalyticsParamRepository;
+import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.testutils.Fixtures;
 import com.braintreepayments.api.testutils.MockApiClientBuilder;
 import com.braintreepayments.api.testutils.MockBraintreeClientBuilder;
@@ -38,6 +39,7 @@ public class VenmoApiUnitTest {
     private BraintreeClient braintreeClient;
     private ApiClient apiClient;
     private AnalyticsParamRepository analyticsParamRepository;
+    private MerchantRepository merchantRepository = mock(MerchantRepository.class);
 
     @Before
     public void beforeEach() {
@@ -50,7 +52,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void createPaymentContext_createsPaymentContextViaGraphQL() throws JSONException {
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -104,7 +106,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void createPaymentContext_whenTransactionAmountOptionsMissing() throws JSONException {
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -137,7 +139,7 @@ public class VenmoApiUnitTest {
                 .sendGraphQLPOSTSuccessfulResponse(
                         Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
                 .build();
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -154,7 +156,7 @@ public class VenmoApiUnitTest {
                 .sendGraphQLPOSTSuccessfulResponse(
                         Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_RESPONSE_WITHOUT_PAYMENT_CONTEXT_ID)
                 .build();
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -177,7 +179,7 @@ public class VenmoApiUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .sendGraphQLPOSTErrorResponse(error)
                 .build();
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -190,7 +192,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void createPaymentContext_withTotalAmountAndSetsFinalAmountToTrue() throws JSONException {
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -216,7 +218,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void createPaymentContext_withTotalAmountAndSetsFinalAmountToFalse() throws JSONException {
-        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi venmoAPI = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoRequest request = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
         request.setProfileId("sample-venmo-merchant");
@@ -242,7 +244,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void createNonceFromPaymentContext_queriesGraphQLPaymentContext() throws JSONException {
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
         sut.createNonceFromPaymentContext("payment-context-id", mock(VenmoInternalCallback.class));
 
         ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);
@@ -259,7 +261,7 @@ public class VenmoApiUnitTest {
                 .sendGraphQLPOSTSuccessfulResponse(graphQLResponse)
                 .build();
 
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoInternalCallback callback = mock(VenmoInternalCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
@@ -275,7 +277,7 @@ public class VenmoApiUnitTest {
                 .sendGraphQLPOSTSuccessfulResponse("not-json")
                 .build();
 
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoInternalCallback callback = mock(VenmoInternalCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
@@ -292,7 +294,7 @@ public class VenmoApiUnitTest {
                 .sendGraphQLPOSTErrorResponse(error)
                 .build();
 
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoInternalCallback callback = mock(VenmoInternalCallback.class);
         sut.createNonceFromPaymentContext("payment-context-id", callback);
@@ -302,7 +304,7 @@ public class VenmoApiUnitTest {
 
     @Test
     public void vaultVenmoAccountNonce_performsVaultRequest() throws JSONException {
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
         sut.vaultVenmoAccountNonce("nonce", mock(VenmoInternalCallback.class));
 
         ArgumentCaptor<VenmoAccount> accountBuilderCaptor =
@@ -320,7 +322,7 @@ public class VenmoApiUnitTest {
                 .tokenizeRESTSuccess(new JSONObject(
                         Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_WITH_NULL_PAYER_INFO_JSON))
                 .build();
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoInternalCallback callback = mock(VenmoInternalCallback.class);
         sut.vaultVenmoAccountNonce("nonce", callback);
@@ -338,7 +340,7 @@ public class VenmoApiUnitTest {
         ApiClient apiClient = new MockApiClientBuilder()
                 .tokenizeRESTError(error)
                 .build();
-        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository);
+        VenmoApi sut = new VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository);
 
         VenmoInternalCallback callback = mock(VenmoInternalCallback.class);
         sut.vaultVenmoAccountNonce("nonce", callback);


### PR DESCRIPTION
### Summary of changes

 - Create MerchantRepository which holds properties that were previously in BraintreeClient
 - MerchantRepository singleton that keeps fields in memory, allowing any class to access its values via dependency injection

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

