### PR TITLE
Fixup CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   * Make LocalPaymentAuthRequestParams public (fixes #1207)
 * ThreeDSecure
   * Add `ThreeDSecureRequest.requestorAppUrl`
+* Venmo
+  * Add `VenmoClient` constructor with `appLinkReturnUri` argument to use App Links when redirecting back from the Venmo flow
+  * Deprecate `VenmoClient` constructor with `returnUrlScheme` argument
 
 ## 5.2.0 (2024-10-30)
 
@@ -17,9 +20,6 @@
 * Shopper Insights (BETA)
   * For analytics, send `experiment` as a parameter to `getRecommendedPaymentMethods` method
   * For analytics, send `experiment` and `paymentMethodsDisplayed` analytic metrics to FPTI via the button presented event methods
-* Venmo
-  * Add `VenmoClient` constructor with `appLinkReturnUri` argument to use App Links when redirecting back from the Venmo flow
-  * Deprecate `VenmoClient` constructor with `returnUrlScheme` argument
 
 ## 5.1.0 (2024-10-15)
 


### PR DESCRIPTION
### Summary of changes

 - The `appLinkReturnUrl` entry accidentally made it under a previous release, this moves it under unreleased

### Checklist

 - [x] Added a changelog entry
 - ~[ ] Relevant test coverage~
 - ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

@jaxdesmarais 