### PR TITLE
Add Shopper Session ID param

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -45,7 +45,8 @@ class AnalyticsClient internal constructor(
             endpoint = analyticsEventParams.endpoint,
             experiment = analyticsEventParams.experiment,
             paymentMethodsDisplayed = analyticsEventParams.paymentMethodsDisplayed,
-            appSwitchUrl = analyticsEventParams.appSwitchUrl
+            appSwitchUrl = analyticsEventParams.appSwitchUrl,
+            shopperSessionId = analyticsEventParams.shopperSessionId
         )
         configurationLoader.loadConfiguration { result ->
             if (result is ConfigurationLoaderResult.Success) {
@@ -242,6 +243,7 @@ class AnalyticsClient internal constructor(
             .putOpt(FPTI_KEY_MERCHANT_PAYMENT_METHODS_DISPLAYED,
                 event.paymentMethodsDisplayed.ifEmpty { null })
             .putOpt(FPTI_KEY_URL, event.appSwitchUrl)
+            .putOpt(FPTI_KEY_SHOPPER_SESSION_ID, event.shopperSessionId)
         return json.toString()
     }
 
@@ -295,6 +297,7 @@ class AnalyticsClient internal constructor(
         private const val FPTI_KEY_MERCHANT_EXPERIMENT = "experiment"
         private const val FPTI_KEY_MERCHANT_PAYMENT_METHODS_DISPLAYED = "payment_methods_displayed"
         private const val FPTI_KEY_URL = "url"
+        private const val FPTI_KEY_SHOPPER_SESSION_ID = "shopper_session_id"
 
         private const val FPTI_BATCH_KEY_VENMO_INSTALLED = "venmo_installed"
         private const val FPTI_BATCH_KEY_PAYPAL_INSTALLED = "paypal_installed"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
@@ -16,5 +16,6 @@ internal data class AnalyticsEvent(
     val endpoint: String? = null,
     val experiment: String? = null,
     val paymentMethodsDisplayed: List<String> = emptyList(),
-    val appSwitchUrl: String? = null
+    val appSwitchUrl: String? = null,
+    val shopperSessionId: String? = null
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -17,7 +17,8 @@ import androidx.annotation.RestrictTo
  * the experiment, as a JSON string, that the merchant sent to the us.
  * @property paymentMethodsDisplayed A ShopperInsights module specific event that indicates the
  * order of payment methods displayed to the shopper by the merchant.
- * @property shopperSessionId The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
+ * @property shopperSessionId The Shopper Insights customer session ID created by a merchant's
+ * server SDK or graphQL integration.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsEventParams @JvmOverloads constructor(

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -17,7 +17,7 @@ import androidx.annotation.RestrictTo
  * the experiment, as a JSON string, that the merchant sent to the us.
  * @property paymentMethodsDisplayed A ShopperInsights module specific event that indicates the
  * order of payment methods displayed to the shopper by the merchant.
- * @property shopperSessionId A ShopperInsights session ID provided by the merchant
+ * @property shopperSessionId The Shopper Insights customer session ID created by a merchant's server SDK or graphQL integration.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsEventParams @JvmOverloads constructor(

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -17,6 +17,7 @@ import androidx.annotation.RestrictTo
  * the experiment, as a JSON string, that the merchant sent to the us.
  * @property paymentMethodsDisplayed A ShopperInsights module specific event that indicates the
  * order of payment methods displayed to the shopper by the merchant.
+ * @property shopperSessionId A ShopperInsights session ID provided by the merchant
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsEventParams @JvmOverloads constructor(
@@ -28,5 +29,6 @@ data class AnalyticsEventParams @JvmOverloads constructor(
     var endpoint: String? = null,
     val experiment: String? = null,
     val paymentMethodsDisplayed: List<String> = emptyList(),
-    val appSwitchUrl: String? = null
+    val appSwitchUrl: String? = null,
+    val shopperSessionId: String? = null
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -30,10 +30,6 @@ class AnalyticsParamRepository(
         _sessionId = uuidHelper.formattedUUID
     }
 
-    fun setSessionId(sessionId: String) {
-        _sessionId = sessionId
-    }
-
     companion object {
 
         /**

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsParamRepositoryUnitTest.kt
@@ -41,10 +41,4 @@ class AnalyticsParamRepositoryUnitTest {
 
         assertEquals(newUuid, sut.sessionId)
     }
-
-    @Test
-    fun `setSessionId sets the session ID with input value`() {
-        sut.setSessionId("override-session-id")
-        assertEquals("override-session-id", sut.sessionId)
-    }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -44,6 +44,8 @@ class PayPalClient internal constructor(
      */
     private var isVaultRequest = false
 
+    private var shopperSessionId: String? = null
+
     /**
      * Initializes a new [PayPalClient] instance
      *
@@ -74,11 +76,7 @@ class PayPalClient internal constructor(
         payPalRequest: PayPalRequest,
         callback: PayPalPaymentAuthCallback
     ) {
-        // The shopper insights server SDK integration
-        payPalRequest.shopperSessionId?.let {
-            analyticsParamRepository.setSessionId(it)
-        }
-
+        shopperSessionId = payPalRequest.shopperSessionId
         isVaultRequest = payPalRequest is PayPalVaultRequest
 
         braintreeClient.sendAnalyticsEvent(PayPalAnalytics.TOKENIZATION_STARTED, analyticsParams)
@@ -337,7 +335,8 @@ class PayPalClient internal constructor(
             return AnalyticsEventParams(
                 payPalContextId = payPalContextId,
                 linkType = linkType?.stringValue,
-                isVaultRequest = isVaultRequest
+                isVaultRequest = isVaultRequest,
+                shopperSessionId = shopperSessionId
             )
         }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.text.TextUtils
 import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.core.AnalyticsEventParams
-import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.BraintreeRequestCodes
@@ -25,8 +24,7 @@ import org.json.JSONObject
 class PayPalClient internal constructor(
     private val braintreeClient: BraintreeClient,
     private val internalPayPalClient: PayPalInternalClient = PayPalInternalClient(braintreeClient),
-    private val merchantRepository: MerchantRepository = MerchantRepository.instance,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val merchantRepository: MerchantRepository = MerchantRepository.instance
 ) {
     /**
      * Used for linking events from the client to server side request
@@ -44,6 +42,9 @@ class PayPalClient internal constructor(
      */
     private var isVaultRequest = false
 
+    /**
+     * Used for sending Shopper Insights session ID provided by merchant to FPTI
+     */
     private var shopperSessionId: String? = null
 
     /**

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -33,6 +33,8 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.util.Collections;
+
 @RunWith(RobolectricTestRunner.class)
 public class PayPalClientUnitTest {
 
@@ -62,6 +64,7 @@ public class PayPalClientUnitTest {
     public void createPaymentAuthRequest_callsBackPayPalResponse_sendsStartedAnalytics() throws JSONException {
         PayPalVaultRequest payPalVaultRequest = new PayPalVaultRequest(true);
         payPalVaultRequest.setMerchantAccountId("sample-merchant-account-id");
+        payPalVaultRequest.setShopperSessionId("test-shopper-session-id");
 
         PayPalPaymentAuthRequestParams paymentAuthRequest = new PayPalPaymentAuthRequestParams(
             payPalVaultRequest,
@@ -106,7 +109,7 @@ public class PayPalClientUnitTest {
 
         verify(braintreeClient).sendAnalyticsEvent(
             PayPalAnalytics.TOKENIZATION_STARTED,
-            new AnalyticsEventParams(null, null, true, null, null, null)
+            new AnalyticsEventParams(null, null, true, null, null, null, null, Collections.emptyList(), null, "test-shopper-session-id")
         );
     }
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -644,7 +644,7 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
-        verify(analyticsParamRepository).setSessionId("test-shopper-id");
+        verify(analyticsParamRepository).setShopperSessionId("test-shopper-id");
     }
 
     @Test
@@ -672,6 +672,6 @@ public class PayPalClientUnitTest {
         PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
         sut.createPaymentAuthRequest(activity, request, paymentAuthCallback);
 
-        verify(analyticsParamRepository).setSessionId("test-shopper-id");
+        verify(analyticsParamRepository).setShopperSessionId("test-shopper-id");
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -44,11 +44,9 @@ public class PayPalClientUnitTest {
     private PayPalPaymentAuthCallback paymentAuthCallback;
 
     private MerchantRepository merchantRepository;
-    private AnalyticsParamRepository analyticsParamRepository;
 
     @Before
     public void beforeEach() throws JSONException {
-        analyticsParamRepository = mock(AnalyticsParamRepository.class);
         activity = mock(FragmentActivity.class);
         merchantRepository = mock(MerchantRepository.class);
         payPalEnabledConfig = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL);
@@ -80,7 +78,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -134,7 +132,7 @@ public class PayPalClientUnitTest {
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
                 .launchesBrowserSwitchAsNewTask(true).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -169,7 +167,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -189,7 +187,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalDisabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, new PayPalCheckoutRequest("1.00", true),
             paymentAuthCallback);
 
@@ -218,7 +216,7 @@ public class PayPalClientUnitTest {
             .configurationError(authError)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, new PayPalCheckoutRequest("1.00", true), paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -243,7 +241,7 @@ public class PayPalClientUnitTest {
             .configurationError(authError)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, new PayPalVaultRequest(true), paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -269,7 +267,7 @@ public class PayPalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalRequest, paymentAuthCallback);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest),
@@ -285,7 +283,7 @@ public class PayPalClientUnitTest {
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalRequest, paymentAuthCallback);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest),
@@ -317,7 +315,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -362,7 +360,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -406,7 +404,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -451,7 +449,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -491,7 +489,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -533,7 +531,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -572,7 +570,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -604,7 +602,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -617,61 +615,5 @@ public class PayPalClientUnitTest {
         AnalyticsEventParams params = new AnalyticsEventParams();
         verify(braintreeClient).sendAnalyticsEvent(PayPalAnalytics.BROWSER_LOGIN_CANCELED, params);
         verify(braintreeClient).sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_CANCELED, params);
-    }
-
-    @Test
-    public void test_vaultRequest_shopperSessionId_sets_repository() throws JSONException {
-        PayPalVaultRequest payPalVaultRequest = new PayPalVaultRequest(true);
-
-        payPalVaultRequest.setShopperSessionId("test-shopper-id");
-
-        PayPalPaymentAuthRequestParams paymentAuthRequest = new PayPalPaymentAuthRequestParams(
-                payPalVaultRequest,
-                null,
-                "https://example.com/approval/url",
-                "sample-client-metadata-id",
-                null,
-                "https://example.com/success/url"
-        );
-
-        PayPalInternalClient payPalInternalClient =
-                new MockPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest)
-                        .build();
-
-        BraintreeClient braintreeClient =
-                new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
-
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
-        sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
-
-        verify(analyticsParamRepository).setShopperSessionId("test-shopper-id");
-    }
-
-    @Test
-    public void test_checkoutRequest_shopperSessionId_sets_repository() throws JSONException {
-        PayPalCheckoutRequest request = new PayPalCheckoutRequest("2.00", true);
-
-        request.setShopperSessionId("test-shopper-id");
-
-        PayPalPaymentAuthRequestParams paymentAuthRequest = new PayPalPaymentAuthRequestParams(
-                request,
-                null,
-                "https://example.com/approval/url",
-                "sample-client-metadata-id",
-                null,
-                "https://example.com/success/url"
-        );
-
-        PayPalInternalClient payPalInternalClient =
-                new MockPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest)
-                        .build();
-
-        BraintreeClient braintreeClient =
-                new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
-
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, analyticsParamRepository);
-        sut.createPaymentAuthRequest(activity, request, paymentAuthCallback);
-
-        verify(analyticsParamRepository).setShopperSessionId("test-shopper-id");
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -240,7 +240,7 @@ class ShopperInsightsClient internal constructor(
         return deviceInspector.isVenmoInstalled(context)
     }
 
-    private val analyticsParams : AnalyticsEventParams get() {
+    private val analyticsParams: AnalyticsEventParams get() {
         return AnalyticsEventParams(shopperSessionId = shopperSessionId)
     }
 

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -45,11 +45,7 @@ class ShopperInsightsClient internal constructor(
     constructor(context: Context, authorization: String, shopperSessionId: String? = null) : this(
         BraintreeClient(context, authorization),
         shopperSessionId = shopperSessionId
-    ) {
-        if (shopperSessionId != null) {
-            analyticsParamRepository.setSessionId(sessionId = shopperSessionId)
-        }
-    }
+    )
 
     /**
      * Retrieves recommended payment methods based on the provided shopper insights request.
@@ -66,9 +62,7 @@ class ShopperInsightsClient internal constructor(
         experiment: String? = null,
         callback: ShopperInsightsCallback
     ) {
-        if (shopperSessionId == null) {
-            analyticsParamRepository.resetSessionId()
-        }
+        analyticsParamRepository.resetSessionId()
         braintreeClient.sendAnalyticsEvent(
             GET_RECOMMENDED_PAYMENTS_STARTED,
             AnalyticsEventParams(experiment = experiment)
@@ -147,7 +141,7 @@ class ShopperInsightsClient internal constructor(
         callback: ShopperInsightsCallback,
         error: Exception
     ) {
-        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED)
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED, analyticsEventParams)
         callback.onResult(ShopperInsightsResult.Failure(error))
     }
 
@@ -157,7 +151,7 @@ class ShopperInsightsClient internal constructor(
         isPayPalRecommended: Boolean,
         isVenmoRecommended: Boolean,
     ) {
-        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED)
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED, analyticsEventParams)
         callback.onResult(
             ShopperInsightsResult.Success(
                 ShopperInsightsInfo(
@@ -185,7 +179,8 @@ class ShopperInsightsClient internal constructor(
             PAYPAL_PRESENTED,
             AnalyticsEventParams(
                 experiment = experiment,
-                paymentMethodsDisplayed = paymentMethodsDisplayed
+                paymentMethodsDisplayed = paymentMethodsDisplayed,
+                shopperSessionId = shopperSessionId
             )
         )
     }
@@ -195,7 +190,7 @@ class ShopperInsightsClient internal constructor(
      * This method sends analytics to help improve the Shopper Insights feature experience.
      */
     fun sendPayPalSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED)
+        braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED, analyticsEventParams)
     }
 
     /**
@@ -214,7 +209,8 @@ class ShopperInsightsClient internal constructor(
             VENMO_PRESENTED,
             AnalyticsEventParams(
                 experiment = experiment,
-                paymentMethodsDisplayed = paymentMethodsDisplayed
+                paymentMethodsDisplayed = paymentMethodsDisplayed,
+                shopperSessionId = shopperSessionId
             )
         )
     }
@@ -224,7 +220,7 @@ class ShopperInsightsClient internal constructor(
      * This method sends analytics to help improve the Shopper Insights feature experience.
      */
     fun sendVenmoSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED)
+        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED, analyticsEventParams)
     }
 
     /**
@@ -239,6 +235,10 @@ class ShopperInsightsClient internal constructor(
      */
     fun isVenmoAppInstalled(context: Context): Boolean {
         return deviceInspector.isVenmoInstalled(context)
+    }
+
+    private val analyticsEventParams : AnalyticsEventParams get() {
+        return AnalyticsEventParams(shopperSessionId = shopperSessionId)
     }
 
     companion object {

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -65,7 +65,10 @@ class ShopperInsightsClient internal constructor(
         analyticsParamRepository.resetSessionId()
         braintreeClient.sendAnalyticsEvent(
             GET_RECOMMENDED_PAYMENTS_STARTED,
-            AnalyticsEventParams(experiment = experiment)
+            AnalyticsEventParams(
+                experiment = experiment,
+                shopperSessionId = shopperSessionId
+            )
         )
 
         if (request.email == null && request.phone == null) {
@@ -141,7 +144,7 @@ class ShopperInsightsClient internal constructor(
         callback: ShopperInsightsCallback,
         error: Exception
     ) {
-        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED, analyticsEventParams)
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_FAILED, analyticsParams)
         callback.onResult(ShopperInsightsResult.Failure(error))
     }
 
@@ -151,7 +154,7 @@ class ShopperInsightsClient internal constructor(
         isPayPalRecommended: Boolean,
         isVenmoRecommended: Boolean,
     ) {
-        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED, analyticsEventParams)
+        braintreeClient.sendAnalyticsEvent(GET_RECOMMENDED_PAYMENTS_SUCCEEDED, analyticsParams)
         callback.onResult(
             ShopperInsightsResult.Success(
                 ShopperInsightsInfo(
@@ -190,7 +193,7 @@ class ShopperInsightsClient internal constructor(
      * This method sends analytics to help improve the Shopper Insights feature experience.
      */
     fun sendPayPalSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED, analyticsEventParams)
+        braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED, analyticsParams)
     }
 
     /**
@@ -220,7 +223,7 @@ class ShopperInsightsClient internal constructor(
      * This method sends analytics to help improve the Shopper Insights feature experience.
      */
     fun sendVenmoSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED, analyticsEventParams)
+        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED, analyticsParams)
     }
 
     /**
@@ -237,7 +240,7 @@ class ShopperInsightsClient internal constructor(
         return deviceInspector.isVenmoInstalled(context)
     }
 
-    private val analyticsEventParams : AnalyticsEventParams get() {
+    private val analyticsParams : AnalyticsEventParams get() {
         return AnalyticsEventParams(shopperSessionId = shopperSessionId)
     }
 

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -44,6 +44,7 @@ class ShopperInsightsClientUnitTest {
     private lateinit var merchantRepository: MerchantRepository
     private lateinit var context: Context
     private lateinit var deviceInspector: DeviceInspector
+    private var shopperSessionId = "test-shopper-session-id"
 
     private val clientToken = mockk<ClientToken>()
 
@@ -62,7 +63,8 @@ class ShopperInsightsClientUnitTest {
             analyticsParamRepository,
             api,
             merchantRepository,
-            deviceInspector
+            deviceInspector,
+            shopperSessionId = shopperSessionId
         )
         context = ApplicationProvider.getApplicationContext()
     }
@@ -79,7 +81,9 @@ class ShopperInsightsClientUnitTest {
         val experiment = "some_experiment"
         sut.getRecommendedPaymentMethods(mockk(relaxed = true), experiment, mockk(relaxed = true))
 
-        verifyStartedAnalyticsEvent(AnalyticsEventParams(experiment = experiment))
+        verifyStartedAnalyticsEvent(AnalyticsEventParams(
+            experiment = experiment,
+            shopperSessionId = shopperSessionId))
     }
 
     @Test
@@ -435,25 +439,29 @@ class ShopperInsightsClientUnitTest {
     @Test
     fun `test paypal presented analytics event`() {
         sut.sendPayPalPresentedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-presented") }
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-presented",
+            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
     }
 
     @Test
     fun `test paypal selected analytics event`() {
         sut.sendPayPalSelectedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-selected") }
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-selected",
+            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
     }
 
     @Test
     fun `test venmo presented analytics event`() {
         sut.sendVenmoPresentedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-presented") }
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-presented",
+            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
     }
 
     @Test
     fun `test venmo selected analytics event`() {
         sut.sendVenmoSelectedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected") }
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected",
+            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
     }
 
     @Test
@@ -504,14 +512,16 @@ class ShopperInsightsClientUnitTest {
     private fun verifySuccessAnalyticsEvent() {
         verify {
             braintreeClient
-                .sendAnalyticsEvent("shopper-insights:get-recommended-payments:succeeded")
+                .sendAnalyticsEvent("shopper-insights:get-recommended-payments:succeeded",
+                    AnalyticsEventParams(shopperSessionId = shopperSessionId))
         }
     }
 
     private fun verifyFailedAnalyticsEvent() {
         verify {
             braintreeClient
-                .sendAnalyticsEvent("shopper-insights:get-recommended-payments:failed")
+                .sendAnalyticsEvent("shopper-insights:get-recommended-payments:failed",
+                    AnalyticsEventParams(shopperSessionId = shopperSessionId))
         }
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -75,22 +75,6 @@ class ShopperInsightsClientUnitTest {
     }
 
     @Test
-    fun `when getRecommendedPaymentMethods is called with shopper session id, session id is not reset`() {
-        sut = ShopperInsightsClient(
-            braintreeClient,
-            analyticsParamRepository,
-            api,
-            merchantRepository,
-            deviceInspector,
-            "shopper-session-id"
-        )
-
-        sut.getRecommendedPaymentMethods(mockk(relaxed = true), "some_experiment", mockk(relaxed = true))
-
-        verify(exactly = 0) { analyticsParamRepository.resetSessionId() }
-    }
-
-    @Test
     fun `when getRecommendedPaymentMethods is called, started event is sent`() {
         val experiment = "some_experiment"
         sut.getRecommendedPaymentMethods(mockk(relaxed = true), experiment, mockk(relaxed = true))


### PR DESCRIPTION
### Summary of changes

 - Remove previous updates to pass existing `sessionId` for shopper insights
 - Add new `shopper_session_id` FPTI tag to be used specifically for shopper insights and related payment flows
 - Tested manually and verified `shopper_session_id` is getting to FPTI as expected
 - Aligns with iOS PR: https://github.com/braintree/braintree_ios/pull/1485

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@sarahkoop 
