### PR TITLE
Update release yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       # After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
       - name: Decode Signing Key
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -132,7 +132,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -204,7 +204,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -216,7 +216,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -228,7 +228,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
@@ -270,7 +270,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: ./.github/actions/setup
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
@@ -304,6 +304,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Setup Java 11
+        uses: ./.github/actions/setup
       - name: Set GitHub User
         uses: ./.github/actions/set_github_user
       - name: Update Version
@@ -320,7 +322,7 @@ jobs:
           ./gradlew -PversionParam=${{ github.event.inputs.version }} incrementSNAPSHOTVersion
           ./gradlew incrementVersionCode
           git commit -am 'Prepare for development'
-          git push origin main ${{ github.event.inputs.version }}
+          git push origin ${GITHUB_REF_NAME} ${{ github.event.inputs.version }}
 
   create_github_release:
     needs: [ bump_version ]
@@ -329,6 +331,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Setup Java 11
+        uses: ./.github/actions/setup
       - name: Save changelog entries to a file
         run: |
           sed -e '1,/##/d' -e '/##/,$d' CHANGELOG.md > changelog_entries.md


### PR DESCRIPTION
### Summary of changes

 - When releasing 4.50.0 the release GitHub action worked failed on the last tow steps. It was noticed that these steps weren't explicitly setting the Java version to run on. This PR makes the change.
 - Also, the final step is merging the changes to `main` which IMO should be the branch the release was kicked off of. In case of 4.x, it should be 4.x and not main.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

