### PR TITLE
Make userAuthenticationEmail optional for app-switch related flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Make `PayPalCheckoutRequest.userAuthenticationEmail` optional for App Switch flows
+
 ## 5.8.0 (2025-03-06)
 
 * All Modules

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -153,7 +153,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             }
         }
 
-        if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
+        if (enablePayPalAppSwitch && !appLink.isNullOrEmpty()) {
             parameters.put(ENABLE_APP_SWITCH_KEY, enablePayPalAppSwitch)
             parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT.toString())
             parameters.put(OS_TYPE_KEY, "Android")

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -98,7 +98,7 @@ class PayPalVaultRequest
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 
-        if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
+        if (enablePayPalAppSwitch && !appLink.isNullOrEmpty()) {
             parameters.put(ENABLE_APP_SWITCH_KEY, enablePayPalAppSwitch)
             parameters.put(OS_VERSION_KEY, Build.VERSION.SDK_INT.toString())
             parameters.put(OS_TYPE_KEY, "Android")

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
@@ -193,6 +193,30 @@ public class PayPalCheckoutRequestUnitTest {
     }
 
     @Test
+    public void createRequestBody_sets_appSwitchParameters_irrespectiveOf_userAuthenticationEmail_emptyOrNot(
+        @TestParameter({"", "some@email.com"}) String payerEmail
+    ) throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+        request.setEnablePayPalAppSwitch(true);
+        request.setUserAuthenticationEmail(payerEmail);
+        String appLink = "universal_url";
+
+        String requestBody = request.createRequestBody(
+                mock(Configuration.class),
+                mock(Authorization.class),
+                "success_url",
+                "cancel_url",
+                appLink
+        );
+
+        JSONObject jsonObject = new JSONObject(requestBody);
+        assertTrue(jsonObject.getBoolean("launch_paypal_app"));
+        assertEquals("Android", jsonObject.getString("os_type"));
+        assertEquals(appLink, jsonObject.getString("merchant_app_return_url"));
+        assertNotNull(jsonObject.getString("os_version"));
+    }
+
+    @Test
     public void createRequestBody_sets_shopper_insights_session_id() throws JSONException {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
         request.setShopperSessionId("shopper-insights-id");


### PR DESCRIPTION
### Summary of changes

 - Make `userAuthenticationEmail` optional for app-switch related flows

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

