### PR TITLE
Send null ShopperInsightsSessionId for PayPal flows

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -156,7 +156,7 @@ public class PayPalFragment extends BaseFragment {
                 buyerEmailAddress,
                 buyerPhoneCountryCode,
                 buyerPhoneNationalNumber,
-                    "fake-session-id"
+                null
             );
         } else {
             payPalRequest = createPayPalCheckoutRequest(


### PR DESCRIPTION
### Summary of changes

 - ShopperInsightsSessionId is only available in Shopper Insights flow and will be null in other flows - PayPal flow in this case.

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

