### PR TITLE
Add `ThreeDSecureRequest.requestorAppUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 * PayPal
   * Add `deepLinkFallbackUrlScheme` to `PayPalClient` constructor params for supporting deep link fallback
+  * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
 * LocalPayment
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
-* PayPal
-  * Send `url` in `event_params` for App Switch events to PayPal's analytics service (FPTI)
+* ThreeDSecure
+  * Add `ThreeDSecureRequest.threeDSRequestorAppUrl`
 
 ## 5.2.0 (2024-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * LocalPayment
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
 * ThreeDSecure
-  * Add `ThreeDSecureRequest.threeDSRequestorAppUrl`
+  * Add `ThreeDSecureRequest.requestorAppUrl`
 
 ## 5.2.0 (2024-10-30)
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/CardinalClient.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/CardinalClient.kt
@@ -109,8 +109,8 @@ internal class CardinalClient {
             cardinalConfigurationParameters.uiCustomization = it.cardinalUiCustomization
         }
 
-        request.threeDSRequestorAppUrl?.let {
-            cardinalConfigurationParameters.threeDSRequestorAppURL = request.threeDSRequestorAppUrl
+        request.requestorAppUrl?.let {
+            cardinalConfigurationParameters.threeDSRequestorAppURL = request.requestorAppUrl
         }
         try {
             Cardinal.getInstance().configure(context, cardinalConfigurationParameters)

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/CardinalClient.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/CardinalClient.kt
@@ -109,6 +109,9 @@ internal class CardinalClient {
             cardinalConfigurationParameters.uiCustomization = it.cardinalUiCustomization
         }
 
+        request.threeDSRequestorAppUrl?.let {
+            cardinalConfigurationParameters.threeDSRequestorAppURL = request.threeDSRequestorAppUrl
+        }
         try {
             Cardinal.getInstance().configure(context, cardinalConfigurationParameters)
         } catch (e: RuntimeException) {

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
@@ -49,7 +49,7 @@ import org.json.JSONObject
  * @property customFields Optional. Object where each key is the name of a custom field which has
  * been configured in the Control Panel. In the Control Panel you can configure 3D Secure Rules
  * which trigger on certain values.
- * @property threeDSRequestorAppUrl Optional. Three DS Requester APP URL Merchant app declaring their
+ * @property requestorAppUrl Optional. Three DS Requester APP URL Merchant app declaring their
  * URL within the CReq message so that the Authentication app can call the Merchant app after
  * OOB authentication has occurred.
  */
@@ -72,7 +72,7 @@ data class ThreeDSecureRequest @JvmOverloads constructor(
     var uiType: ThreeDSecureUiType = ThreeDSecureUiType.BOTH,
     var renderTypes: List<ThreeDSecureRenderType>? = null,
     var customFields: Map<String, String>? = null,
-    var threeDSRequestorAppUrl: String? = null
+    var requestorAppUrl: String? = null
 ) : Parcelable {
 
     /**

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequest.kt
@@ -49,6 +49,9 @@ import org.json.JSONObject
  * @property customFields Optional. Object where each key is the name of a custom field which has
  * been configured in the Control Panel. In the Control Panel you can configure 3D Secure Rules
  * which trigger on certain values.
+ * @property threeDSRequestorAppUrl Optional. Three DS Requester APP URL Merchant app declaring their
+ * URL within the CReq message so that the Authentication app can call the Merchant app after
+ * OOB authentication has occurred.
  */
 @Parcelize
 data class ThreeDSecureRequest @JvmOverloads constructor(
@@ -68,7 +71,8 @@ data class ThreeDSecureRequest @JvmOverloads constructor(
     var v2UiCustomization: ThreeDSecureV2UiCustomization? = null,
     var uiType: ThreeDSecureUiType = ThreeDSecureUiType.BOTH,
     var renderTypes: List<ThreeDSecureRenderType>? = null,
-    var customFields: Map<String, String>? = null
+    var customFields: Map<String, String>? = null,
+    var threeDSRequestorAppUrl: String? = null
 ) : Parcelable {
 
     /**

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
@@ -185,7 +185,6 @@ class CardinalClientUnitTest {
         assertEquals(exceptionSlot.captured.message, "consumer session id not available")
     }
 
-
     @Test
     fun `when cardinal configuration is called with a requestorAppUrl, sets threeDSRequestorAppURL`() {
         every { Cardinal.getInstance() } returns cardinalInstance

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
@@ -185,6 +185,23 @@ class CardinalClientUnitTest {
         assertEquals(exceptionSlot.captured.message, "consumer session id not available")
     }
 
+
+    @Test
+    fun `when cardinal configuration is called with a requestorAppUrl, sets threeDSRequestorAppURL`() {
+        every { Cardinal.getInstance() } returns cardinalInstance
+
+        val sut = CardinalClient()
+        val request = ThreeDSecureRequest()
+        request.requestorAppUrl = "www.paypal.com"
+        sut.initialize(context, configuration, request, cardinalInitializeCallback)
+
+        val parametersSlot = slot<CardinalConfigurationParameters>()
+        verify { cardinalInstance.configure(context, capture(parametersSlot)) }
+
+        val parameters = parametersSlot.captured
+        assertEquals("www.paypal.com", parameters.threeDSRequestorAppURL)
+    }
+
     @Test
     fun initialize_onCardinalConfigureRuntimeException_throwsError() {
         every { Cardinal.getInstance() } returns cardinalInstance


### PR DESCRIPTION
### Summary of changes

 - Add `ThreeDSecureRequest.requestorAppUrl` - this is a new property required by Mastercard for 3DS for out of band transactions. There was an internal request from a large merchant for exposing this field.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 