### PR TITLE
Add contactPreference to PayPalCheckoutRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal
+  * Add `contactPreference` property to `PayPalCheckoutRequest`
+
 ## 5.8.0 (2025-03-06)
 
 * All Modules

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -8,6 +8,7 @@ import com.braintreepayments.api.paypal.PayPalBillingInterval;
 import com.braintreepayments.api.paypal.PayPalBillingPricing;
 import com.braintreepayments.api.paypal.PayPalCheckoutRequest;
 import com.braintreepayments.api.paypal.PayPalContactInformation;
+import com.braintreepayments.api.paypal.PayPalContactPreference;
 import com.braintreepayments.api.paypal.PayPalLandingPageType;
 import com.braintreepayments.api.paypal.PayPalPaymentIntent;
 import com.braintreepayments.api.paypal.PayPalPaymentUserAction;
@@ -37,11 +38,11 @@ public class PayPalRequestFactory {
         }
 
         if ((buyerPhoneCountryCode != null && !buyerPhoneCountryCode.isEmpty())
-                && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
+            && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
 
             request.setUserPhoneNumber(new PayPalPhoneNumber(
-                    buyerPhoneCountryCode,
-                    buyerPhoneNationalNumber)
+                buyerPhoneCountryCode,
+                buyerPhoneNationalNumber)
             );
         }
 
@@ -87,9 +88,9 @@ public class PayPalRequestFactory {
             );
 
             PayPalBillingCycle billingCycle = new PayPalBillingCycle(
-                    false,
+                false,
                 1,
-                    PayPalBillingInterval.MONTH,
+                PayPalBillingInterval.MONTH,
                 1,
                 1,
                 "2024-08-01",
@@ -134,10 +135,10 @@ public class PayPalRequestFactory {
         }
 
         if ((buyerPhoneCountryCode != null && !buyerPhoneCountryCode.isEmpty())
-                && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
+            && (buyerPhoneNationalNumber != null && !buyerPhoneNationalNumber.isEmpty())) {
             request.setUserPhoneNumber(new PayPalPhoneNumber(
-                    buyerPhoneCountryCode,
-                    buyerPhoneNationalNumber)
+                buyerPhoneCountryCode,
+                buyerPhoneNationalNumber)
             );
         }
 
