### PR TITLE
Add Contact Information request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * LocalPayment
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
+* PayPal
+  * Add `PayPalContactInformation` request object
+  * Add `PayPalCheckoutRequest.contactInformation` optional property
 
 ## 5.2.0 (2024-10-30)
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -64,6 +64,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     var currencyCode: String? = null,
     var shouldRequestBillingAgreement: Boolean = false,
     var shouldOfferPayLater: Boolean = false,
+    var contactInformation: PayPalContactInformation? = null,
     override var localeCode: String? = null,
     override var billingAgreementDescription: String? = null,
     override var isShippingAddressRequired: Boolean = false,
@@ -125,6 +126,11 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
         }
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
+
+        contactInformation?.let { info ->
+            info.recipientEmail?.let { parameters.put(RECIPIENT_EMAIL_KEY, it) }
+            info.recipentPhoneNumber?.let { parameters.put(RECIPIENT_PHONE_NUMBER_KEY, it.toJson()) }
+        }
 
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactInformation.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactInformation.kt
@@ -1,0 +1,30 @@
+package com.braintreepayments.api.paypal
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
+
+/**
+ * Representation of a recipient Contact Information for the order.
+ *
+ * @property recipientEmail Email address of the recipient.
+ * @property recipentPhoneNumber Phone number of the recipient.
+ */
+@Parcelize
+data class PayPalContactInformation(
+    val recipientEmail: String?,
+    val recipentPhoneNumber: PayPalPhoneNumber?
+) : Parcelable {
+
+    internal fun toJson(): JSONObject {
+        return JSONObject().apply {
+            put(RECIPIENT_EMAIL_KEY, recipientEmail)
+            put(RECIPIENT_PHONE_NUMBER_KEY, recipentPhoneNumber)
+        }
+    }
+
+    companion object {
+        private const val RECIPIENT_EMAIL_KEY: String = "recipient_email"
+        private const val RECIPIENT_PHONE_NUMBER_KEY: String = "international_phone"
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactInformation.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactInformation.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api.paypal
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import org.json.JSONObject
 
 /**
  * Representation of a recipient Contact Information for the order.
@@ -12,19 +11,6 @@ import org.json.JSONObject
  */
 @Parcelize
 data class PayPalContactInformation(
-    val recipientEmail: String?,
-    val recipentPhoneNumber: PayPalPhoneNumber?
-) : Parcelable {
-
-    internal fun toJson(): JSONObject {
-        return JSONObject().apply {
-            put(RECIPIENT_EMAIL_KEY, recipientEmail)
-            put(RECIPIENT_PHONE_NUMBER_KEY, recipentPhoneNumber)
-        }
-    }
-
-    companion object {
-        private const val RECIPIENT_EMAIL_KEY: String = "recipient_email"
-        private const val RECIPIENT_PHONE_NUMBER_KEY: String = "international_phone"
-    }
-}
+    val recipientEmail: String? = null,
+    val recipentPhoneNumber: PayPalPhoneNumber? = null
+) : Parcelable

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -132,5 +132,7 @@ abstract class PayPalRequest internal constructor(
         internal const val PLAN_TYPE_KEY: String = "plan_type"
         internal const val PLAN_METADATA_KEY: String = "plan_metadata"
         internal const val PHONE_NUMBER_KEY: String = "phone_number"
+        internal const val RECIPIENT_EMAIL_KEY: String = "recipient_email"
+        internal const val RECIPIENT_PHONE_NUMBER_KEY: String = "international_phone"
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
@@ -171,4 +171,37 @@ public class PayPalCheckoutRequestUnitTest {
 
         assertTrue(requestBody.contains("\"phone_number\":{\"country_code\":\"1\",\"national_number\":\"1231231234\"}"));
     }
+
+    @Test
+    public void createRequestBody_sets_contactInformation_when_not_null() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        request.setContactInformation(new PayPalContactInformation("some@email.com", new PayPalPhoneNumber("1", "1234567890")));
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        assertTrue(requestBody.contains("\"recipient_email\":\"some@email.com\""));
+        assertTrue(requestBody.contains("\"international_phone\":{\"country_code\":\"1\",\"national_number\":\"1234567890\"}"));
+    }
+
+    @Test
+    public void createRequestBody_does_not_set_contactInformation_when_contactInformation_is_null() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                null
+        );
+
+        assertFalse(requestBody.contains("\"recipient_email\":\"some@email.com\""));
+        assertFalse(requestBody.contains("\"international_phone\":{\"country_code\":\"1\",\"national_number\":\"1234567890\"}"));
+    }
 }


### PR DESCRIPTION
### Summary of changes

Introduces support for passing recipient contact information in the `PayPalCheckoutRequest`
- A new class `PayPalContactInformation` was created to encapsulate the recipient's contact information for the order.
   Properties: `recipientEmail` and`recipientPhoneNumber`
- Updated PayPalCheckoutRequest: Added a new optional property `contactInformation` of type `PayPalContactInformation`.
- The `contactInformation.recipientEmail` and `contactInformation.recipientPhoneNumber` are passed to the `create_payment_resource` endpoint as the `recipient_email`  and `international_phone` parameters when present.

**Note:** When the new parameters (recipient_email and international_phone) are included, the gateway returns an error. I will follow up with updates once I gather more information or implement any necessary fixes.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [ ] **Pending:** Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 
