### PR TITLE
Add `isPayPalAppInstalled` and `isVenmoAppInstalled` to Shopper Insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * LocalPayment
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
+* ShopperInsights (BETA)
+  * Add `isPayPalAppInstalled` and `isVenmoAppInstalled` methods
 
 ## 5.2.0 (2024-10-30)
 

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -41,7 +41,7 @@ class ShopperInsightsClient internal constructor(
      * @param authorization: a Tokenization Key or Client Token used to authenticate
      */
     constructor(context: Context, authorization: String) : this(
-        BraintreeClient(context, authorization),
+        BraintreeClient(context, authorization)
     )
 
     /**

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -5,6 +5,7 @@ import com.braintreepayments.api.core.AnalyticsEventParams
 import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
+import com.braintreepayments.api.core.DeviceInspector
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.TokenizationKey
@@ -32,6 +33,7 @@ class ShopperInsightsClient internal constructor(
         EligiblePaymentsApi(braintreeClient, analyticsParamRepository)
     ),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
+    private val deviceInspector: DeviceInspector = DeviceInspector(),
 ) {
 
     /**
@@ -39,7 +41,7 @@ class ShopperInsightsClient internal constructor(
      * @param authorization: a Tokenization Key or Client Token used to authenticate
      */
     constructor(context: Context, authorization: String) : this(
-        BraintreeClient(context, authorization)
+        BraintreeClient(context, authorization),
     )
 
     /**
@@ -214,6 +216,20 @@ class ShopperInsightsClient internal constructor(
      */
     fun sendVenmoSelectedEvent() {
         braintreeClient.sendAnalyticsEvent(VENMO_SELECTED)
+    }
+
+    /**
+     * Indicates whether the PayPal App is installed.
+     */
+    fun isPayPalAppInstalled(context: Context): Boolean {
+        return deviceInspector.isPayPalInstalled(context)
+    }
+
+    /**
+     * Indicates whether the Venmo App is installed.
+     */
+    fun isVenmoAppInstalled(context: Context): Boolean {
+        return deviceInspector.isVenmoInstalled(context)
     }
 
     companion object {

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -54,7 +54,12 @@ class ShopperInsightsClientUnitTest {
 
         every { merchantRepository.authorization } returns clientToken
 
-        sut = ShopperInsightsClient(braintreeClient, analyticsParamRepository, api, merchantRepository)
+        sut = ShopperInsightsClient(
+            braintreeClient,
+            analyticsParamRepository,
+            api,
+            merchantRepository,
+        )
         context = ApplicationProvider.getApplicationContext()
     }
 
@@ -403,7 +408,12 @@ class ShopperInsightsClientUnitTest {
         every { merchantRepository.authorization } returns mockk<TokenizationKey>()
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
-        sut = ShopperInsightsClient(braintreeClient, analyticsParamRepository, api, merchantRepository)
+        sut = ShopperInsightsClient(
+            braintreeClient,
+            analyticsParamRepository,
+            api,
+            merchantRepository,
+        )
 
         val request = ShopperInsightsRequest("some-email", null)
         sut.getRecommendedPaymentMethods(request) { result ->

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -7,6 +7,7 @@ import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.ClientToken
+import com.braintreepayments.api.core.DeviceInspector
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.TokenizationKey
@@ -42,6 +43,7 @@ class ShopperInsightsClientUnitTest {
     private lateinit var analyticsParamRepository: AnalyticsParamRepository
     private lateinit var merchantRepository: MerchantRepository
     private lateinit var context: Context
+    private lateinit var deviceInspector: DeviceInspector
 
     private val clientToken = mockk<ClientToken>()
 
@@ -51,6 +53,7 @@ class ShopperInsightsClientUnitTest {
         braintreeClient = mockk(relaxed = true)
         analyticsParamRepository = mockk(relaxed = true)
         merchantRepository = mockk(relaxed = true)
+        deviceInspector = mockk(relaxed = true)
 
         every { merchantRepository.authorization } returns clientToken
 
@@ -59,6 +62,7 @@ class ShopperInsightsClientUnitTest {
             analyticsParamRepository,
             api,
             merchantRepository,
+            deviceInspector
         )
         context = ApplicationProvider.getApplicationContext()
     }
@@ -450,6 +454,30 @@ class ShopperInsightsClientUnitTest {
     fun `test venmo selected analytics event`() {
         sut.sendVenmoSelectedEvent()
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected") }
+    }
+
+    @Test
+    fun `test isPayPalAppInstalled returns true when deviceInspector returns true`() {
+        every { deviceInspector.isPayPalInstalled(context) } returns true
+        assertTrue { sut.isPayPalAppInstalled(context) }
+    }
+
+    @Test
+    fun `test isVenmoAppInstalled returns true when deviceInspector returns true`() {
+        every { deviceInspector.isVenmoInstalled(context) } returns true
+        assertTrue { sut.isVenmoAppInstalled(context) }
+    }
+
+    @Test
+    fun `test isPayPalAppInstalled returns false when deviceInspector returns false`() {
+        every { deviceInspector.isPayPalInstalled(context) } returns false
+        assertFalse { sut.isPayPalAppInstalled(context) }
+    }
+
+    @Test
+    fun `test isVenmoAppInstalled returns false when deviceInspector returns false`() {
+        every { deviceInspector.isVenmoInstalled(context) } returns false
+        assertFalse { sut.isVenmoAppInstalled(context) }
     }
 
     private fun executeTestForFindEligiblePaymentsApi(


### PR DESCRIPTION
### Summary of changes

 - Add `isPayPalAppInstalled` and `isVenmoAppInstalled`methods to `ShopperInsightsClient`

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@sarahkoop 
