### PR TITLE
Fix for landscape mode crash in 3DS

### DIFF
--- a/SEPADirectDebit/AndroidManifest.xml
+++ b/SEPADirectDebit/AndroidManifest.xml
@@ -1,10 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
-
     <application>
-
-        <!--suppress AndroidDomInspection -->
         <activity
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:name=".TestActivity" />

--- a/ThreeDSecure/src/main/AndroidManifest.xml
+++ b/ThreeDSecure/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <application>
         <activity
             android:name=".ThreeDSecureActivity"
-            android:theme="@style/Theme.Translucent.NoTitleBar.Fullscreen" />
+            android:theme="@style/Theme.Translucent.NoTitleBar.Fullscreen"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
     </application>
 </manifest>


### PR DESCRIPTION
Crashing occurs when user switches to landscape mode when 3DS screen is loading. Issue is occurring on devices running Android 8.0 (API 26)

https://github.com/user-attachments/assets/59bdf304-b3d7-43c9-a6a4-36a62ab164fd

### Summary of changes

 - Added changes to 3DS manifest to fix the crash

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

