### PR TITLE
Add app switch analytics calls for Venmo

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -24,8 +24,13 @@ class AnalyticsClient internal constructor(
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
     private val time: Time = Time(),
     private val configurationLoader: ConfigurationLoader = ConfigurationLoader.instance,
-    private val merchantRepository: MerchantRepository = MerchantRepository.instance
+    private val merchantRepository: MerchantRepository
 ) {
+
+    constructor() : this(
+        merchantRepository = MerchantRepository.instance
+    )
+
     private val applicationContext: Context
         get() = merchantRepository.applicationContext
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -44,7 +44,8 @@ class AnalyticsClient internal constructor(
             endTime = analyticsEventParams.endTime,
             endpoint = analyticsEventParams.endpoint,
             experiment = analyticsEventParams.experiment,
-            paymentMethodsDisplayed = analyticsEventParams.paymentMethodsDisplayed
+            paymentMethodsDisplayed = analyticsEventParams.paymentMethodsDisplayed,
+            appSwitchUrl = analyticsEventParams.appSwitchUrl
         )
         configurationLoader.loadConfiguration { result ->
             if (result is ConfigurationLoaderResult.Success) {
@@ -240,6 +241,7 @@ class AnalyticsClient internal constructor(
             .putOpt(FPTI_KEY_MERCHANT_EXPERIMENT, event.experiment)
             .putOpt(FPTI_KEY_MERCHANT_PAYMENT_METHODS_DISPLAYED,
                 event.paymentMethodsDisplayed.ifEmpty { null })
+            .putOpt(FPTI_KEY_URL, event.appSwitchUrl)
         return json.toString()
     }
 
@@ -292,6 +294,7 @@ class AnalyticsClient internal constructor(
         private const val FPTI_KEY_ENDPOINT = "endpoint"
         private const val FPTI_KEY_MERCHANT_EXPERIMENT = "experiment"
         private const val FPTI_KEY_MERCHANT_PAYMENT_METHODS_DISPLAYED = "payment_methods_displayed"
+        private const val FPTI_KEY_URL = "url"
 
         private const val FPTI_BATCH_KEY_VENMO_INSTALLED = "venmo_installed"
         private const val FPTI_BATCH_KEY_PAYPAL_INSTALLED = "paypal_installed"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -24,12 +24,8 @@ class AnalyticsClient internal constructor(
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
     private val time: Time = Time(),
     private val configurationLoader: ConfigurationLoader = ConfigurationLoader.instance,
-    private val merchantRepository: MerchantRepository
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance
 ) {
-
-    constructor() : this(
-        merchantRepository = MerchantRepository.instance
-    )
 
     private val applicationContext: Context
         get() = merchantRepository.applicationContext
@@ -275,6 +271,9 @@ class AnalyticsClient internal constructor(
     }
 
     companion object {
+
+        val lazyInstance: Lazy<AnalyticsClient> = lazy { AnalyticsClient() }
+
         private const val FPTI_ANALYTICS_URL = "https://api-m.paypal.com/v1/tracking/batch/events"
 
         private const val FPTI_KEY_PAYPAL_CONTEXT_ID = "paypal_context_id"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
@@ -15,5 +15,6 @@ internal data class AnalyticsEvent(
     val endTime: Long? = null,
     val endpoint: String? = null,
     val experiment: String? = null,
-    val paymentMethodsDisplayed: List<String> = emptyList()
+    val paymentMethodsDisplayed: List<String> = emptyList(),
+    val appSwitchUrl: String? = null
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -27,5 +27,6 @@ data class AnalyticsEventParams @JvmOverloads constructor(
     var endTime: Long? = null,
     var endpoint: String? = null,
     val experiment: String? = null,
-    val paymentMethodsDisplayed: List<String> = emptyList()
+    val paymentMethodsDisplayed: List<String> = emptyList(),
+    val appSwitchUrl: String? = null
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -16,10 +16,7 @@ internal class ConfigurationLoader(
      * This should be refactored to remove the circular dependency.
      */
     lazyAnalyticsClient: Lazy<AnalyticsClient> = lazy {
-        AnalyticsClient(
-            httpClient = httpClient,
-            merchantRepository = merchantRepository
-        )
+        AnalyticsClient(httpClient = httpClient)
     },
 ) {
     private val analyticsClient: AnalyticsClient by lazyAnalyticsClient

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -15,7 +15,12 @@ internal class ConfigurationLoader(
      * TODO: AnalyticsClient must be lazy due to the circular dependency between ConfigurationLoader and AnalyticsClient
      * This should be refactored to remove the circular dependency.
      */
-    lazyAnalyticsClient: Lazy<AnalyticsClient> = lazy { AnalyticsClient(httpClient) },
+    lazyAnalyticsClient: Lazy<AnalyticsClient> = lazy {
+        AnalyticsClient(
+            httpClient = httpClient,
+            merchantRepository = merchantRepository
+        )
+    },
 ) {
     private val analyticsClient: AnalyticsClient by lazyAnalyticsClient
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
@@ -47,6 +47,7 @@ class AnalyticsClientUnitTest {
     private lateinit var sut: AnalyticsClient
 
     private var timestamp: Long = 0
+    private val returnUrlScheme = "com.braintreepayments.demo.braintree"
 
     @Before
     @Throws(InvalidArgumentException::class, GeneralSecurityException::class, IOException::class)
@@ -74,6 +75,7 @@ class AnalyticsClientUnitTest {
         every { time.currentTime } returns 123
         every { merchantRepository.authorization } returns authorization
         every { merchantRepository.applicationContext } returns context
+        every { merchantRepository.returnUrlScheme } returns returnUrlScheme
 
         configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -103,7 +105,7 @@ class AnalyticsClientUnitTest {
             )
         } returns mockk()
 
-        sut.sendEvent(eventName)
+        sut.sendEvent(eventName, AnalyticsEventParams(appSwitchUrl = returnUrlScheme))
 
         val workSpec = workRequestSlot.captured.workSpec
         assertEquals(AnalyticsWriteToDbWorker::class.java.name, workSpec.workerClassName)
@@ -115,7 +117,8 @@ class AnalyticsClientUnitTest {
           "event_name": "sample-event-name",
           "t": 123,
           "is_vault": false,
-          "tenant_name": "Braintree"
+          "tenant_name": "Braintree",
+          "url": "$returnUrlScheme"
         }
         """
         val actualJSON = workSpec.input.getString(WORK_INPUT_KEY_ANALYTICS_JSON)!!

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAnalytics.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAnalytics.kt
@@ -8,11 +8,14 @@ internal object VenmoAnalytics {
     const val TOKENIZE_SUCCEEDED = "venmo:tokenize:succeeded"
     const val APP_SWITCH_CANCELED = "venmo:tokenize:app-switch:canceled"
 
-    // Additional Detail Events
+    // Launching App Switch events
+    const val APP_SWITCH_STARTED = "venmo:tokenize:app-switch:started"
     const val APP_SWITCH_SUCCEEDED = "venmo:tokenize:app-switch:succeeded"
     const val APP_SWITCH_FAILED = "venmo:tokenize:app-switch:failed"
 
-    // App Switch events
-    const val APP_SWITCH_STARTED = "venmo:tokenize:app-switch:started"
+    // Handle return events
     const val HANDLE_RETURN_STARTED = "venmo:tokenize:handle-return:started"
+    const val HANDLE_RETURN_SUCCEEDED = "venmo:tokenize:handle-return:succeeded"
+    const val HANDLE_RETURN_FAILED = "venmo:tokenize:handle-return:failed"
+    const val HANDLE_RETURN_NO_RESULT = "venmo:tokenize:handle-return:no-result"
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAnalytics.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAnalytics.kt
@@ -11,4 +11,8 @@ internal object VenmoAnalytics {
     // Additional Detail Events
     const val APP_SWITCH_SUCCEEDED = "venmo:tokenize:app-switch:succeeded"
     const val APP_SWITCH_FAILED = "venmo:tokenize:app-switch:failed"
+
+    // App Switch events
+    const val APP_SWITCH_STARTED = "venmo:tokenize:app-switch:started"
+    const val HANDLE_RETURN_STARTED = "venmo:tokenize:handle-return:started"
 }

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
@@ -335,7 +335,7 @@ class VenmoClient internal constructor(
 
     private val analyticsParams: AnalyticsEventParams
         get() {
-            val eventParameters = AnalyticsEventParams()
+            val eventParameters = AnalyticsEventParams(appSwitchUrl = merchantRepository.returnUrlScheme)
             eventParameters.payPalContextId = payPalContextId
             eventParameters.linkType = LINK_TYPE
             eventParameters.isVaultRequest = isVaultRequest

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
@@ -32,6 +32,7 @@ class VenmoClient internal constructor(
     private val sharedPrefsWriter: VenmoSharedPrefsWriter = VenmoSharedPrefsWriter(),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
+    private val venmoRepository: VenmoRepository = VenmoRepository.instance
 ) {
     /**
      * Used for linking events from the client to server side request
@@ -182,6 +183,8 @@ class VenmoClient internal constructor(
             )
             .appendQueryParameter("customerClient", "MOBILE_APP")
             .build()
+
+        venmoRepository.venmoUrl = venmoBaseURL
 
         val browserSwitchOptions = BrowserSwitchOptions()
             .requestCode(BraintreeRequestCodes.VENMO.code)
@@ -335,7 +338,7 @@ class VenmoClient internal constructor(
 
     private val analyticsParams: AnalyticsEventParams
         get() {
-            val eventParameters = AnalyticsEventParams(appSwitchUrl = merchantRepository.returnUrlScheme)
+            val eventParameters = AnalyticsEventParams(appSwitchUrl = venmoRepository.venmoUrl.toString())
             eventParameters.payPalContextId = payPalContextId
             eventParameters.linkType = LINK_TYPE
             eventParameters.isVaultRequest = isVaultRequest

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
@@ -10,20 +10,19 @@ import com.braintreepayments.api.BrowserSwitchStartResult
 import com.braintreepayments.api.core.AnalyticsClient
 import com.braintreepayments.api.core.AnalyticsEventParams
 import com.braintreepayments.api.core.BraintreeException
-import com.braintreepayments.api.core.MerchantRepository
 
 /**
  * Responsible for launching the Venmo app to authenticate users
  */
 class VenmoLauncher internal constructor(
     private val browserSwitchClient: BrowserSwitchClient,
-    private val merchantRepository: MerchantRepository,
+    private val venmoRepository: VenmoRepository,
     lazyAnalyticsClient: Lazy<AnalyticsClient>,
 ) {
 
     constructor() : this(
         browserSwitchClient = BrowserSwitchClient(),
-        merchantRepository = MerchantRepository.instance,
+        venmoRepository = VenmoRepository.instance,
         lazyAnalyticsClient = AnalyticsClient.lazyInstance
     )
 
@@ -124,7 +123,9 @@ class VenmoLauncher internal constructor(
         browserSwitchClient.assertCanPerformBrowserSwitch(activity, params.browserSwitchOptions)
     }
 
-    private val analyticsEventParams by lazy { AnalyticsEventParams(appSwitchUrl = merchantRepository.returnUrlScheme) }
+    private val analyticsEventParams by lazy {
+        AnalyticsEventParams(appSwitchUrl = venmoRepository.venmoUrl.toString())
+    }
 
     companion object {
         private const val VENMO_PACKAGE_NAME = "com.venmo"

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoLauncher.kt
@@ -20,7 +20,7 @@ class VenmoLauncher internal constructor(
 
     constructor() : this(
         browserSwitchClient = BrowserSwitchClient(),
-        lazyAnalyticsClient = lazy { AnalyticsClient() }
+        lazyAnalyticsClient = AnalyticsClient.lazyInstance
     )
 
     private val analyticsClient: AnalyticsClient by lazyAnalyticsClient

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoRepository.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoRepository.kt
@@ -1,0 +1,22 @@
+package com.braintreepayments.api.venmo
+
+import android.net.Uri
+
+/**
+ * An internal, in memory repository that holds properties specific for the Venmo payment flow.
+ */
+internal class VenmoRepository {
+
+    /**
+     * The Venmo URL that is used to load the CCT or app switch into the Venmo payment flow.
+     */
+    var venmoUrl: Uri? = null
+
+    companion object {
+
+        /**
+         * Singleton instance of the VenmoRepository.
+         */
+        val instance: VenmoRepository by lazy { VenmoRepository() }
+    }
+}

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
@@ -65,7 +65,7 @@ public class VenmoClientUnitTest {
     private final Uri CANCEL_URL = Uri.parse("sample-scheme://x-callback-url/vzero/auth/venmo/cancel");
 
     private final String LINK_TYPE = "universal";
-    private final String appSwitchUrl = "com.braintreepayments.demo.braintree";
+    private final Uri appSwitchUrl = Uri.parse("https://example.com");
     private final AnalyticsEventParams expectedAnalyticsParams = new AnalyticsEventParams(
         null,
         LINK_TYPE,
@@ -75,7 +75,7 @@ public class VenmoClientUnitTest {
         null,
         null,
         new ArrayList<>(),
-        appSwitchUrl
+        appSwitchUrl.toString()
     );
     private final AnalyticsEventParams expectedVaultAnalyticsParams = new AnalyticsEventParams(
         null,
@@ -86,10 +86,11 @@ public class VenmoClientUnitTest {
         null,
         null,
         new ArrayList<>(),
-        appSwitchUrl
+        appSwitchUrl.toString()
     );
 
     private final MerchantRepository merchantRepository = mock(MerchantRepository.class);
+    private final VenmoRepository venmoRepository = mock(VenmoRepository.class);
 
     @Before
     public void beforeEach() throws JSONException {
@@ -114,7 +115,7 @@ public class VenmoClientUnitTest {
         when(analyticsParamRepository.getSessionId()).thenReturn("session-id");
         when(merchantRepository.getIntegrationType()).thenReturn(IntegrationType.CUSTOM);
         when(merchantRepository.getApplicationContext()).thenReturn(context);
-        when(merchantRepository.getReturnUrlScheme()).thenReturn(appSwitchUrl);
+        when(venmoRepository.getVenmoUrl()).thenReturn(appSwitchUrl);
     }
 
     @Test
@@ -142,7 +143,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -178,7 +180,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -227,7 +230,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -256,7 +260,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -291,7 +296,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -329,7 +335,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -363,7 +370,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_STARTED, new AnalyticsEventParams());
@@ -391,7 +399,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -420,7 +429,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -449,7 +459,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -477,7 +488,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
 
@@ -504,7 +516,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -529,7 +542,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -563,7 +577,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -600,7 +615,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -641,7 +657,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -661,7 +678,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -695,7 +713,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -717,7 +736,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -747,7 +767,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -787,7 +808,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -822,7 +844,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);
@@ -866,7 +889,8 @@ public class VenmoClientUnitTest {
             venmoApi,
             sharedPrefsWriter,
             analyticsParamRepository,
-            merchantRepository
+            merchantRepository,
+            venmoRepository
         );
 
         sut.tokenize(paymentAuthResult, venmoTokenizeCallback);

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.venmo
 
 import android.content.Intent
+import android.net.Uri
 import androidx.activity.ComponentActivity
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchException
@@ -9,7 +10,6 @@ import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.BrowserSwitchStartResult
 import com.braintreepayments.api.core.AnalyticsClient
 import com.braintreepayments.api.core.AnalyticsEventParams
-import com.braintreepayments.api.core.MerchantRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,7 +27,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class VenmoLauncherUnitTest {
     private val browserSwitchClient: BrowserSwitchClient = mockk(relaxed = true)
-    private val merchantRepository: MerchantRepository = mockk(relaxed = true)
+    private val venmoRepository: VenmoRepository = mockk(relaxed = true)
     private val analyticsClient: AnalyticsClient = mockk(relaxed = true)
     private val activity: ComponentActivity = mockk(relaxed = true)
     private val paymentAuthRequestParams: VenmoPaymentAuthRequestParams = mockk(relaxed = true)
@@ -37,14 +37,14 @@ class VenmoLauncherUnitTest {
 
     private lateinit var sut: VenmoLauncher
 
-    private val appSwitchUrl = "com.braintreepayments.demo.braintree"
+    private val appSwitchUrl = Uri.parse("http://example.com")
 
     @Before
     fun setup() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
-        every { merchantRepository.returnUrlScheme } returns appSwitchUrl
+        every { venmoRepository.venmoUrl } returns appSwitchUrl
 
-        sut = VenmoLauncher(browserSwitchClient, merchantRepository, lazy { analyticsClient })
+        sut = VenmoLauncher(browserSwitchClient, venmoRepository, lazy { analyticsClient })
     }
 
     @Test
@@ -54,7 +54,7 @@ class VenmoLauncherUnitTest {
         verify {
             analyticsClient.sendEvent(
                 eventName = VenmoAnalytics.APP_SWITCH_STARTED,
-                analyticsEventParams = AnalyticsEventParams(appSwitchUrl = appSwitchUrl)
+                analyticsEventParams = AnalyticsEventParams(appSwitchUrl = appSwitchUrl.toString())
             )
         }
     }
@@ -121,7 +121,7 @@ class VenmoLauncherUnitTest {
         verify {
             analyticsClient.sendEvent(
                 eventName = VenmoAnalytics.HANDLE_RETURN_STARTED,
-                analyticsEventParams = AnalyticsEventParams(appSwitchUrl = appSwitchUrl)
+                analyticsEventParams = AnalyticsEventParams(appSwitchUrl = appSwitchUrl.toString())
             )
         }
     }

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
@@ -34,7 +34,7 @@ class VenmoLauncherUnitTest {
     @Before
     fun setup() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
-        sut = VenmoLauncher(browserSwitchClient)
+        sut = VenmoLauncher(browserSwitchClient, lazy { mockk(relaxed = true) })
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Add `app-switch:started` and `handle-return:started` events for the Venmo integration
 - Add `url` analytics parameter for Venmo events. This value represents the `appSwitchUrl`

I also validated these changes in Lighthouse.

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