@@ -186,6 +187,7 @@ public class PayPalRequestFactory {
 
         if (isContactInformationEnabled) {
             request.setContactInformation(new PayPalContactInformation("some@email.com", new PayPalPhoneNumber("1", "1234567890")));
+            request.setContactPreference(PayPalContactPreference.UPDATE_CONTACT_INFORMATION);
         }
 
         return request;

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -1,7 +1,7 @@
 package com.braintreepayments.api.paypal
 
-import android.os.Build
 import android.net.Uri
+import android.os.Build
 import android.text.TextUtils
 import com.braintreepayments.api.core.Authorization
 import com.braintreepayments.api.core.ClientToken
@@ -63,6 +63,8 @@ import org.json.JSONObject
  * at this URL.
  *
  * @property contactInformation Contact information of the recipient for the order
+ *
+ * @property contactPreference Preference for the contact information section within the payment flow
  */
 @Parcelize
 class PayPalCheckoutRequest @JvmOverloads constructor(
@@ -76,6 +78,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var enablePayPalAppSwitch: Boolean = false,
     var shippingCallbackUrl: Uri? = null,
     var contactInformation: PayPalContactInformation? = null,
+    var contactPreference: PayPalContactPreference? = null,
     override var localeCode: String? = null,
     override var billingAgreementDescription: String? = null,
     override var isShippingAddressRequired: Boolean = false,
@@ -87,7 +90,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var riskCorrelationId: String? = null,
     override var userAuthenticationEmail: String? = null,
     override var userPhoneNumber: PayPalPhoneNumber? = null,
-    override var lineItems: List<PayPalLineItem> = emptyList()
+    override var lineItems: List<PayPalLineItem> = emptyList(),
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -146,11 +149,11 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
         contactInformation?.let { info ->
             info.recipientEmail?.let { parameters.put(RECIPIENT_EMAIL_KEY, it) }
             info.recipentPhoneNumber?.let {
-                parameters.put(
-                    RECIPIENT_PHONE_NUMBER_KEY,
-                    it.toJson()
-                )
+                parameters.put(RECIPIENT_PHONE_NUMBER_KEY, it.toJson())
             }
+        }
+        contactPreference?.let { preference ->
+            parameters.put(CONTACT_PREFERENCE_KEY, preference.stringValue)
         }
 
         if (enablePayPalAppSwitch && !appLink.isNullOrEmpty() && !userAuthenticationEmail.isNullOrEmpty()) {
@@ -160,7 +163,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             parameters.put(MERCHANT_APP_RETURN_URL_KEY, appLink)
         }
 
-        parameters.putOpt(SHOPPER_SESSION_ID, shopperSessionId)
+        parameters.putOpt(SHOPPER_SESSION_ID_KEY, shopperSessionId)
 
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactPreference.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalContactPreference.kt
@@ -1,0 +1,23 @@
+package com.braintreepayments.api.paypal
+
+/**
+ * Contact information section preference within the payment flow
+ */
+enum class PayPalContactPreference(
+    internal val stringValue: String
+) {
+    /**
+     * Disables the contact information section in the payment flow
+     */
+    NO_CONTACT_INFORMATION("NO_CONTACT_INFO"),
+
+    /**
+     * Enables the contact information section but disables the buyer's ability to update the contact information
+     */
+    RETAIN_CONTACT_INFORMATION("RETAIN_CONTACT_INFO"),
+
+    /**
+     * Enables the contact information section and enables the buyer's ability to update the contact information
+     */
+    UPDATE_CONTACT_INFORMATION("UPDATE_CONTACT_INFO"),
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -145,6 +145,7 @@ abstract class PayPalRequest internal constructor(
         internal const val SHIPPING_CALLBACK_URL_KEY: String = "shipping_callback_url"
         internal const val RECIPIENT_EMAIL_KEY: String = "recipient_email"
         internal const val RECIPIENT_PHONE_NUMBER_KEY: String = "international_phone"
-        internal const val SHOPPER_SESSION_ID: String = "shopper_session_id"
+        internal const val CONTACT_PREFERENCE_KEY: String = "contact_preference"
+        internal const val SHOPPER_SESSION_ID_KEY: String = "shopper_session_id"
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -94,7 +94,7 @@ class PayPalVaultRequest
             parameters.put(PAYER_EMAIL_KEY, userAuthenticationEmail)
         }
 
-        parameters.putOpt(SHOPPER_SESSION_ID, shopperSessionId)
+        parameters.putOpt(SHOPPER_SESSION_ID_KEY, shopperSessionId)
 
         userPhoneNumber?.let { parameters.put(PHONE_NUMBER_KEY, it.toJson()) }
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.java
@@ -288,4 +288,35 @@ public class PayPalCheckoutRequestUnitTest {
         assertFalse(requestBody.contains("\"recipient_email\":\"some@email.com\""));
         assertFalse(requestBody.contains("\"international_phone\":{\"country_code\":\"1\",\"national_number\":\"1234567890\"}"));
     }
+
+    @Test
+    public void createRequestBody_does_not_set_contactPreference_when_not_null() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        request.setContactPreference(PayPalContactPreference.UPDATE_CONTACT_INFORMATION);
+        String requestBody = request.createRequestBody(
+            mock(Configuration.class),
+            mock(Authorization.class),
+            "success_url",
+            "cancel_url",
+            null
+        );
+
+        assertTrue(requestBody.contains("\"contact_preference\":\"UPDATE_CONTACT_INFO\""));
+    }
+
+    @Test
+    public void createRequestBody_sets_contactPreference_when_not_null() throws JSONException {
+        PayPalCheckoutRequest request = new PayPalCheckoutRequest("1.00", true);
+
+        String requestBody = request.createRequestBody(
+            mock(Configuration.class),
+            mock(Authorization.class),
+            "success_url",
+            "cancel_url",
+            null
+        );
+
+        assertFalse(requestBody.contains("contact_preference"));
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - Add `contactPreference` param to `PayPalCheckoutRequest`
 - Rename `SHOPPER_SESSION_ID` to `SHOPPER_SESSION_ID_KEY` to match naming convention

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

