### PR TITLE
Shopper insights rp1 feature include session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Add `isPayPalAppInstalled` and `isVenmoAppInstalled` methods
   * Add `shopperSessionId` parameter to `ShopperInsightsClient`
 * BraintreePayPal
-  * Add `shopperSessionInsight`
+  * Add `shopperSessionId` to `PayPalCheckoutRequest` and `PayPalVaultRequest`
 
 ## 5.2.0 (2024-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * ShopperInsights (BETA)
   * Add `isPayPalAppInstalled` and `isVenmoAppInstalled` methods
   * Add `shopperSessionId` parameter to `ShopperInsightsClient`
+* BraintreePayPal
+  * Add `shopperSessionInsight`
 
 ## 5.2.0 (2024-10-30)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -148,7 +148,8 @@ public class PayPalFragment extends BaseFragment {
                 activity,
                 buyerEmailAddress,
                 buyerPhoneCountryCode,
-                buyerPhoneNationalNumber
+                buyerPhoneNationalNumber,
+                    null
             );
         } else {
             payPalRequest = createPayPalCheckoutRequest(
@@ -156,7 +157,8 @@ public class PayPalFragment extends BaseFragment {
                 amount,
                 buyerEmailAddress,
                 buyerPhoneCountryCode,
-                buyerPhoneNationalNumber
+                buyerPhoneNationalNumber,
+                    null
             );
         }
         payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -42,7 +42,6 @@ public class PayPalRequestFactory {
 
         if (!shopperInsightsSessionId.toString().isEmpty()) {
             request.setShopperSessionId(shopperInsightsSessionId.toString());
-            request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
         if (Settings.isPayPalAppSwithEnabled(context)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -118,21 +118,20 @@ public class PayPalRequestFactory {
         String buyerEmailAddress,
         String buyerPhoneCountryCode,
         String buyerPhoneNationalNumber,
-        Optional<String> shopperInsightsSessionId
+        String shopperInsightsSessionId
     ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount, true);
 
-        if (!buyerEmailAddress.isEmpty()) {
+        if (buyerEmailAddress != null) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
-        if (!buyerPhoneCountryCode.isEmpty() && !buyerPhoneNationalNumber.isEmpty()) {
+        if (buyerPhoneCountryCode != null && buyerPhoneNationalNumber != null) {
             request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
         }
 
-        if (!shopperInsightsSessionId.toString().isEmpty()) {
-            request.setShopperSessionId(shopperInsightsSessionId.toString());
-            request.setUserAuthenticationEmail(buyerEmailAddress);
+        if (shopperInsightsSessionId != null) {
+            request.setShopperSessionId(shopperInsightsSessionId);
         }
 
         request.setDisplayName(Settings.getPayPalDisplayName(context));

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -18,6 +18,7 @@ import com.braintreepayments.api.paypal.PayPalVaultRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class PayPalRequestFactory {
 
@@ -25,7 +26,8 @@ public class PayPalRequestFactory {
         Context context,
         String buyerEmailAddress,
         String buyerPhoneCountryCode,
-        String buyerPhoneNationalNumber
+        String buyerPhoneNationalNumber,
+        Optional<String> shopperInsightsSessionId
     ) {
 
         PayPalVaultRequest request = new PayPalVaultRequest(true);
@@ -36,6 +38,11 @@ public class PayPalRequestFactory {
 
         if (!buyerPhoneCountryCode.isEmpty() && !buyerPhoneNationalNumber.isEmpty()) {
             request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
+        }
+
+        if (!shopperInsightsSessionId.toString().isEmpty()) {
+            request.setShopperSessionId(shopperInsightsSessionId.toString());
+            request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
         if (Settings.isPayPalAppSwithEnabled(context)) {
@@ -111,7 +118,8 @@ public class PayPalRequestFactory {
         String amount,
         String buyerEmailAddress,
         String buyerPhoneCountryCode,
-        String buyerPhoneNationalNumber
+        String buyerPhoneNationalNumber,
+        Optional<String> shopperInsightsSessionId
     ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount, true);
 
@@ -121,6 +129,11 @@ public class PayPalRequestFactory {
 
         if (!buyerPhoneCountryCode.isEmpty() && !buyerPhoneNationalNumber.isEmpty()) {
             request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
+        }
+
+        if (!shopperInsightsSessionId.toString().isEmpty()) {
+            request.setShopperSessionId(shopperInsightsSessionId.toString());
+            request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
         request.setDisplayName(Settings.getPayPalDisplayName(context));

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -18,7 +18,6 @@ import com.braintreepayments.api.paypal.PayPalVaultRequest;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class PayPalRequestFactory {
 
@@ -32,15 +31,20 @@ public class PayPalRequestFactory {
 
         PayPalVaultRequest request = new PayPalVaultRequest(true);
 
-        if (buyerEmailAddress != null) {
+        if (buyerEmailAddress != null && !buyerEmailAddress.isEmpty() ) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
-        if (buyerPhoneCountryCode != null && buyerPhoneNationalNumber != null) {
-            request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
+        if ((buyerPhoneCountryCode != null && !buyerPhoneCountryCode.isEmpty())
+                && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
+
+            request.setUserPhoneNumber(new PayPalPhoneNumber(
+                    buyerPhoneCountryCode,
+                    buyerPhoneNationalNumber)
+            );
         }
 
-        if (shopperInsightsSessionId != null) {
+        if (shopperInsightsSessionId != null && !shopperInsightsSessionId.isEmpty()) {
             request.setShopperSessionId(shopperInsightsSessionId);
         }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -27,21 +27,21 @@ public class PayPalRequestFactory {
         String buyerEmailAddress,
         String buyerPhoneCountryCode,
         String buyerPhoneNationalNumber,
-        Optional<String> shopperInsightsSessionId
+        String shopperInsightsSessionId
     ) {
 
         PayPalVaultRequest request = new PayPalVaultRequest(true);
 
-        if (!buyerEmailAddress.isEmpty()) {
+        if (buyerEmailAddress != null) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
-        if (!buyerPhoneCountryCode.isEmpty() && !buyerPhoneNationalNumber.isEmpty()) {
+        if (buyerPhoneCountryCode != null && buyerPhoneNationalNumber != null) {
             request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
         }
 
-        if (!shopperInsightsSessionId.toString().isEmpty()) {
-            request.setShopperSessionId(shopperInsightsSessionId.toString());
+        if (shopperInsightsSessionId != null) {
+            request.setShopperSessionId(shopperInsightsSessionId);
         }
 
         if (Settings.isPayPalAppSwithEnabled(context)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -31,7 +31,7 @@ public class PayPalRequestFactory {
 
         PayPalVaultRequest request = new PayPalVaultRequest(true);
 
-        if (buyerEmailAddress != null && !buyerEmailAddress.isEmpty() ) {
+        if (buyerEmailAddress != null && !buyerEmailAddress.isEmpty()) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
@@ -126,15 +126,19 @@ public class PayPalRequestFactory {
     ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount, true);
 
-        if (buyerEmailAddress != null) {
+        if (buyerEmailAddress != null && !buyerEmailAddress.isEmpty()) {
             request.setUserAuthenticationEmail(buyerEmailAddress);
         }
 
-        if (buyerPhoneCountryCode != null && buyerPhoneNationalNumber != null) {
-            request.setUserPhoneNumber(new PayPalPhoneNumber(buyerPhoneCountryCode, buyerPhoneNationalNumber));
+        if ((buyerPhoneCountryCode != null && !buyerPhoneCountryCode.isEmpty())
+                && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
+            request.setUserPhoneNumber(new PayPalPhoneNumber(
+                    buyerPhoneCountryCode,
+                    buyerPhoneNationalNumber)
+            );
         }
 
-        if (shopperInsightsSessionId != null) {
+        if (shopperInsightsSessionId != null && !shopperInsightsSessionId.isEmpty()) {
             request.setShopperSessionId(shopperInsightsSessionId);
         }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -49,7 +49,6 @@ class ShopperInsightsFragment : BaseFragment() {
     private lateinit var nationalNumberInput: TextInputLayout
     private lateinit var emailNullSwitch: SwitchMaterial
     private lateinit var phoneNullSwitch: SwitchMaterial
-    private lateinit var shopperInsightsSessionIdNullSwitch: SwitchMaterial
 
     private lateinit var shopperInsightsClient: ShopperInsightsClient
     private lateinit var payPalClient: PayPalClient

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -32,7 +32,6 @@ import com.braintreepayments.api.venmo.VenmoRequest
 import com.braintreepayments.api.venmo.VenmoResult
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
-import java.util.Optional
 
 /**
  * Fragment for handling shopping insights.
@@ -241,7 +240,7 @@ class ShopperInsightsFragment : BaseFragment() {
                 emailInput.editText?.text.toString(),
                 countryCodeInput.editText?.text.toString(),
                 nationalNumberInput.editText?.text.toString(),
-                Optional.ofNullable(shopperSessionId)
+                shopperSessionId
 
             )
         ) { authRequest ->

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -49,6 +49,8 @@ class ShopperInsightsFragment : BaseFragment() {
     private lateinit var nationalNumberInput: TextInputLayout
     private lateinit var emailNullSwitch: SwitchMaterial
     private lateinit var phoneNullSwitch: SwitchMaterial
+    private lateinit var shopperInsightsSessionIdInput: TextInputLayout
+    private lateinit var shopperInsightsSessionIdNullSwitch: SwitchMaterial
 
     private lateinit var shopperInsightsClient: ShopperInsightsClient
     private lateinit var payPalClient: PayPalClient
@@ -95,9 +97,13 @@ class ShopperInsightsFragment : BaseFragment() {
         nationalNumberInput = view.findViewById(R.id.nationalNumberInput)
         emailNullSwitch = view.findViewById(R.id.emailNullSwitch)
         phoneNullSwitch = view.findViewById(R.id.phoneNullSwitch)
+        shopperInsightsSessionIdInput = view.findViewById(R.id.shopperInsightsSessionIdInput)
+        shopperInsightsSessionIdNullSwitch = view.findViewById(R.id.shopperInsightsSessionIdNullSwitch)
+
 
         emailInput.editText?.setText("PR1_merchantname@personal.example.com")
         nationalNumberInput.editText?.setText("4082321001")
+        shopperInsightsSessionIdInput.editText?.setText("shopperSessionId")
         countryCodeInput.editText?.setText("1")
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -61,14 +61,14 @@ class ShopperInsightsFragment : BaseFragment() {
     private lateinit var venmoStartedPendingRequest: VenmoPendingRequest.Started
     private lateinit var paypalStartedPendingRequest: PayPalPendingRequest.Started
 
-    private var sessionId: String = "test-shopper-session-id"
+    private var shopperSessionId: String = "test-shopper-session-id"
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg, sessionId)
+        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg, shopperSessionId)
 
         venmoClient = VenmoClient(requireContext(), super.getAuthStringArg(), null)
         payPalClient = PayPalClient(
@@ -233,7 +233,7 @@ class ShopperInsightsFragment : BaseFragment() {
                 emailInput.editText?.text.toString(),
                 countryCodeInput.editText?.text.toString(),
                 nationalNumberInput.editText?.text.toString(),
-                sessionId
+                shopperSessionId
 
             )
         ) { authRequest ->

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -32,6 +32,7 @@ import com.braintreepayments.api.venmo.VenmoRequest
 import com.braintreepayments.api.venmo.VenmoResult
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
+import java.util.Optional
 
 /**
  * Fragment for handling shopping insights.
@@ -229,13 +230,19 @@ class ShopperInsightsFragment : BaseFragment() {
     private fun launchPayPalVault() {
         shopperInsightsClient.sendPayPalSelectedEvent()
 
+        val shopperSessionId =
+            if (shopperInsightsSessionIdNullSwitch.isChecked) null
+            else shopperInsightsSessionIdInput.editText?.text.toString()
+
         payPalClient.createPaymentAuthRequest(
             requireContext(),
             PayPalRequestFactory.createPayPalVaultRequest(
                 activity,
                 emailInput.editText?.text.toString(),
                 countryCodeInput.editText?.text.toString(),
-                nationalNumberInput.editText?.text.toString()
+                nationalNumberInput.editText?.text.toString(),
+                Optional.ofNullable(shopperSessionId)
+
             )
         ) { authRequest ->
             when (authRequest) {

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -49,7 +49,6 @@ class ShopperInsightsFragment : BaseFragment() {
     private lateinit var nationalNumberInput: TextInputLayout
     private lateinit var emailNullSwitch: SwitchMaterial
     private lateinit var phoneNullSwitch: SwitchMaterial
-    private lateinit var shopperInsightsSessionIdInput: TextInputLayout
     private lateinit var shopperInsightsSessionIdNullSwitch: SwitchMaterial
 
     private lateinit var shopperInsightsClient: ShopperInsightsClient
@@ -62,12 +61,14 @@ class ShopperInsightsFragment : BaseFragment() {
     private lateinit var venmoStartedPendingRequest: VenmoPendingRequest.Started
     private lateinit var paypalStartedPendingRequest: PayPalPendingRequest.Started
 
+    private var sessionId: String = "test-shopper-session-id"
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg, "test-shopper-session-id")
+        shopperInsightsClient = ShopperInsightsClient(requireContext(), authStringArg, sessionId)
 
         venmoClient = VenmoClient(requireContext(), super.getAuthStringArg(), null)
         payPalClient = PayPalClient(
@@ -97,13 +98,9 @@ class ShopperInsightsFragment : BaseFragment() {
         nationalNumberInput = view.findViewById(R.id.nationalNumberInput)
         emailNullSwitch = view.findViewById(R.id.emailNullSwitch)
         phoneNullSwitch = view.findViewById(R.id.phoneNullSwitch)
-        shopperInsightsSessionIdInput = view.findViewById(R.id.shopperInsightsSessionIdInput)
-        shopperInsightsSessionIdNullSwitch = view.findViewById(R.id.shopperInsightsSessionIdNullSwitch)
-
 
         emailInput.editText?.setText("PR1_merchantname@personal.example.com")
         nationalNumberInput.editText?.setText("4082321001")
-        shopperInsightsSessionIdInput.editText?.setText("shopperSessionId")
         countryCodeInput.editText?.setText("1")
     }
 
@@ -229,10 +226,6 @@ class ShopperInsightsFragment : BaseFragment() {
     private fun launchPayPalVault() {
         shopperInsightsClient.sendPayPalSelectedEvent()
 
-        val shopperSessionId =
-            if (shopperInsightsSessionIdNullSwitch.isChecked) null
-            else shopperInsightsSessionIdInput.editText?.text.toString()
-
         payPalClient.createPaymentAuthRequest(
             requireContext(),
             PayPalRequestFactory.createPayPalVaultRequest(
@@ -240,7 +233,7 @@ class ShopperInsightsFragment : BaseFragment() {
                 emailInput.editText?.text.toString(),
                 countryCodeInput.editText?.text.toString(),
                 nationalNumberInput.editText?.text.toString(),
-                shopperSessionId
+                sessionId
 
             )
         ) { authRequest ->

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -79,6 +79,23 @@
             android:hint="@string/insights_text_input_national_number" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/shopperInsightsSessionIdInput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/shopperInsightsSessionIdNullSwitch"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/countryCodeInput">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Session Id" />
+    </com.google.android.material.textfield.TextInputLayout>
+
     <TextView
         android:id="@+id/responseTextView"
         android:layout_width="0dp"
@@ -101,7 +118,7 @@
         android:text="@string/insights_action_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/countryCodeInput" />
+        app:layout_constraintTop_toBottomOf="@+id/shopperInsightsSessionIdInput" />
 
     <Button
         android:id="@+id/payPalVaultButton"
@@ -148,6 +165,16 @@
         app:layout_constraintBottom_toBottomOf="@+id/countryCodeInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/nationalNumberInput" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/shopperInsightsSessionIdNullSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:text="@string/insights_null_switch"
+        app:layout_constraintBottom_toBottomOf="@+id/shopperInsightsSessionIdInput"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/shopperInsightsSessionIdInput" />
 
     <View
         android:id="@+id/view3"

--- a/Demo/src/main/res/layout/fragment_shopping_insights.xml
+++ b/Demo/src/main/res/layout/fragment_shopping_insights.xml
@@ -79,23 +79,6 @@
             android:hint="@string/insights_text_input_national_number" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/shopperInsightsSessionIdInput"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        app:layout_constraintEnd_toStartOf="@+id/shopperInsightsSessionIdNullSwitch"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/countryCodeInput">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Session Id" />
-    </com.google.android.material.textfield.TextInputLayout>
-
     <TextView
         android:id="@+id/responseTextView"
         android:layout_width="0dp"
@@ -118,7 +101,7 @@
         android:text="@string/insights_action_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/shopperInsightsSessionIdInput" />
+        app:layout_constraintTop_toBottomOf="@+id/countryCodeInput" />
 
     <Button
         android:id="@+id/payPalVaultButton"
@@ -165,16 +148,6 @@
         app:layout_constraintBottom_toBottomOf="@+id/countryCodeInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/nationalNumberInput" />
-
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/shopperInsightsSessionIdNullSwitch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:text="@string/insights_null_switch"
-        app:layout_constraintBottom_toBottomOf="@+id/shopperInsightsSessionIdInput"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/shopperInsightsSessionIdInput" />
 
     <View
         android:id="@+id/view3"

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
 import com.braintreepayments.api.core.ClientToken
 import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.PostalAddress
 import com.braintreepayments.api.core.PostalAddressParser
 import kotlinx.parcelize.Parcelize
@@ -91,6 +92,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     lineItems = lineItems
 ) {
 
+    @OptIn(ExperimentalBetaApi::class)
     @Throws(JSONException::class)
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     override fun createRequestBody(
@@ -126,9 +128,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 
-        shopperSessionId?.let {
-            if (it.isNotEmpty()) parameters.put(SHOPPER_SESSION_ID, it)
-        }
+        parameters.putOpt(SHOPPER_SESSION_ID, shopperSessionId)
 
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -126,6 +126,10 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 
+        shopperSessionId?.let {
+            if (it.isNotEmpty()) parameters.put(SHOPPER_SESSION_ID, it)
+        }
+
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode
         }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -72,8 +72,8 @@ import org.json.JSONException
  * where the user has a PayPal Account with the same email.
  * @property userPhoneNumber User phone number used to initiate a quicker authentication flow in
  * cases where the user has a PayPal Account with the phone number.
- * @property shopperSessionId value should be the shopper session ID returned from your server SDK
- * request.
+ * @property shopperSessionId the shopper session ID returned from your shopper insights server SDK
+ * integration
  * @property lineItems The line items for this transaction. It can include up to 249 line items.
  */
 abstract class PayPalRequest internal constructor(

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -72,6 +72,8 @@ import org.json.JSONException
  * where the user has a PayPal Account with the same email.
  * @property userPhoneNumber User phone number used to initiate a quicker authentication flow in
  * cases where the user has a PayPal Account with the phone number.
+ * @property shopperSessionId value should be the shopper session ID returned from your server SDK
+ * request.
  * @property lineItems The line items for this transaction. It can include up to 249 line items.
  */
 abstract class PayPalRequest internal constructor(
@@ -87,6 +89,7 @@ abstract class PayPalRequest internal constructor(
     open var riskCorrelationId: String? = null,
     open var userAuthenticationEmail: String? = null,
     open var userPhoneNumber: PayPalPhoneNumber? = null,
+    open var shopperSessionId: String? = null,
     open var lineItems: List<PayPalLineItem> = emptyList()
 ) : Parcelable {
 
@@ -132,5 +135,6 @@ abstract class PayPalRequest internal constructor(
         internal const val PLAN_TYPE_KEY: String = "plan_type"
         internal const val PLAN_METADATA_KEY: String = "plan_metadata"
         internal const val PHONE_NUMBER_KEY: String = "phone_number"
+        internal const val SHOPPER_SESSION_ID: String = "shopper_session_id"
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.braintreepayments.api.core.Authorization
 import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.PostalAddress
 import org.json.JSONException
 
@@ -89,6 +90,8 @@ abstract class PayPalRequest internal constructor(
     open var riskCorrelationId: String? = null,
     open var userAuthenticationEmail: String? = null,
     open var userPhoneNumber: PayPalPhoneNumber? = null,
+
+    @property:ExperimentalBetaApi
     open var shopperSessionId: String? = null,
     open var lineItems: List<PayPalLineItem> = emptyList()
 ) : Parcelable {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -92,6 +92,8 @@ class PayPalVaultRequest
 
         parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail)
 
+        parameters.putOpt(SHOPPER_SESSION_ID, shopperSessionId)
+
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 
         if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -5,6 +5,7 @@ import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
 import com.braintreepayments.api.core.ClientToken
 import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.PostalAddress
 import com.braintreepayments.api.core.PostalAddressParser
 import kotlinx.parcelize.Parcelize
@@ -65,6 +66,7 @@ class PayPalVaultRequest
     lineItems = lineItems
 ) {
 
+    @OptIn(ExperimentalBetaApi::class)
     @Throws(JSONException::class)
     @Suppress("LongMethod")
     override fun createRequestBody(

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal;
 
+import android.os.Build;
 import android.os.Parcel;
 
 import com.braintreepayments.api.core.Authorization;
@@ -27,6 +28,7 @@ public class PayPalCheckoutRequestUnitTest {
     public void newPayPalCheckoutRequest_setsDefaultValues() {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", false);
 
+        assertNull(request.getShopperSessionId());
         assertNotNull(request.getAmount());
         assertNull(request.getCurrencyCode());
         assertNull(request.getLocaleCode());
@@ -44,6 +46,7 @@ public class PayPalCheckoutRequestUnitTest {
     public void setsValuesCorrectly() {
         PostalAddress postalAddress = new PostalAddress();
         PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+        request.setShopperSessionId("shopper-insights-id");
         request.setCurrencyCode("USD");
         request.setShouldOfferPayLater(true);
         request.setIntent(PayPalPaymentIntent.SALE);
@@ -58,6 +61,7 @@ public class PayPalCheckoutRequestUnitTest {
         request.setRiskCorrelationId("123-correlation");
         request.setLandingPageType(PayPalLandingPageType.LANDING_PAGE_TYPE_LOGIN);
 
+        assertEquals("shopper-insights-id", request.getShopperSessionId());
         assertEquals("1.00", request.getAmount());
         assertEquals("USD", request.getCurrencyCode());
         assertEquals("US", request.getLocaleCode());
@@ -154,6 +158,21 @@ public class PayPalCheckoutRequestUnitTest {
         );
 
         assertFalse(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
+    }
+
+    @Test
+    public void createRequestBody_sets_shopper_insights_session_id() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+        request.setShopperSessionId("shopper-insights-id");
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                "universal_url"
+        );
+
+        assertTrue(requestBody.contains("\"shopper_session_id\":" + "\"shopper-insights-id\""));
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -216,11 +216,11 @@ public class PayPalVaultRequestUnitTest {
         assertTrue(requestBody.contains("\"payer_email\":" + "\"" + payerEmail + "\""));
     }
 
+    @Test
     public void createRequestBody_sets_enablePayPalSwitch_and_userAuthenticationEmail_not_null() throws JSONException {
         String versionSDK = String.valueOf(Build.VERSION.SDK_INT);
         String payerEmail = "payer_email@example.com";
         PayPalVaultRequest request = new PayPalVaultRequest(true);
-        request.setShopperSessionId("shopper-insights-id");
         request.setEnablePayPalAppSwitch(true);
         request.setUserAuthenticationEmail(payerEmail);
         String requestBody = request.createRequestBody(
@@ -231,11 +231,25 @@ public class PayPalVaultRequestUnitTest {
             "universal_url"
         );
 
-        assertTrue(requestBody.contains("\"shopper_session_id\":shopper-insights-id"));
         assertTrue(requestBody.contains("\"launch_paypal_app\":true"));
         assertTrue(requestBody.contains("\"os_type\":" + "\"Android\""));
         assertTrue(requestBody.contains("\"os_version\":" + "\"" + versionSDK + "\""));
         assertTrue(requestBody.contains("\"merchant_app_return_url\":" + "\"universal_url\""));
+    }
+
+    @Test
+    public void createRequestBody_sets_shopper_insights_session_id() throws JSONException {
+        PayPalVaultRequest request = new PayPalVaultRequest(true);
+        request.setShopperSessionId("shopper-insights-id");
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                "universal_url"
+        );
+
+        assertTrue(requestBody.contains("\"shopper_session_id\":" + "\"shopper-insights-id\""));
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -16,6 +16,7 @@ import com.braintreepayments.api.core.PostalAddress;
 import com.braintreepayments.api.testutils.Fixtures;
 
 import org.json.JSONException;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -32,6 +33,7 @@ public class PayPalVaultRequestUnitTest {
     public void newPayPalVaultRequest_setsDefaultValues() {
         PayPalVaultRequest request = new PayPalVaultRequest(false);
 
+        assertNull(request.getShopperSessionId());
         assertNull(request.getLocaleCode());
         assertFalse(request.isShippingAddressRequired());
         assertNull(request.getShippingAddressOverride());
@@ -46,6 +48,7 @@ public class PayPalVaultRequestUnitTest {
     public void setsValuesCorrectly() {
         PostalAddress postalAddress = new PostalAddress();
         PayPalVaultRequest request = new PayPalVaultRequest(true);
+        request.setShopperSessionId("shopper-insights-id");
         request.setLocaleCode("US");
         request.setBillingAgreementDescription("Billing Agreement Description");
         request.setShippingAddressRequired(true);
@@ -75,6 +78,7 @@ public class PayPalVaultRequestUnitTest {
         request.setRecurringBillingDetails(billingDetails);
         request.setRecurringBillingPlanType(PayPalRecurringBillingPlanType.RECURRING);
 
+        assertEquals("shopper-insights-id", request.getShopperSessionId());
         assertEquals("US", request.getLocaleCode());
         assertEquals("Billing Agreement Description", request.getBillingAgreementDescription());
         assertTrue(request.isShippingAddressRequired());

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.java
@@ -220,7 +220,7 @@ public class PayPalVaultRequestUnitTest {
         String versionSDK = String.valueOf(Build.VERSION.SDK_INT);
         String payerEmail = "payer_email@example.com";
         PayPalVaultRequest request = new PayPalVaultRequest(true);
-
+        request.setShopperSessionId("shopper-insights-id");
         request.setEnablePayPalAppSwitch(true);
         request.setUserAuthenticationEmail(payerEmail);
         String requestBody = request.createRequestBody(
@@ -231,6 +231,7 @@ public class PayPalVaultRequestUnitTest {
             "universal_url"
         );
 
+        assertTrue(requestBody.contains("\"shopper_session_id\":shopper-insights-id"));
         assertTrue(requestBody.contains("\"launch_paypal_app\":true"));
         assertTrue(requestBody.contains("\"os_type\":" + "\"Android\""));
         assertTrue(requestBody.contains("\"os_version\":" + "\"" + versionSDK + "\""));


### PR DESCRIPTION
Summary of changes

Add public property shopperSessionId to BTPaypalRequest. Value should be passed to both the create_payment_resource and setup_billing_agreement endpoints. Demo app should be updated enable/disable passing this value.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@stechiu 
@warmkesselj 
@jwarmkessel 

