### PR TITLE
Shopper insights rp2 feature selected event button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BraintreePayPal
     * Add `shopperSessionId` to `PayPalCheckoutRequest` and `PayPalVaultRequest`
     * Replace `sendPayPalPresentedEvent()` and `sendVenmoPresentedEvent()` with `sendPresentedEvent()`
+    * Replace `sendPayPalSelectedEvent()` and `sendVenmoSelectedEvent()` with `sendSelectedEvent()`
 
 ## 5.3.0 (2024-12-11)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -237,12 +237,7 @@ class ShopperInsightsFragment : BaseFragment() {
 
     private fun launchPayPalVault() {
         shopperInsightsClient.sendSelectedEvent(
-            ButtonType.PAYPAL,
-            PresentmentDetails(
-                ExperimentType.CONTROL,
-                ButtonOrder.FIRST,
-                PageType.ORDER_CONFIRMATION
-            )
+            ButtonType.PAYPAL
         )
 
         payPalClient.createPaymentAuthRequest(
@@ -282,12 +277,7 @@ class ShopperInsightsFragment : BaseFragment() {
 
     private fun launchVenmo() {
         shopperInsightsClient.sendSelectedEvent(
-            ButtonType.VENMO,
-            PresentmentDetails(
-                ExperimentType.TEST,
-                ButtonOrder.THIRD,
-                PageType.ORDER_REVIEW
-            )
+            ButtonType.VENMO
         )
 
         val venmoRequest = VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE)

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragment.kt
@@ -236,7 +236,14 @@ class ShopperInsightsFragment : BaseFragment() {
     }
 
     private fun launchPayPalVault() {
-        shopperInsightsClient.sendPayPalSelectedEvent()
+        shopperInsightsClient.sendSelectedEvent(
+            ButtonType.PAYPAL,
+            PresentmentDetails(
+                ExperimentType.CONTROL,
+                ButtonOrder.FIRST,
+                PageType.ORDER_CONFIRMATION
+            )
+        )
 
         payPalClient.createPaymentAuthRequest(
             requireContext(),
@@ -274,7 +281,14 @@ class ShopperInsightsFragment : BaseFragment() {
     }
 
     private fun launchVenmo() {
-        shopperInsightsClient.sendVenmoSelectedEvent()
+        shopperInsightsClient.sendSelectedEvent(
+            ButtonType.VENMO,
+            PresentmentDetails(
+                ExperimentType.TEST,
+                ButtonOrder.THIRD,
+                PageType.ORDER_REVIEW
+            )
+        )
 
         val venmoRequest = VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE)
         venmoRequest.profileId = null

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsAnalytics.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsAnalytics.kt
@@ -1,8 +1,7 @@
 package com.braintreepayments.api.shopperinsights
 
 internal object ShopperInsightsAnalytics {
-    const val PAYPAL_SELECTED = "shopper-insights:paypal-selected"
-    const val VENMO_SELECTED = "shopper-insights:venmo-selected"
+    const val BUTTON_SELECTED = "shopper-insights:button-selected"
     const val BUTTON_PRESENTED = "shopper-insights:button-presented"
 
     const val GET_RECOMMENDED_PAYMENTS_FAILED = "shopper-insights:get-recommended-payments:failed"

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -188,7 +188,7 @@ class ShopperInsightsClient internal constructor(
     }
 
     /**
-     * Call this method when the PayPal, Venmo or Other button has been successfully displayed to the buyer.
+     * Call this method when the PayPal, Venmo or Other button has been selected/tapped by the buyer.
      * This method sends analytics to help improve the Shopper Insights feature experience.
      * @param buttonType Type of button presented - PayPal, Venmo, or Other.
      */

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -191,20 +191,13 @@ class ShopperInsightsClient internal constructor(
      * Call this method when the PayPal, Venmo or Other button has been successfully displayed to the buyer.
      * This method sends analytics to help improve the Shopper Insights feature experience.
      * @param buttonType Type of button presented - PayPal, Venmo, or Other.
-     * @param presentmentDetails Detailed information, including button order, experiment type,
-     * and page type about the payment button that is sent to analytics to help improve the Shopper
-     * Insights feature experience.
      */
     fun sendSelectedEvent(
         buttonType: ButtonType,
-        presentmentDetails: PresentmentDetails
     ) {
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails.type?.formattedExperiment(),
             shopperSessionId = shopperSessionId,
             buttonType = buttonType.getStringRepresentation(),
-            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
-            pageType = presentmentDetails.pageType.getStringRepresentation()
         )
 
         braintreeClient.sendAnalyticsEvent(BUTTON_SELECTED, params)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -10,11 +10,10 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.TokenizationKey
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.BUTTON_PRESENTED
+import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.BUTTON_SELECTED
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_FAILED
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_STARTED
 import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.GET_RECOMMENDED_PAYMENTS_SUCCEEDED
-import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.PAYPAL_SELECTED
-import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.VENMO_SELECTED
 
 /**
  * Use [ShopperInsightsClient] to optimize your checkout experience
@@ -166,7 +165,7 @@ class ShopperInsightsClient internal constructor(
     }
 
     /**
-     * Call this method when the PayPal button has been successfully displayed to the buyer.
+     * Call this method when the PayPal, Venmo or Other button has been successfully displayed to the buyer.
      * This method sends analytics to help improve the Shopper Insights feature experience.
      * @param buttonType Type of button presented - PayPal, Venmo, or Other.
      * @param presentmentDetails Detailed information, including button order, experiment type,
@@ -189,19 +188,26 @@ class ShopperInsightsClient internal constructor(
     }
 
     /**
-     * Call this method when the PayPal button has been selected/tapped by the buyer.
+     * Call this method when the PayPal, Venmo or Other button has been successfully displayed to the buyer.
      * This method sends analytics to help improve the Shopper Insights feature experience.
+     * @param buttonType Type of button presented - PayPal, Venmo, or Other.
+     * @param presentmentDetails Detailed information, including button order, experiment type,
+     * and page type about the payment button that is sent to analytics to help improve the Shopper
+     * Insights feature experience.
      */
-    fun sendPayPalSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(PAYPAL_SELECTED, analyticsParams)
-    }
+    fun sendSelectedEvent(
+        buttonType: ButtonType,
+        presentmentDetails: PresentmentDetails
+    ) {
+        val params = AnalyticsEventParams(
+            experiment = presentmentDetails.type?.formattedExperiment(),
+            shopperSessionId = shopperSessionId,
+            buttonType = buttonType.getStringRepresentation(),
+            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
+            pageType = presentmentDetails.pageType.getStringRepresentation()
+        )
 
-    /**
-     * Call this method when the Venmo button has been selected/tapped by the buyer.
-     * This method sends analytics to help improve the Shopper Insights feature experience.
-     */
-    fun sendVenmoSelectedEvent() {
-        braintreeClient.sendAnalyticsEvent(VENMO_SELECTED, analyticsParams)
+        braintreeClient.sendAnalyticsEvent(BUTTON_SELECTED, params)
     }
 
     /**

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -438,7 +438,6 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test paypal button presented analytics event`() {
-
         // A Test type, with a button in the first position displayed in the mini cart.
         val presentmentDetails = PresentmentDetails(
             ExperimentType.TEST,
@@ -467,7 +466,6 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test venmo button presented analytics event`() {
-
         // A Control type, with a button in the second position displayed on the homepage.
         val presentmentDetails = PresentmentDetails(
             ExperimentType.CONTROL,
@@ -490,22 +488,65 @@ class ShopperInsightsClientUnitTest {
                 PageType.HOMEPAGE
             )
         )
+
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:button-presented",
             params) }
     }
 
     @Test
     fun `test paypal selected analytics event`() {
-        sut.sendPayPalSelectedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:paypal-selected",
-            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
+        // A Test type, with a button in the first position displayed in the mini cart.
+        val presentmentDetails = PresentmentDetails(
+            ExperimentType.TEST,
+            ButtonOrder.FIRST,
+            PageType.MINI_CART
+        )
+
+        val params = AnalyticsEventParams(
+            experiment = presentmentDetails?.type?.formattedExperiment(),
+            shopperSessionId = shopperSessionId,
+            buttonType = ButtonType.PAYPAL.getStringRepresentation(),
+            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
+            pageType = presentmentDetails.pageType.getStringRepresentation()
+        )
+        sut.sendSelectedEvent(
+            ButtonType.PAYPAL,
+            PresentmentDetails(
+                ExperimentType.TEST,
+                ButtonOrder.FIRST,
+                PageType.MINI_CART
+            )
+        )
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:button-selected",
+            params) }
     }
 
     @Test
     fun `test venmo selected analytics event`() {
-        sut.sendVenmoSelectedEvent()
-        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:venmo-selected",
-            AnalyticsEventParams(shopperSessionId = shopperSessionId)) }
+        // A Test type, with a button in the first position displayed in the mini cart.
+        val presentmentDetails = PresentmentDetails(
+            ExperimentType.TEST,
+            ButtonOrder.FIRST,
+            PageType.MINI_CART
+        )
+
+        val params = AnalyticsEventParams(
+            experiment = presentmentDetails?.type?.formattedExperiment(),
+            shopperSessionId = shopperSessionId,
+            buttonType = ButtonType.VENMO.getStringRepresentation(),
+            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
+            pageType = presentmentDetails.pageType.getStringRepresentation()
+        )
+        sut.sendSelectedEvent(
+            ButtonType.VENMO,
+            PresentmentDetails(
+                ExperimentType.TEST,
+                ButtonOrder.FIRST,
+                PageType.MINI_CART
+            )
+        )
+        verify { braintreeClient.sendAnalyticsEvent("shopper-insights:button-selected",
+            params) }
     }
 
     @Test

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -495,27 +495,12 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test paypal selected analytics event`() {
-        // A Test type, with a button in the first position displayed in the mini cart.
-        val presentmentDetails = PresentmentDetails(
-            ExperimentType.TEST,
-            ButtonOrder.FIRST,
-            PageType.MINI_CART
-        )
-
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails?.type?.formattedExperiment(),
             shopperSessionId = shopperSessionId,
-            buttonType = ButtonType.PAYPAL.getStringRepresentation(),
-            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
-            pageType = presentmentDetails.pageType.getStringRepresentation()
+            buttonType = ButtonType.PAYPAL.getStringRepresentation()
         )
         sut.sendSelectedEvent(
-            ButtonType.PAYPAL,
-            PresentmentDetails(
-                ExperimentType.TEST,
-                ButtonOrder.FIRST,
-                PageType.MINI_CART
-            )
+            ButtonType.PAYPAL
         )
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:button-selected",
             params) }
@@ -523,27 +508,12 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test venmo selected analytics event`() {
-        // A Test type, with a button in the first position displayed in the mini cart.
-        val presentmentDetails = PresentmentDetails(
-            ExperimentType.TEST,
-            ButtonOrder.FIRST,
-            PageType.MINI_CART
-        )
-
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails?.type?.formattedExperiment(),
             shopperSessionId = shopperSessionId,
             buttonType = ButtonType.VENMO.getStringRepresentation(),
-            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
-            pageType = presentmentDetails.pageType.getStringRepresentation()
         )
         sut.sendSelectedEvent(
             ButtonType.VENMO,
-            PresentmentDetails(
-                ExperimentType.TEST,
-                ButtonOrder.FIRST,
-                PageType.MINI_CART
-            )
         )
         verify { braintreeClient.sendAnalyticsEvent("shopper-insights:button-selected",
             params) }


### PR DESCRIPTION
### Summary of changes

Refactor `sendPayPalSelectedEvent()` and `sendVenmoSelectedEvent()` to `sendSelectedEvent()`
<img width="1377" alt="Screenshot 2024-12-19 at 9 50 57 AM" src="https://github.com/user-attachments/assets/79cf8ba7-3f5b-42bb-853b-ff90e99c0d48" />

### Checklist

 - [X] Added a changelog entry
 - [X] Relevant test coverage
 - [X] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@jwarmkessel 
@warmkesselj 

