### PR TITLE
Reset AnalyticsParamRepository at the end of the Venmo flow

### DIFF
--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
@@ -379,21 +379,25 @@ class VenmoClient internal constructor(
     ) {
         braintreeClient.sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_FAILED, analyticsParams)
         callback.onVenmoPaymentAuthRequest(request)
+        analyticsParamRepository.reset()
     }
 
     private fun callbackSuccess(callback: VenmoTokenizeCallback, venmoResult: VenmoResult) {
         braintreeClient.sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_SUCCEEDED, analyticsParams)
         callback.onVenmoResult(venmoResult)
+        analyticsParamRepository.reset()
     }
 
     private fun callbackTokenizeCancel(callback: VenmoTokenizeCallback) {
         braintreeClient.sendAnalyticsEvent(VenmoAnalytics.APP_SWITCH_CANCELED, analyticsParams)
         callback.onVenmoResult(VenmoResult.Cancel)
+        analyticsParamRepository.reset()
     }
 
     private fun callbackTokenizeFailure(callback: VenmoTokenizeCallback, venmoResult: VenmoResult) {
         braintreeClient.sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_FAILED, analyticsParams)
         callback.onVenmoResult(venmoResult)
+        analyticsParamRepository.reset()
     }
 
     private val analyticsParams: AnalyticsEventParams

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.java
@@ -197,6 +197,7 @@ public class VenmoClientUnitTest {
 
         verify(venmoPaymentAuthRequestCallback).onVenmoPaymentAuthRequest(captor.capture());
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_FAILED, expectedAnalyticsParams, true);
+        verify(analyticsParamRepository).reset();
         VenmoPaymentAuthRequest paymentAuthRequest = captor.getValue();
         assertTrue(paymentAuthRequest instanceof VenmoPaymentAuthRequest.Failure);
         assertEquals(
@@ -705,7 +706,7 @@ public class VenmoClientUnitTest {
         VenmoResult result = captor.getValue();
         assertTrue(result instanceof VenmoResult.Cancel);
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.APP_SWITCH_CANCELED, expectedAnalyticsParams, true);
-
+        verify(analyticsParamRepository).reset();
     }
 
     @Test
@@ -746,6 +747,7 @@ public class VenmoClientUnitTest {
         assertEquals("venmojoe", nonce.getUsername());
 
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_SUCCEEDED, expectedAnalyticsParams, true);
+        verify(analyticsParamRepository).reset();
     }
 
     @Test
@@ -783,6 +785,7 @@ public class VenmoClientUnitTest {
         assertTrue(result instanceof VenmoResult.Failure);
         assertEquals(graphQLError, ((VenmoResult.Failure) result).getError());
         verify(braintreeClient).sendAnalyticsEvent(VenmoAnalytics.TOKENIZE_FAILED, expectedAnalyticsParams, true);
+        verify(analyticsParamRepository).reset();
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Reset AnalyticsParamRepository at the end of the Venmo flow

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

