### PR TITLE
Fix Shopper Insights PayPal flow and PayPal Vault flow

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -61,6 +61,7 @@ public class PayPalRequestFactory {
             postalAddress.setStreetAddress("123 Fake Street");
             postalAddress.setExtendedAddress("Floor A");
             postalAddress.setLocality("San Francisco");
+            postalAddress.setPostalCode("12345");
             postalAddress.setRegion("CA");
             postalAddress.setCountryCodeAlpha2("US");
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -69,8 +69,9 @@ class ShopperInsightsFragment : BaseFragment() {
 
         venmoClient = VenmoClient(requireContext(), super.getAuthStringArg(), null)
         payPalClient = PayPalClient(
-            requireContext(), super.getAuthStringArg(),
-            Uri.parse("https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/")
+            requireContext(),
+            super.getAuthStringArg(),
+            Uri.parse("https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com/braintree-payments"),
         )
 
         return inflater.inflate(R.layout.fragment_shopping_insights, container, false)


### PR DESCRIPTION
### Summary of changes

 - Add missing path to Shopper Insights App Link URL
 - Add required postal code for the demo app vault request.
 
Vault error:
```json
{
   "error": {
      "debugId": "b891a597f94c4",
      "errorDetails": [
         {
            "description": "The specified country requires a postal code.",
            "issue": "SHIPPING_POSTAL_CODE_REQUIRED"
         }
      ],
      "errorMessage": "The requested action could not be performed, semantically incorrect, or failed business validation. --- :",
      "errorName": "UNPROCESSABLE_ENTITY",
      "paypalHttpStatus": 422
   }
}
```

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [X] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

