### PR TITLE
link_type FPTI Parameter Updates

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -8,6 +8,7 @@ import org.json.JSONException
 @Suppress("SwallowedException", "TooGenericExceptionCaught")
 class AnalyticsClient internal constructor(
     private val analyticsApi: AnalyticsApi = AnalyticsApi(),
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
     private val analyticsEventRepository: AnalyticsEventRepository = AnalyticsEventRepository.instance,
     private val time: Time = Time(),
     private val configurationLoader: ConfigurationLoader = ConfigurationLoader.instance,
@@ -22,7 +23,7 @@ class AnalyticsClient internal constructor(
             name = eventName,
             timestamp = time.currentTime,
             payPalContextId = analyticsEventParams.payPalContextId,
-            linkType = analyticsEventParams.linkType,
+            linkType = analyticsParamRepository.linkType?.stringValue,
             isVaultRequest = analyticsEventParams.isVaultRequest,
             startTime = analyticsEventParams.startTime,
             endTime = analyticsEventParams.endTime,

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEventParams.kt
@@ -8,7 +8,6 @@ import androidx.annotation.RestrictTo
  * all parameters are required at each call site.
  *
  * @property payPalContextId Used for linking events from the client to server side request.
- * @property linkType Indicates whether a deeplink or an app link was used to launch the app. Also see [LinkType].
  * @property isVaultRequest Indicates whether the request was a BillingAgreement(BA)/Vault request.
  * @property startTime [HttpResponseTiming] start time.
  * @property endTime [HttpResponseTiming] end time.
@@ -24,7 +23,6 @@ import androidx.annotation.RestrictTo
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsEventParams @JvmOverloads constructor(
     val payPalContextId: String? = null,
-    val linkType: String? = null,
     val isVaultRequest: Boolean = false,
     val startTime: Long? = null,
     val endTime: Long? = null,

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -10,6 +10,8 @@ class AnalyticsParamRepository(
     private val uuidHelper: UUIDHelper = UUIDHelper()
 ) {
 
+    var linkType: LinkType? = null
+
     private lateinit var _sessionId: String
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetReturnLinkTypeUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetReturnLinkTypeUseCase.kt
@@ -1,0 +1,34 @@
+package com.braintreepayments.api.core
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.annotation.RestrictTo
+
+/**
+ * Use case that returns a return link type that will be used for navigating from App Switch or browser back into the
+ * merchant app.
+ *
+ * If a user unchecks the "Open supported links" checkbox in the Android OS settings for the merchant's app. If this
+ * setting is unchecked, this use case will return [ReturnLinkTypeResult.DEEP_LINK], otherwise
+ * [ReturnLinkTypeResult.APP_LINK] will be returned.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GetReturnLinkTypeUseCase(private val merchantRepository: MerchantRepository) {
+
+    enum class ReturnLinkTypeResult {
+        APP_LINK, DEEP_LINK
+    }
+
+    operator fun invoke(): ReturnLinkTypeResult {
+        val context = merchantRepository.applicationContext
+        val intent = Intent(Intent.ACTION_VIEW, merchantRepository.appLinkReturnUri).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        val resolvedActivity = context.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return if (resolvedActivity?.activityInfo?.packageName == context.packageName) {
+            ReturnLinkTypeResult.APP_LINK
+        } else {
+            ReturnLinkTypeResult.DEEP_LINK
+        }
+    }
+}

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/LinkType.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/LinkType.kt
@@ -9,6 +9,6 @@ import androidx.annotation.RestrictTo
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class LinkType(val stringValue: String) {
-    APP_SWITCH("universal"),
-    APP_LINK("deeplink")
+    APP_LINK("universal"),
+    DEEP_LINK("deeplink")
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
@@ -18,18 +18,19 @@ class AnalyticsClientUnitTest {
 
     private val analyticsApi: AnalyticsApi = mockk(relaxed = true)
     private val analyticsEventRepository: AnalyticsEventRepository = mockk(relaxed = true)
+    private val analyticsParamRepository: AnalyticsParamRepository = mockk(relaxed = true)
     private val time: Time = mockk()
     private lateinit var configurationLoader: ConfigurationLoader
 
     private val configuration: Configuration = fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
     private val eventName = "sample-event-name"
     private val timestamp = 123L
+    private val linkType = LinkType.APP_LINK
 
     private lateinit var sut: AnalyticsClient
 
     private val analyticsEventParams = AnalyticsEventParams(
         payPalContextId = "sample-paypal-context-id",
-        linkType = "sample-link-type",
         isVaultRequest = true,
         startTime = 789,
         endTime = 987,
@@ -46,7 +47,7 @@ class AnalyticsClientUnitTest {
         name = eventName,
         timestamp = timestamp,
         payPalContextId = analyticsEventParams.payPalContextId,
-        linkType = analyticsEventParams.linkType,
+        linkType = linkType.stringValue,
         isVaultRequest = analyticsEventParams.isVaultRequest,
         startTime = analyticsEventParams.startTime,
         endTime = analyticsEventParams.endTime,
@@ -63,6 +64,7 @@ class AnalyticsClientUnitTest {
     @Throws(InvalidArgumentException::class, GeneralSecurityException::class, IOException::class)
     fun beforeEach() {
         every { time.currentTime } returns timestamp
+        every { analyticsParamRepository.linkType } returns linkType
 
         configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -70,6 +72,7 @@ class AnalyticsClientUnitTest {
 
         sut = AnalyticsClient(
             analyticsApi = analyticsApi,
+            analyticsParamRepository = analyticsParamRepository,
             analyticsEventRepository = analyticsEventRepository,
             time = time,
             configurationLoader = configurationLoader,

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkTypeUseCaseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkTypeUseCaseUnitTest.kt
@@ -1,0 +1,53 @@
+package com.braintreepayments.api.core
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class GetReturnLinkTypeUseCaseUnitTest {
+
+    private val merchantRepository: MerchantRepository = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+    private val resolveInfo = ResolveInfo()
+    private val activityInfo = ActivityInfo()
+    private val contextPackageName = "context.package.name"
+
+    lateinit var subject: GetReturnLinkTypeUseCase
+
+    @Before
+    fun setUp() {
+        every { merchantRepository.applicationContext } returns context
+        every { context.packageName } returns contextPackageName
+        resolveInfo.activityInfo = activityInfo
+        every { context.packageManager.resolveActivity(any<Intent>(), any<Int>()) } returns resolveInfo
+
+        subject = GetReturnLinkTypeUseCase(merchantRepository)
+    }
+
+    @Test
+    fun `when invoke is called and app link is available, APP_LINK is returned`() {
+        activityInfo.packageName = "context.package.name"
+
+        val result = subject()
+
+        assertEquals(GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK, result)
+    }
+
+    @Test
+    fun `when invoke is called and app link is not available, DEEP_LINK is returned`() {
+        activityInfo.packageName = "different.package.name"
+
+        val result = subject()
+
+        assertEquals(GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK, result)
+    }
+}

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkUseCaseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkUseCaseUnitTest.kt
@@ -1,9 +1,5 @@
 package com.braintreepayments.api.core
 
-import android.content.Context
-import android.content.Intent
-import android.content.pm.ActivityInfo
-import android.content.pm.ResolveInfo
 import android.net.Uri
 import io.mockk.every
 import io.mockk.mockk
@@ -18,10 +14,7 @@ import kotlin.test.assertTrue
 class GetReturnLinkUseCaseUnitTest {
 
     private val merchantRepository: MerchantRepository = mockk(relaxed = true)
-    private val context: Context = mockk(relaxed = true)
-    private val resolveInfo = ResolveInfo()
-    private val activityInfo = ActivityInfo()
-    private val contextPackageName = "context.package.name"
+    private val getReturnLinkTypeUseCase: GetReturnLinkTypeUseCase = mockk(relaxed = true)
     private val appLinkReturnUri = Uri.parse("https://example.com")
     private val deepLinkFallbackUrlScheme = "com.braintreepayments.demo"
 
@@ -29,19 +22,15 @@ class GetReturnLinkUseCaseUnitTest {
 
     @Before
     fun setUp() {
-        every { merchantRepository.applicationContext } returns context
         every { merchantRepository.appLinkReturnUri } returns appLinkReturnUri
         every { merchantRepository.deepLinkFallbackUrlScheme } returns deepLinkFallbackUrlScheme
-        every { context.packageName } returns contextPackageName
-        resolveInfo.activityInfo = activityInfo
-        every { context.packageManager.resolveActivity(any<Intent>(), any<Int>()) } returns resolveInfo
 
-        subject = GetReturnLinkUseCase(merchantRepository)
+        subject = GetReturnLinkUseCase(merchantRepository, getReturnLinkTypeUseCase)
     }
 
     @Test
-    fun `when invoke is called and app link is available, APP_LINK is returned`() {
-        activityInfo.packageName = "context.package.name"
+    fun `when invoke is called and app link is available, AppLink is returned`() {
+        every { getReturnLinkTypeUseCase() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK
 
         val result = subject()
 
@@ -49,8 +38,8 @@ class GetReturnLinkUseCaseUnitTest {
     }
 
     @Test
-    fun `when invoke is called and app link is not available, DEEP_LINK is returned`() {
-        activityInfo.packageName = "different.package.name"
+    fun `when invoke is called and app link is not available, DeepLink is returned`() {
+        every { getReturnLinkTypeUseCase() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK
 
         val result = subject()
 
@@ -59,7 +48,7 @@ class GetReturnLinkUseCaseUnitTest {
 
     @Test
     fun `when invoke is called and deep link is available but null, Failure is returned`() {
-        activityInfo.packageName = "different.package.name"
+        every { getReturnLinkTypeUseCase() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK
         every { merchantRepository.deepLinkFallbackUrlScheme } returns null
 
         val result = subject()
@@ -73,7 +62,7 @@ class GetReturnLinkUseCaseUnitTest {
 
     @Test
     fun `when invoke is called and app link is available but null, Failure is returned`() {
-        activityInfo.packageName = "context.package.name"
+        every { getReturnLinkTypeUseCase() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK
         every { merchantRepository.appLinkReturnUri } returns null
 
         val result = subject()

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.text.TextUtils
 import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.core.AnalyticsEventParams
+import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
@@ -12,6 +13,8 @@ import com.braintreepayments.api.core.BraintreeRequestCodes
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.GetAppSwitchUseCase
+import com.braintreepayments.api.core.GetReturnLinkTypeUseCase
+import com.braintreepayments.api.core.GetReturnLinkTypeUseCase.ReturnLinkTypeResult
 import com.braintreepayments.api.core.GetReturnLinkUseCase
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
@@ -28,19 +31,16 @@ class PayPalClient internal constructor(
     private val braintreeClient: BraintreeClient,
     private val internalPayPalClient: PayPalInternalClient = PayPalInternalClient(braintreeClient),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
+    getReturnLinkTypeUseCase: GetReturnLinkTypeUseCase = GetReturnLinkTypeUseCase(merchantRepository),
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
-    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(AppSwitchRepository.instance)
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(AppSwitchRepository.instance),
+    analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
 ) {
     /**
      * Used for linking events from the client to server side request
      * In the PayPal flow this will be either an EC token or a Billing Agreement token
      */
     private var payPalContextId: String? = null
-
-    /**
-     * Used for sending the type of flow, universal vs deeplink to FPTI
-     */
-    private var linkType: LinkType? = null
 
     /**
      * True if `tokenize()` was called with a Vault request object type
@@ -80,6 +80,13 @@ class PayPalClient internal constructor(
             appLinkReturnUri = appLinkReturnUrl
         )
     )
+
+    init {
+        analyticsParamRepository.linkType = when (getReturnLinkTypeUseCase()) {
+            ReturnLinkTypeResult.APP_LINK -> LinkType.APP_LINK
+            ReturnLinkTypeResult.DEEP_LINK -> LinkType.DEEP_LINK
+        }
+    }
 
     /**
      * Starts the PayPal payment flow by creating a [PayPalPaymentAuthRequestParams] to be
@@ -130,7 +137,6 @@ class PayPalClient internal constructor(
                 payPalContextId = payPalResponse.paypalContextId
                 val isAppSwitchFlow = getAppSwitchUseCase() && internalPayPalClient.isAppSwitchEnabled(payPalRequest) &&
                     internalPayPalClient.isPayPalInstalled(context)
-                linkType = if (isAppSwitchFlow) LinkType.APP_SWITCH else LinkType.APP_LINK
 
                 try {
                     payPalResponse.browserSwitchOptions = buildBrowserSwitchOptions(payPalResponse)
@@ -372,7 +378,6 @@ class PayPalClient internal constructor(
         get() {
             return AnalyticsEventParams(
                 payPalContextId = payPalContextId,
-                linkType = linkType?.stringValue,
                 isVaultRequest = isVaultRequest,
                 shopperSessionId = shopperSessionId
             )

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
@@ -26,8 +26,10 @@ import com.braintreepayments.api.core.BraintreeClient;
 import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.BraintreeRequestCodes;
 import com.braintreepayments.api.core.Configuration;
+import com.braintreepayments.api.core.GetReturnLinkTypeUseCase;
 import com.braintreepayments.api.core.GetReturnLinkUseCase;
 import com.braintreepayments.api.core.IntegrationType;
+import com.braintreepayments.api.core.LinkType;
 import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.testutils.Fixtures;
 import com.braintreepayments.api.testutils.MockBraintreeClientBuilder;
@@ -52,6 +54,7 @@ public class VenmoClientUnitTest {
     private VenmoPaymentAuthRequestCallback venmoPaymentAuthRequestCallback;
     private VenmoSharedPrefsWriter sharedPrefsWriter;
     private AnalyticsParamRepository analyticsParamRepository;
+    private GetReturnLinkTypeUseCase getReturnLinkTypeUseCase;
 
     private VenmoApi venmoApi;
     private ApiClient apiClient;
@@ -67,7 +70,6 @@ public class VenmoClientUnitTest {
     private final Uri appSwitchUrl = Uri.parse("https://example.com");
     private final AnalyticsEventParams expectedAnalyticsParams = new AnalyticsEventParams(
         null,
-        LINK_TYPE,
         false,
         null,
         null,
@@ -77,7 +79,6 @@ public class VenmoClientUnitTest {
     );
     private final AnalyticsEventParams expectedVaultAnalyticsParams = new AnalyticsEventParams(
         null,
-        LINK_TYPE,
         true,
         null,
         null,
@@ -96,6 +97,7 @@ public class VenmoClientUnitTest {
         venmoApi = mock(VenmoApi.class);
         apiClient = mock(ApiClient.class);
         analyticsParamRepository = mock(AnalyticsParamRepository.class);
+        getReturnLinkTypeUseCase = mock(GetReturnLinkTypeUseCase.class);
 
         venmoEnabledConfiguration =
             Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO);
@@ -115,6 +117,51 @@ public class VenmoClientUnitTest {
         when(merchantRepository.getApplicationContext()).thenReturn(context);
         when(venmoRepository.getVenmoUrl()).thenReturn(appSwitchUrl);
         when(getReturnLinkUseCase.invoke()).thenReturn(new GetReturnLinkUseCase.ReturnLinkResult.AppLink(appSwitchUrl));
+        when(getReturnLinkTypeUseCase.invoke()).thenReturn(GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK);
+    }
+
+    @Test
+    public void initialization_sets_app_link_in_analyticsParamRepository() {
+        when(getReturnLinkTypeUseCase.invoke()).thenReturn(GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK);
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(venmoEnabledConfiguration)
+            .build();
+
+        new VenmoClient(
+            braintreeClient,
+            apiClient,
+            venmoApi,
+            sharedPrefsWriter,
+            analyticsParamRepository,
+            merchantRepository,
+            venmoRepository,
+            getReturnLinkTypeUseCase,
+            getReturnLinkUseCase
+        );
+
+        verify(analyticsParamRepository).setLinkType(LinkType.APP_LINK);
+    }
+
+    @Test
+    public void initialization_sets_deep_link_in_analyticsParamRepository() {
+        when(getReturnLinkTypeUseCase.invoke()).thenReturn(GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK);
+        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
+            .configuration(venmoEnabledConfiguration)
+            .build();
+
+        new VenmoClient(
+            braintreeClient,
+            apiClient,
+            venmoApi,
+            sharedPrefsWriter,
+            analyticsParamRepository,
+            merchantRepository,
+            venmoRepository,
+            getReturnLinkTypeUseCase,
+            getReturnLinkUseCase
+        );
+
+        verify(analyticsParamRepository).setLinkType(LinkType.DEEP_LINK);
     }
 
     @Test
@@ -144,6 +191,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -183,6 +231,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -234,6 +283,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -265,6 +315,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -302,6 +353,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -340,6 +392,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -383,6 +436,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -419,6 +473,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -455,6 +510,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -485,6 +541,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -516,6 +573,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -547,6 +605,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -577,6 +636,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
         sut.createPaymentAuthRequest(context, request, venmoPaymentAuthRequestCallback);
@@ -606,6 +666,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -633,6 +694,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -669,6 +731,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -708,6 +771,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -751,6 +815,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -773,6 +838,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -809,6 +875,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -833,6 +900,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -865,6 +933,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -907,6 +976,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -944,6 +1014,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 
@@ -956,11 +1027,6 @@ public class VenmoClientUnitTest {
         assertTrue(result instanceof VenmoResult.Failure);
         assertEquals(error, ((VenmoResult.Failure) result).getError());
 
-        AnalyticsEventParams params = new AnalyticsEventParams(
-            null,
-            LINK_TYPE,
-            true
-        );
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_FAILED, expectedVaultAnalyticsParams, true);
     }
 
@@ -992,6 +1058,7 @@ public class VenmoClientUnitTest {
             analyticsParamRepository,
             merchantRepository,
             venmoRepository,
+            getReturnLinkTypeUseCase,
             getReturnLinkUseCase
         );
 


### PR DESCRIPTION
### Summary of changes

 - Update the logic of the `link_type` FPTI parameter - it now represents when are enabled/disabled by the user on the merchant app
 - Update PayPalClient and VenmoClient to set the `linkType` property on initialization
 - Separated out the app link vs deep link logic from `GetReturnLinkUseCase` into `GetReturnLinkTypeUseCase`
 
`GetReturnLinkTypeUseCase` - returns the type of link to be used for navigating back to the merchant app
`GetReturnLinkUseCase` - returns the actual link value (deep link or app link string value)

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

