### PR TITLE
Add SdkComponent and move configuration fetch out of BraintreeClient

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -27,17 +27,14 @@ internal class AnalyticsClient(
     private val applicationContext: Context
         get() = merchantRepository.applicationContext
 
-    fun sendEvent(
-        event: AnalyticsEvent,
-        integration: IntegrationType?,
-    ) {
+    fun sendEvent(event: AnalyticsEvent) {
         configurationLoader.loadConfiguration { result ->
             if (result is ConfigurationLoaderResult.Success) {
                 scheduleAnalyticsWriteInBackground(event, merchantRepository.authorization)
                 scheduleAnalyticsUploadInBackground(
                     configuration = result.configuration,
                     authorization = merchantRepository.authorization,
-                    integration = integration
+                    integration = merchantRepository.integrationType
                 )
             }
         }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsUploadWorker.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsUploadWorker.kt
@@ -16,7 +16,7 @@ internal class AnalyticsUploadWorker(
 ) : Worker(context, params) {
 
     override fun doWork(): Result {
-        val analyticsClient = AnalyticsClient(applicationContext)
+        val analyticsClient = AnalyticsClient()
         return analyticsClient.performAnalyticsUpload(inputData)
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsWriteToDbWorker.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsWriteToDbWorker.kt
@@ -16,7 +16,7 @@ internal class AnalyticsWriteToDbWorker(
 ) : Worker(context, params) {
 
     override fun doWork(): Result {
-        val analyticsClient = AnalyticsClient(applicationContext)
+        val analyticsClient = AnalyticsClient()
         return analyticsClient.performAnalyticsWrite(inputData)
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -114,10 +114,7 @@ class BraintreeClient internal constructor(
             experiment = params.experiment,
             paymentMethodsDisplayed = params.paymentMethodsDisplayed
         )
-        analyticsClient.sendEvent(
-            event = event,
-            integration = merchantRepository.integrationType,
-        )
+        analyticsClient.sendEvent(event)
     }
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -101,10 +101,9 @@ class BraintreeClient internal constructor(
         eventName: String,
         params: AnalyticsEventParams = AnalyticsEventParams()
     ) {
-        val timestamp = time.currentTime
         val event = AnalyticsEvent(
             name = eventName,
-            timestamp = timestamp,
+            timestamp = time.currentTime,
             payPalContextId = params.payPalContextId,
             linkType = params.linkType,
             isVaultRequest = params.isVaultRequest,
@@ -200,7 +199,7 @@ class BraintreeClient internal constructor(
                                         endpoint = finalQuery
                                     )
                                     sendAnalyticsEvent(
-                                        CoreAnalytics.apiRequestLatency,
+                                        CoreAnalytics.API_REQUEST_LATENCY,
                                         params
                                     )
                                 }
@@ -272,7 +271,7 @@ class BraintreeClient internal constructor(
         )
 
         sendAnalyticsEvent(
-            CoreAnalytics.apiRequestLatency,
+            CoreAnalytics.API_REQUEST_LATENCY,
             AnalyticsEventParams(
                 startTime = timing.startTime,
                 endTime = timing.endTime,

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -11,6 +11,10 @@ internal class ConfigurationLoader(
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
     private val configurationCache: ConfigurationCache = ConfigurationCacheProvider().configurationCache,
     private val time: Time = Time(),
+    /**
+     * TODO: AnalyticsClient must be lazy due to the circular dependency between ConfigurationLoader and AnalyticsClient
+     * This should be refactored to remove the circular dependency.
+     */
     lazyAnalyticsClient: Lazy<AnalyticsClient> = lazy { AnalyticsClient(httpClient) },
 ) {
     private val analyticsClient: AnalyticsClient by lazyAnalyticsClient

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -7,10 +7,9 @@ import org.json.JSONException
 
 internal class ConfigurationLoader(
     private val httpClient: BraintreeHttpClient = BraintreeHttpClient(),
-    private val merchantRepository: MerchantRepository = MerchantRepository.instance
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
+    private val configurationCache: ConfigurationCache = ConfigurationCacheProvider().configurationCache,
 ) {
-    private val configurationCache: ConfigurationCache
-        get() = ConfigurationCache.getInstance(merchantRepository.applicationContext)
 
     fun loadConfiguration(callback: ConfigurationLoaderCallback) {
         val authorization = merchantRepository.authorization
@@ -45,9 +44,6 @@ internal class ConfigurationLoader(
                         callback.onResult(ConfigurationLoaderResult.Success(configuration, timing))
 
                         // TODO: send timing analytics
-
-
-
                     } catch (jsonException: JSONException) {
                         callback.onResult(ConfigurationLoaderResult.Failure(jsonException))
                     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
@@ -1,7 +1,5 @@
 package com.braintreepayments.api.core
 
-import com.braintreepayments.api.sharedutils.HttpResponseTiming
-
 internal fun interface ConfigurationLoaderCallback {
     fun onResult(result: ConfigurationLoaderResult)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderCallback.kt
@@ -3,5 +3,5 @@ package com.braintreepayments.api.core
 import com.braintreepayments.api.sharedutils.HttpResponseTiming
 
 internal fun interface ConfigurationLoaderCallback {
-    fun onResult(result: Configuration?, error: Exception?, timing: HttpResponseTiming?)
+    fun onResult(result: ConfigurationLoaderResult)
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResult.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResult.kt
@@ -1,0 +1,16 @@
+package com.braintreepayments.api.core
+
+import com.braintreepayments.api.sharedutils.HttpResponseTiming
+
+/**
+ * Result of calling [ConfigurationLoader.loadConfiguration]
+ */
+internal sealed class ConfigurationLoaderResult {
+
+    class Success(
+        val configuration: Configuration,
+        val timing: HttpResponseTiming? = null
+    ) : ConfigurationLoaderResult()
+
+    class Failure(val error: Exception) : ConfigurationLoaderResult()
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResult.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoaderResult.kt
@@ -7,10 +7,10 @@ import com.braintreepayments.api.sharedutils.HttpResponseTiming
  */
 internal sealed class ConfigurationLoaderResult {
 
-    class Success(
+    data class Success(
         val configuration: Configuration,
         val timing: HttpResponseTiming? = null
     ) : ConfigurationLoaderResult()
 
-    class Failure(val error: Exception) : ConfigurationLoaderResult()
+    data class Failure(val error: Exception) : ConfigurationLoaderResult()
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/CoreAnalytics.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/CoreAnalytics.kt
@@ -1,5 +1,5 @@
 package com.braintreepayments.api.core
 
 internal object CoreAnalytics {
-    const val apiRequestLatency = "core:api-request-latency"
+    const val API_REQUEST_LATENCY = "core:api-request-latency"
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
@@ -1,0 +1,45 @@
+package com.braintreepayments.api.core
+
+import android.content.Context
+import androidx.work.WorkManager
+
+/**
+ * Component class that is created when the BT SDK is launched. It contains dependencies that need to be injected that
+ * contain Context.
+ */
+internal class SdkComponent(
+    applicationContext: Context,
+) {
+    val analyticsDatabase: AnalyticsDatabase = AnalyticsDatabase.getInstance(applicationContext)
+    val workManager: WorkManager = WorkManager.getInstance(applicationContext)
+
+    companion object {
+        private var instance: SdkComponent? = null
+
+        /**
+         * Creates and returns a new instance of [SdkComponent], or returns the existing instance.
+         */
+        fun create(applicationContext: Context): SdkComponent {
+            return instance ?: SdkComponent(applicationContext).also { sdkComponent ->
+                instance = sdkComponent
+            }
+        }
+
+        /**
+         * Returns the instance of [SdkComponent]
+         */
+        fun getInstance(): SdkComponent {
+            return checkNotNull(instance)
+        }
+    }
+}
+
+internal class AnalyticsDatabaseProvider {
+    val analyticsDatabase: AnalyticsDatabase
+        get() = SdkComponent.getInstance().analyticsDatabase
+}
+
+internal class WorkManagerProvider {
+    val workManager: WorkManager
+        get() = SdkComponent.getInstance().workManager
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
@@ -12,6 +12,7 @@ internal class SdkComponent(
 ) {
     val analyticsDatabase: AnalyticsDatabase = AnalyticsDatabase.getInstance(applicationContext)
     val workManager: WorkManager = WorkManager.getInstance(applicationContext)
+    val configurationCache: ConfigurationCache = ConfigurationCache.getInstance(applicationContext)
 
     companion object {
         private var instance: SdkComponent? = null
@@ -42,4 +43,9 @@ internal class AnalyticsDatabaseProvider {
 internal class WorkManagerProvider {
     val workManager: WorkManager
         get() = SdkComponent.getInstance().workManager
+}
+
+internal class ConfigurationCacheProvider {
+    val configurationCache: ConfigurationCache
+        get() = SdkComponent.getInstance().configurationCache
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
@@ -327,24 +327,9 @@ class BraintreeClientUnitTest {
 
         verify {
             analyticsClient.sendEvent(
-                configuration,
                 match { it.name == "event.started" && it.timestamp == 123L },
-                IntegrationType.CUSTOM,
-                authorization
             )
         }
-    }
-
-    @Test
-    fun sendAnalyticsEvent_whenConfigurationLoadFails_doesNothing() {
-        val configurationLoader = MockkConfigurationLoaderBuilder()
-            .configurationError(Exception("error"))
-            .build()
-
-        val sut = createBraintreeClient(configurationLoader)
-        sut.sendAnalyticsEvent("event.started")
-
-        verify { analyticsClient wasNot Called }
     }
 
     @Test
@@ -416,10 +401,10 @@ class BraintreeClientUnitTest {
 
         val callbackSlot = slot<ConfigurationLoaderCallback>()
         verify {
-            configurationLoader.loadConfiguration(authorization, capture(callbackSlot))
+            configurationLoader.loadConfiguration(capture(callbackSlot))
         }
 
-        callbackSlot.captured.onResult(configuration, null, null)
+        callbackSlot.captured.onResult(ConfigurationLoaderResult.Success(configuration))
 
         verify {
             analyticsClient.reportCrash(


### PR DESCRIPTION
### Summary of changes

 - Created `ConfigurationLoaderResult` to make it easier to handle `ConfigurationLoaderCallback.onResult()`
 - Move the fetching of configuration to `AnalyticsClient`
 - Move latency analytics call to configuration loader
 - Create SdkComponent for instantiating classes that require Context

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

