### PR TITLE
Add Payer Email to Base Parameters if not null/empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+ 
+* PayPal
+  * Fix bug to ensure that `PayPalVaultRequest.userAuthenticationEmail` is not sent as an empty string
+  
 ## 5.3.0 (2024-12-11)
 
 * PayPal

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -66,7 +66,7 @@ class PayPalVaultRequest
 ) {
 
     @Throws(JSONException::class)
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
     override fun createRequestBody(
         configuration: Configuration?,
         authorization: Authorization?,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -90,7 +90,9 @@ class PayPalVaultRequest
             parameters.put(DESCRIPTION_KEY, billingAgreementDescription)
         }
 
-        parameters.putOpt(PAYER_EMAIL_KEY, userAuthenticationEmail)
+        if (!userAuthenticationEmail.isNullOrEmpty()) {
+            parameters.put(PAYER_EMAIL_KEY, userAuthenticationEmail)
+        }
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 


### PR DESCRIPTION
### Summary of changes

- Add a conditional check to ensure that the userAuthenticationEmail is not null/empty before setting it as the payer_email

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

- @richherrera 

