### PR TITLE
Remove `paymentMethodsDisplayed`

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -44,7 +44,6 @@ class AnalyticsClient internal constructor(
             endTime = analyticsEventParams.endTime,
             endpoint = analyticsEventParams.endpoint,
             experiment = analyticsEventParams.experiment,
-            paymentMethodsDisplayed = analyticsEventParams.paymentMethodsDisplayed,
             appSwitchUrl = analyticsEventParams.appSwitchUrl,
             shopperSessionId = analyticsEventParams.shopperSessionId,
             buttonType = analyticsEventParams.buttonType,
@@ -243,8 +242,6 @@ class AnalyticsClient internal constructor(
             .putOpt(FPTI_KEY_END_TIME, event.endTime)
             .putOpt(FPTI_KEY_ENDPOINT, event.endpoint)
             .putOpt(FPTI_KEY_MERCHANT_EXPERIMENT, event.experiment)
-            .putOpt(FPTI_KEY_MERCHANT_PAYMENT_METHODS_DISPLAYED,
-                event.paymentMethodsDisplayed.ifEmpty { null })
             .putOpt(FPTI_KEY_URL, event.appSwitchUrl)
             .putOpt(FPTI_KEY_SHOPPER_SESSION_ID, event.shopperSessionId)
             .putOpt(FPTI_KEY_BUTTON_TYPE, event.buttonType)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
@@ -15,7 +15,6 @@ internal data class AnalyticsEvent(
     val endTime: Long? = null,
     val endpoint: String? = null,
     val experiment: String? = null,
-    val paymentMethodsDisplayed: List<String> = emptyList(),
     val appSwitchUrl: String? = null,
     val shopperSessionId: String? = null,
     val buttonType: String? = null,

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -15,7 +15,6 @@ import androidx.annotation.RestrictTo
  * @property endpoint The endpoint being called.
  * @property experiment Currently a ShopperInsights module specific event that indicates
  * the experiment, as a JSON string, that the merchant sent to the us.
- * order of payment methods displayed to the shopper by the merchant.
  * @property shopperSessionId The Shopper Insights customer session ID created by a merchant's
  * server SDK or graphQL integration.
  * @property buttonType buttonType Represents the tapped button type.

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -15,7 +15,6 @@ import androidx.annotation.RestrictTo
  * @property endpoint The endpoint being called.
  * @property experiment Currently a ShopperInsights module specific event that indicates
  * the experiment, as a JSON string, that the merchant sent to the us.
- * @property paymentMethodsDisplayed A ShopperInsights module specific event that indicates the
  * order of payment methods displayed to the shopper by the merchant.
  * @property shopperSessionId The Shopper Insights customer session ID created by a merchant's
  * server SDK or graphQL integration.
@@ -32,7 +31,6 @@ data class AnalyticsEventParams @JvmOverloads constructor(
     var endTime: Long? = null,
     var endpoint: String? = null,
     val experiment: String? = null,
-    val paymentMethodsDisplayed: List<String> = emptyList(),
     val appSwitchUrl: String? = null,
     val shopperSessionId: String? = null,
     val buttonType: String? = null,

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import static java.util.Collections.emptyList;
-
 import android.net.Uri;
 
 import androidx.fragment.app.FragmentActivity;
@@ -120,7 +118,7 @@ public class PayPalClientUnitTest {
 
         verify(braintreeClient).sendAnalyticsEvent(
             PayPalAnalytics.TOKENIZATION_STARTED,
-            new AnalyticsEventParams(null, null, true, null, null, null, null, Collections.emptyList(), null, "test-shopper-session-id")
+            new AnalyticsEventParams(null, null, true, null, null, null, null, null, "test-shopper-session-id")
         );
     }
 
@@ -639,7 +637,6 @@ public class PayPalClientUnitTest {
                 null,
                 null,
                 null,
-                emptyList(),
                 "sample-scheme://onetouch/v1/success?PayerID=HERMES-SANDBOX-PAYER-ID&paymentId=HERMES-SANDBOX-PAYMENT-ID&token=EC-HERMES-SANDBOX-EC-TOKEN&switch_initiated_time=17166111926211"
         );
         verify(braintreeClient).sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_SUCCEEDED, appSwitchParams);
@@ -681,7 +678,6 @@ public class PayPalClientUnitTest {
                 null,
                 null,
                 null,
-                emptyList(),
                 "https://some-scheme/onetouch/v1/cancel?token=SOME-BA&switch_initiated_time=17166111926211"
         );
         verify(braintreeClient).sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_FAILED, appSwitchParams);

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
@@ -42,8 +42,6 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.ArrayList;
-
 @RunWith(RobolectricTestRunner.class)
 public class VenmoClientUnitTest {
 
@@ -75,7 +73,6 @@ public class VenmoClientUnitTest {
         null,
         null,
         null,
-        new ArrayList<>(),
         appSwitchUrl.toString()
     );
     private final AnalyticsEventParams expectedVaultAnalyticsParams = new AnalyticsEventParams(
@@ -86,7 +83,6 @@ public class VenmoClientUnitTest {
         null,
         null,
         null,
-        new ArrayList<>(),
         appSwitchUrl.toString()
     );
 


### PR DESCRIPTION
### Summary of changes

 - Remove `paymentMethodsDisplayed` - no longer needed for v1.5 of Shopper Insights

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~
 - ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors

@jaxdesmarais 