### PR TITLE
Send `error_desc` as Expected

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -81,6 +81,7 @@ internal class AnalyticsApi(
             .putOpt(FPTI_KEY_BUTTON_TYPE, event.buttonType)
             .putOpt(FPTI_KEY_BUTTON_POSITION, event.buttonOrder)
             .putOpt(FPTI_KEY_PAGE_TYPE, event.pageType)
+            .putOpt(FPTI_KEY_ERROR_DESC, event.errorDescription)
     }
 
     @Throws(JSONException::class)
@@ -133,6 +134,7 @@ internal class AnalyticsApi(
         private const val FPTI_KEY_BUTTON_TYPE = "button_type"
         private const val FPTI_KEY_BUTTON_POSITION = "button_position"
         private const val FPTI_KEY_PAGE_TYPE = "page_type"
+        private const val FPTI_KEY_ERROR_DESC = "error_desc"
 
         private const val FPTI_BATCH_KEY_VENMO_INSTALLED = "venmo_installed"
         private const val FPTI_BATCH_KEY_PAYPAL_INSTALLED = "paypal_installed"

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
@@ -57,7 +57,8 @@ class AnalyticsApiUnitTest {
         buttonOrder = "button-order",
         pageType = "page-type",
         didEnablePayPalAppSwitch = true,
-        didPayPalServerAttemptAppSwitch = true
+        didPayPalServerAttemptAppSwitch = true,
+        errorDescription = "error-description"
     )
 
     @Before
@@ -174,6 +175,7 @@ class AnalyticsApiUnitTest {
                                     "t": ${event.timestamp},
                                     "experiment": "${event.experiment}",
                                     "shopper_session_id": "${event.shopperSessionId}",
+                                    "error_desc": "${event.errorDescription}",
                                     "event_name": "${event.name}",
                                     "button_position": "${event.buttonOrder}"
                                 }
@@ -227,6 +229,7 @@ class AnalyticsApiUnitTest {
                                     "t": ${event.timestamp},
                                     "experiment": "${event.experiment}",
                                     "shopper_session_id": "${event.shopperSessionId}",
+                                    "error_desc": "${event.errorDescription}",
                                     "event_name": "${event.name}",
                                     "button_position": "${event.buttonOrder}"
                                 }


### PR DESCRIPTION
### Summary of changes

 - I noticed in a recent PR we weren't actually setting the FPTI key for `error_desc` but added it to other parts of the flow - this PR adds the tag as expected
 - Verified in FPTI that we now see the error description sent in our logs
 - Added unit test

### Checklist

 - ~[ ] Added a changelog entry~
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 