### PR TITLE
Fix app switch vault analytics

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AppSwitchRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AppSwitchRepository.kt
@@ -1,6 +1,8 @@
 package com.braintreepayments.api.core
 
-// should possibly be a higher level repo
+/**
+ * Repository to hold the state of the app switch flow.
+ */
 class AppSwitchRepository {
     var isAppSwitchFlow = false
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AppSwitchRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AppSwitchRepository.kt
@@ -1,0 +1,10 @@
+package com.braintreepayments.api.core
+
+// should possibly be a higher level repo
+class AppSwitchRepository {
+    var isAppSwitchFlow = false
+
+    companion object {
+        val instance by lazy { AppSwitchRepository() }
+    }
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
@@ -1,0 +1,7 @@
+package com.braintreepayments.api.core
+
+class GetAppSwitchUseCase(private val appSwitchRepository: AppSwitchRepository) {
+    operator fun invoke() : Boolean {
+        return appSwitchRepository.isAppSwitchFlow
+    }
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
@@ -1,7 +1,7 @@
 package com.braintreepayments.api.core
 
 class GetAppSwitchUseCase(private val appSwitchRepository: AppSwitchRepository) {
-    operator fun invoke() : Boolean {
+    operator fun invoke(): Boolean {
         return appSwitchRepository.isAppSwitchFlow
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/SetAppSwitchUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/SetAppSwitchUseCase.kt
@@ -1,0 +1,8 @@
+package com.braintreepayments.api.core
+
+class SetAppSwitchUseCase(private val appSwitchRepository: AppSwitchRepository) {
+
+    operator fun invoke(appSwitchFlow: Boolean) {
+        appSwitchRepository.isAppSwitchFlow = appSwitchFlow
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Fix a bug to correctly log app switch flow analytics.
+
 ## 5.6.0 (2025-02-05)
 
 * ShopperInsights (BETA)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -5,11 +5,13 @@ import android.net.Uri
 import android.text.TextUtils
 import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.core.AnalyticsEventParams
+import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.BraintreeRequestCodes
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.core.GetAppSwitchUseCase
 import com.braintreepayments.api.core.GetReturnLinkUseCase
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
@@ -26,7 +28,8 @@ class PayPalClient internal constructor(
     private val braintreeClient: BraintreeClient,
     private val internalPayPalClient: PayPalInternalClient = PayPalInternalClient(braintreeClient),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
-    private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository)
+    private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(AppSwitchRepository.instance)
 ) {
     /**
      * Used for linking events from the client to server side request
@@ -125,7 +128,7 @@ class PayPalClient internal constructor(
             error: Exception? ->
             if (payPalResponse != null) {
                 payPalContextId = payPalResponse.pairingId
-                val isAppSwitchFlow = internalPayPalClient.isAppSwitchEnabled(payPalRequest) &&
+                val isAppSwitchFlow = getAppSwitchUseCase() && internalPayPalClient.isAppSwitchEnabled(payPalRequest) &&
                     internalPayPalClient.isPayPalInstalled(context)
                 linkType = if (isAppSwitchFlow) LinkType.APP_SWITCH else LinkType.APP_LINK
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -3,12 +3,14 @@ package com.braintreepayments.api.paypal
 import android.content.Context
 import android.net.Uri
 import com.braintreepayments.api.core.ApiClient
+import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.DeviceInspector
 import com.braintreepayments.api.core.GetReturnLinkUseCase
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.SetAppSwitchUseCase
 import com.braintreepayments.api.datacollector.DataCollector
 import com.braintreepayments.api.datacollector.DataCollectorInternalRequest
 import com.braintreepayments.api.paypal.PayPalPaymentResource.Companion.fromJson
@@ -21,7 +23,8 @@ internal class PayPalInternalClient(
     private val apiClient: ApiClient = ApiClient(braintreeClient),
     private val deviceInspector: DeviceInspector = DeviceInspector(),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
-    private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository)
+    private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
+    private val setAppSwitchUseCase: SetAppSwitchUseCase = SetAppSwitchUseCase(AppSwitchRepository.instance)
 ) {
 
     fun sendRequest(
@@ -125,6 +128,7 @@ internal class PayPalInternalClient(
             try {
                 val paypalPaymentResource = fromJson(responseBody)
                 val parsedRedirectUri = Uri.parse(paypalPaymentResource.redirectUrl)
+                setAppSwitchUseCase(paypalPaymentResource.isAppSwitchFlow)
 
                 val pairingId = findPairingId(parsedRedirectUri)
                 val clientMetadataId = payPalRequest.riskCorrelationId ?: run {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -23,7 +23,7 @@ internal class PayPalInternalClient(
     private val deviceInspector: DeviceInspector = DeviceInspector(),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
-    private val setAppSwitchUseCase: SetAppSwitchUseCase = SetAppSwitchUseCase(AppSwitchRepository.instance)
+    private val setAppSwitchUseCase: SetAppSwitchUseCase = SetAppSwitchUseCase(AppSwitchRepository.instance),
     private val payPalTokenResponseRepository: PayPalTokenResponseRepository = PayPalTokenResponseRepository.instance,
     private val payPalSetPaymentTokenUseCase: PayPalSetPaymentTokenUseCase = PayPalSetPaymentTokenUseCase(
         payPalTokenResponseRepository

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -138,11 +138,7 @@ internal class PayPalInternalClient(
                         applicationGuid = dataCollector.getPayPalInstallationGUID(context)
                         clientMetadataId = paypalContextId
                     }
-                    dataCollector.getClientMetadataId(
-                        context = context,
-                        request = dataCollectorRequest,
-                        configuration = configuration
-                    )
+                    dataCollector.getClientMetadataId(context, dataCollectorRequest, configuration)
                 }
                 val returnLink: String = when (val returnLinkResult = getReturnLinkUseCase()) {
                     is GetReturnLinkUseCase.ReturnLinkResult.AppLink -> returnLinkResult.appLinkReturnUri.toString()

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentResource.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentResource.kt
@@ -11,7 +11,8 @@ import org.json.JSONObject
  * containing an EC token
  */
 internal data class PayPalPaymentResource(
-    val redirectUrl: String
+    val redirectUrl: String,
+    val isAppSwitchFlow: Boolean = false
 ) {
 
     companion object {
@@ -20,6 +21,7 @@ internal data class PayPalPaymentResource(
         private const val AGREEMENT_SETUP_KEY = "agreementSetup"
         private const val APPROVAL_URL_KEY = "approvalUrl"
         private const val PAYPAL_APP_APPROVAL_URL_KEY = "paypalAppApprovalUrl"
+        private const val LAUNCH_PAYPAL_APP_KEY = "launchPayPalApp"
 
         /**
          * Create a PayPalPaymentResource from a jsonString. Checks for keys associated with Single
@@ -34,20 +36,21 @@ internal data class PayPalPaymentResource(
         fun fromJson(jsonString: String): PayPalPaymentResource {
             val json = JSONObject(jsonString)
             val paymentResource = json.optJSONObject(PAYMENT_RESOURCE_KEY)
-            val redirectUrl = if (paymentResource != null) {
-                Json.optString(paymentResource, REDIRECT_URL_KEY, "")
+            return if (paymentResource != null) {
+                val redirectUrl = Json.optString(paymentResource, REDIRECT_URL_KEY, "")
+                val isAppSwitchFlow = Json.optBoolean(paymentResource, LAUNCH_PAYPAL_APP_KEY, false)
+                PayPalPaymentResource(redirectUrl, isAppSwitchFlow)
             } else {
+                var isAppSwitchFlow = true
                 val redirectJson = json.optJSONObject(AGREEMENT_SETUP_KEY)
                 val payPalApprovalURL = Json.optString(redirectJson, PAYPAL_APP_APPROVAL_URL_KEY, "")
+                var redirectUrl = payPalApprovalURL
                 payPalApprovalURL.ifEmpty {
-                    Json.optString(
-                        redirectJson,
-                        APPROVAL_URL_KEY,
-                        ""
-                    )
+                    isAppSwitchFlow = false
+                    redirectUrl = Json.optString(redirectJson, APPROVAL_URL_KEY, "")
                 }
+                PayPalPaymentResource(redirectUrl = redirectUrl, isAppSwitchFlow = isAppSwitchFlow)
             }
-            return PayPalPaymentResource(redirectUrl)
         }
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentResource.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentResource.kt
@@ -41,10 +41,13 @@ internal data class PayPalPaymentResource(
                 val isAppSwitchFlow = Json.optBoolean(paymentResource, LAUNCH_PAYPAL_APP_KEY, false)
                 PayPalPaymentResource(redirectUrl, isAppSwitchFlow)
             } else {
-                var isAppSwitchFlow = true
                 val redirectJson = json.optJSONObject(AGREEMENT_SETUP_KEY)
+                var isAppSwitchFlow = true
                 val payPalApprovalURL = Json.optString(redirectJson, PAYPAL_APP_APPROVAL_URL_KEY, "")
                 var redirectUrl = payPalApprovalURL
+                // Presence of `payPalApprovalURL` indicates that this is an app-switch flow.
+                // In case `payPalApprovalURL` is empty and we end up using `approvalUrl` instead,
+                // one wouldn't go through the app-switch flow.
                 payPalApprovalURL.ifEmpty {
                     isAppSwitchFlow = false
                     redirectUrl = Json.optString(redirectJson, APPROVAL_URL_KEY, "")

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.java
@@ -17,10 +17,12 @@ import com.braintreepayments.api.BrowserSwitchFinalResult;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.core.AnalyticsEventParams;
 import com.braintreepayments.api.core.AnalyticsParamRepository;
+import com.braintreepayments.api.core.AppSwitchRepository;
 import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.BraintreeRequestCodes;
 import com.braintreepayments.api.core.Configuration;
+import com.braintreepayments.api.core.GetAppSwitchUseCase;
 import com.braintreepayments.api.core.GetReturnLinkUseCase;
 import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.testutils.Fixtures;
@@ -49,6 +51,8 @@ public class PayPalClientUnitTest {
 
     private MerchantRepository merchantRepository;
     private GetReturnLinkUseCase getReturnLinkUseCase;
+    private AppSwitchRepository appSwitchRepository;
+    private GetAppSwitchUseCase getAppSwitchUseCase;
 
     @Before
     public void beforeEach() throws JSONException {
@@ -63,10 +67,14 @@ public class PayPalClientUnitTest {
         merchantRepository = mock(MerchantRepository.class);
         getReturnLinkUseCase = mock(GetReturnLinkUseCase.class);
 
+        getAppSwitchUseCase = mock(GetAppSwitchUseCase.class);
+
         when(merchantRepository.getReturnUrlScheme()).thenReturn("com.braintreepayments.demo");
         when(getReturnLinkUseCase.invoke()).thenReturn(new GetReturnLinkUseCase.ReturnLinkResult.AppLink(
             Uri.parse("www.example.com")
         ));
+
+        when(getAppSwitchUseCase.invoke()).thenReturn(true);
     }
 
     @Test
@@ -90,7 +98,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -144,7 +152,7 @@ public class PayPalClientUnitTest {
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
                 .launchesBrowserSwitchAsNewTask(true).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -179,7 +187,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -216,7 +224,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -253,7 +261,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().configuration(payPalEnabledConfig)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor = ArgumentCaptor.forClass(PayPalPaymentAuthRequest.class);
@@ -271,7 +279,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalDisabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, new PayPalCheckoutRequest("1.00", true),
             paymentAuthCallback);
 
@@ -303,7 +311,7 @@ public class PayPalClientUnitTest {
             .configurationError(authError)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, new PayPalCheckoutRequest("1.00", true), paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -331,7 +339,7 @@ public class PayPalClientUnitTest {
             .configurationError(authError)
             .build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, new PayPalVaultRequest(true), paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -360,7 +368,7 @@ public class PayPalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalRequest, paymentAuthCallback);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest),
@@ -376,7 +384,7 @@ public class PayPalClientUnitTest {
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalRequest, paymentAuthCallback);
 
         verify(payPalInternalClient).sendRequest(same(activity), same(payPalRequest),
@@ -408,7 +416,7 @@ public class PayPalClientUnitTest {
         BraintreeClient braintreeClient =
             new MockBraintreeClientBuilder().configuration(payPalEnabledConfig).build();
 
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
         sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequest> captor =
@@ -455,7 +463,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -499,7 +507,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -544,7 +552,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -587,7 +595,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -631,7 +639,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -680,7 +688,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 
@@ -723,7 +731,7 @@ public class PayPalClientUnitTest {
         PayPalPaymentAuthResult.Success payPalPaymentAuthResult = new PayPalPaymentAuthResult.Success(
             browserSwitchResult);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
-        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase);
+        PayPalClient sut = new PayPalClient(braintreeClient, payPalInternalClient, merchantRepository, getReturnLinkUseCase, getAppSwitchUseCase);
 
         sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback);
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -107,7 +107,7 @@ public class PayPalInternalClientUnitTest {
             deviceInspector,
             merchantRepository,
             getReturnLinkUseCase,
-            setAppSwitchUseCase
+            setAppSwitchUseCase,
             tokenRepository,
             tokenUseCase
         );

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -27,6 +27,7 @@ import com.braintreepayments.api.core.DeviceInspector;
 import com.braintreepayments.api.core.GetReturnLinkUseCase;
 import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.core.PostalAddress;
+import com.braintreepayments.api.core.SetAppSwitchUseCase;
 import com.braintreepayments.api.core.TokenizationKey;
 import com.braintreepayments.api.core.TokenizeCallback;
 import com.braintreepayments.api.datacollector.DataCollector;
@@ -67,6 +68,8 @@ public class PayPalInternalClientUnitTest {
     private MerchantRepository merchantRepository = mock(MerchantRepository.class);
     private GetReturnLinkUseCase getReturnLinkUseCase = mock(GetReturnLinkUseCase.class);
 
+    private SetAppSwitchUseCase setAppSwitchUseCase = mock(SetAppSwitchUseCase.class);
+
     @Before
     public void beforeEach() throws JSONException {
         context = mock(Context.class);
@@ -100,7 +103,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PostalAddress shippingAddressOverride = new PostalAddress();
@@ -181,7 +185,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PostalAddress shippingAddressOverride = new PostalAddress();
@@ -257,7 +262,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
         PostalAddress shippingAddressOverride = new PostalAddress();
         shippingAddressOverride.setRecipientName("Brianna Tree");
@@ -359,7 +365,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -395,7 +402,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(false);
@@ -431,7 +439,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -467,7 +476,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -503,7 +513,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -540,7 +551,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -578,7 +590,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -614,7 +627,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -648,7 +662,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -686,7 +701,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -719,7 +735,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -750,7 +767,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -791,7 +809,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -831,7 +850,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -874,7 +894,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
@@ -910,7 +931,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -953,7 +975,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -977,7 +1000,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -1002,7 +1026,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -1029,7 +1054,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
@@ -1050,7 +1076,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         sut.tokenize(payPalAccount, callback);
@@ -1074,7 +1101,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         sut.tokenize(payPalAccount, callback);
@@ -1105,7 +1133,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         sut.tokenize(payPalAccount, callback);
@@ -1130,7 +1159,8 @@ public class PayPalInternalClientUnitTest {
             apiClient,
             deviceInspector,
             merchantRepository,
-            getReturnLinkUseCase
+            getReturnLinkUseCase,
+            setAppSwitchUseCase
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalPaymentResourceUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalPaymentResourceUnitTest.java
@@ -6,19 +6,32 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-import com.braintreepayments.api.paypal.PayPalPaymentResource;
-
 public class PayPalPaymentResourceUnitTest {
 
     @Test
-    public void fromJson_parsesRedirectUrlFromOneTimePaymentResource() throws JSONException {
+    public void fromJson_parsesRedirectUrlFromOneTimePaymentResource_appSwitchFlow() throws JSONException {
         String oneTimePaymentJson = new JSONObject()
                 .put("paymentResource", new JSONObject()
                         .put("redirectUrl", "www.example.com/redirect")
+                        .put("launchPayPalApp", true)
                 ).toString();
 
         PayPalPaymentResource sut = PayPalPaymentResource.fromJson(oneTimePaymentJson);
         assertEquals("www.example.com/redirect", sut.getRedirectUrl());
+        assertTrue(sut.isAppSwitchFlow());
+    }
+
+    @Test
+    public void fromJson_parsesRedirectUrlFromOneTimePaymentResource_fallbackFlow() throws JSONException {
+        String oneTimePaymentJson = new JSONObject()
+                .put("paymentResource", new JSONObject()
+                        .put("redirectUrl", "www.example.com/redirect")
+                        .put("launchPayPalApp", false)
+                ).toString();
+
+        PayPalPaymentResource sut = PayPalPaymentResource.fromJson(oneTimePaymentJson);
+        assertEquals("www.example.com/redirect", sut.getRedirectUrl());
+        assertFalse(sut.isAppSwitchFlow());
     }
 
     @Test
@@ -30,6 +43,7 @@ public class PayPalPaymentResourceUnitTest {
 
         PayPalPaymentResource sut = PayPalPaymentResource.fromJson(billingAgreementJson);
         assertEquals("www.example.com/redirect", sut.getRedirectUrl());
+        assertFalse(sut.isAppSwitchFlow());
     }
 
     @Test
@@ -42,5 +56,6 @@ public class PayPalPaymentResourceUnitTest {
 
         PayPalPaymentResource sut = PayPalPaymentResource.fromJson(billingAgreementJson);
         assertEquals("www.paypal.example.com/redirect", sut.getRedirectUrl());
+        assertTrue(sut.isAppSwitchFlow());
     }
 }


### PR DESCRIPTION
### Summary of changes

 - We were logging the app-switch analytics when a couple static checks were satisfied even if the launchPayPalApp was false from the BT gateway.
 - In this PR, I'm making changes to take into consideration if launchPayPalApp is being returned true or not.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

