### PR TITLE
Bug Fix: Handle Missing 3DS `dfReferenceId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
  
 * PayPal
   * Fix bug to ensure that `PayPalVaultRequest.userAuthenticationEmail` is not sent as an empty string
+* ThreeDSecure
+  * Return error if no `dfReferenceId` is returned in the 3D Secure flow
   
 ## 5.3.0 (2024-12-11)
 

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
@@ -204,11 +204,17 @@ class ThreeDSecureClient internal constructor(
                     configuration,
                     request
                 ) { consumerSessionId: String?, _ ->
-                    if (consumerSessionId != null) {
-                        try {
+                    if (consumerSessionId != null && !consumerSessionId.isEmpty()) {
                             lookupJSON.put("dfReferenceId", consumerSessionId)
-                        } catch (ignored: JSONException) {
-                        }
+                    } else {
+                        callbackPrepareLookupFailure(
+                            callback,
+                            ThreeDSecurePrepareLookupResult.Failure(
+                                BraintreeException("There was an error retrieving the dfReferenceId.")
+                            )
+                        )
+
+                        return@initialize
                     }
                     braintreeClient.sendAnalyticsEvent(ThreeDSecureAnalytics.LOOKUP_SUCCEEDED)
                     callback.onPrepareLookupResult(


### PR DESCRIPTION
### Summary of changes

 - Return error if no `dfReferenceId` is returned in the 3D Secure flow
    - Confirmed with Cardinal that we should not continue the flow if we do not get a `dfReferenceId` back, there is also no fallback mechanism on mobile like exists on web

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 