### PR TITLE
Add `sessionId` to `ShopperInsightsClient`

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -30,6 +30,10 @@ class AnalyticsParamRepository(
         _sessionId = uuidHelper.formattedUUID
     }
 
+    fun overrideSessionId(sessionId: String) {
+        _sessionId = sessionId
+    }
+
     companion object {
 
         /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -30,7 +30,7 @@ class AnalyticsParamRepository(
         _sessionId = uuidHelper.formattedUUID
     }
 
-    fun overrideSessionId(sessionId: String) {
+    fun setSessionId(sessionId: String) {
         _sessionId = sessionId
     }
 

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
@@ -43,8 +43,8 @@ class AnalyticsParamRepositoryUnitTest {
     }
 
     @Test
-    fun `overrideSessionId overrides the session ID with input value`() {
-        sut.overrideSessionId("override-session-id")
+    fun `setSessionId sets the session ID with input value`() {
+        sut.setSessionId("override-session-id")
         assertEquals("override-session-id", sut.sessionId)
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
@@ -41,4 +41,10 @@ class AnalyticsParamRepositoryUnitTest {
 
         assertEquals(newUuid, sut.sessionId)
     }
+
+    @Test
+    fun `overrideSessionId overrides the session ID with input value`() {
+        sut.overrideSessionId("override-session-id")
+        assertEquals("override-session-id", sut.sessionId)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
 * ShopperInsights (BETA)
   * Add `isPayPalAppInstalled` and `isVenmoAppInstalled` methods
+  * Add `shopperSessionId` parameter to `ShopperInsightsClient`
 
 ## 5.2.0 (2024-10-30)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -65,7 +65,7 @@ class ShopperInsightsFragment : BaseFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg)
+        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg, "test-shopper-session-id")
 
         venmoClient = VenmoClient(requireContext(), super.getAuthStringArg(), null)
         payPalClient = PayPalClient(

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -40,20 +40,15 @@ class ShopperInsightsClient internal constructor(
     /**
      * @param context: an Android context
      * @param authorization: a Tokenization Key or Client Token used to authenticate
-     */
-    constructor(context: Context, authorization: String) : this(
-        BraintreeClient(context, authorization)
-    )
-    /**
-     * @param context: an Android context
-     * @param authorization: a Tokenization Key or Client Token used to authenticate
      * @param shopperSessionId: the shopper session ID returned from your server SDK request
      */
-    constructor(context: Context, authorization: String, shopperSessionId: String) : this(
+    constructor(context: Context, authorization: String, shopperSessionId: String? = null) : this(
         BraintreeClient(context, authorization),
         shopperSessionId = shopperSessionId
     ) {
-        analyticsParamRepository.overrideSessionId(sessionId = shopperSessionId)
+        if (shopperSessionId != null) {
+            analyticsParamRepository.setSessionId(sessionId = shopperSessionId)
+        }
     }
 
     /**

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -71,7 +71,7 @@ class ShopperInsightsClient internal constructor(
         experiment: String? = null,
         callback: ShopperInsightsCallback
     ) {
-        if(shopperSessionId == null) {
+        if (shopperSessionId == null) {
             analyticsParamRepository.resetSessionId()
         }
         braintreeClient.sendAnalyticsEvent(

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -34,6 +34,7 @@ class ShopperInsightsClient internal constructor(
     ),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
     private val deviceInspector: DeviceInspector = DeviceInspector(),
+    private val shopperSessionId: String? = null
 ) {
 
     /**
@@ -43,6 +44,16 @@ class ShopperInsightsClient internal constructor(
     constructor(context: Context, authorization: String) : this(
         BraintreeClient(context, authorization)
     )
+    /**
+     * @param context: an Android context
+     * @param authorization: a Tokenization Key or Client Token used to authenticate
+     */
+    constructor(context: Context, authorization: String, shopperSessionId: String) : this(
+        BraintreeClient(context, authorization),
+        shopperSessionId = shopperSessionId
+    ) {
+        analyticsParamRepository.overrideSessionId(sessionId = shopperSessionId)
+    }
 
     /**
      * Retrieves recommended payment methods based on the provided shopper insights request.
@@ -59,7 +70,9 @@ class ShopperInsightsClient internal constructor(
         experiment: String? = null,
         callback: ShopperInsightsCallback
     ) {
-        analyticsParamRepository.resetSessionId()
+        if(shopperSessionId == null) {
+            analyticsParamRepository.resetSessionId()
+        }
         braintreeClient.sendAnalyticsEvent(
             GET_RECOMMENDED_PAYMENTS_STARTED,
             AnalyticsEventParams(experiment = experiment)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -47,6 +47,7 @@ class ShopperInsightsClient internal constructor(
     /**
      * @param context: an Android context
      * @param authorization: a Tokenization Key or Client Token used to authenticate
+     * @param shopperSessionId: the shopper session ID returned from your server SDK request
      */
     constructor(context: Context, authorization: String, shopperSessionId: String) : this(
         BraintreeClient(context, authorization),

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -68,10 +68,26 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `when getRecommendedPaymentMethods is called, session id is reset`() {
+    fun `when getRecommendedPaymentMethods is called without shopper session id, session id is reset`() {
         sut.getRecommendedPaymentMethods(mockk(relaxed = true), "some_experiment", mockk(relaxed = true))
 
         verify { analyticsParamRepository.resetSessionId() }
+    }
+
+    @Test
+    fun `when getRecommendedPaymentMethods is called with shopper session id, session id is not reset`() {
+        sut = ShopperInsightsClient(
+            braintreeClient,
+            analyticsParamRepository,
+            api,
+            merchantRepository,
+            deviceInspector,
+            "shopper-session-id"
+        )
+
+        sut.getRecommendedPaymentMethods(mockk(relaxed = true), "some_experiment", mockk(relaxed = true))
+
+        verify(exactly = 0) { analyticsParamRepository.resetSessionId() }
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Add `sessionId` parameter to `ShopperInsightsClient` and pass parameter as `session_id` analytics field
 - Tested and confirmed the session ID passed to the demo app client is correctly appearing as `session_id` field in FPTI

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@sarahkoop 
