### PR TITLE
Move existing logic to ShopperInsightsClientV2

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ButtonOrder.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ButtonOrder.kt
@@ -48,9 +48,5 @@ enum class ButtonOrder(internal val stringValue: String) {
     /**
      * Greater than Eighth place
      */
-    OTHER("other");
-
-    internal fun getStringRepresentation(): String {
-        return stringValue
-    }
+    OTHER("other")
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ButtonType.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ButtonType.kt
@@ -17,9 +17,5 @@ enum class ButtonType(internal val stringValue: String) {
     /**
      * Other button
      */
-    OTHER("Other");
-
-    internal fun getStringRepresentation(): String {
-        return stringValue
-    }
+    OTHER("Other")
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/PageType.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/PageType.kt
@@ -67,9 +67,5 @@ enum class PageType(internal val stringValue: String) {
     /**
      * Some other page
      */
-    OTHER("other");
-
-    internal fun getStringRepresentation(): String {
-        return stringValue
-    }
+    OTHER("other")
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -181,11 +181,11 @@ class ShopperInsightsClient internal constructor(
         presentmentDetails: PresentmentDetails
     ) {
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails.type?.formattedExperiment(),
+            experiment = presentmentDetails.type.formattedExperiment(),
             shopperSessionId = shopperSessionId,
-            buttonType = buttonType.getStringRepresentation(),
-            buttonOrder = presentmentDetails.buttonOrder.getStringRepresentation(),
-            pageType = presentmentDetails.pageType.getStringRepresentation()
+            buttonType = buttonType.stringValue,
+            buttonOrder = presentmentDetails.buttonOrder.stringValue,
+            pageType = presentmentDetails.pageType.stringValue
         )
 
         braintreeClient.sendAnalyticsEvent(BUTTON_PRESENTED, params)
@@ -201,7 +201,7 @@ class ShopperInsightsClient internal constructor(
     ) {
         val params = AnalyticsEventParams(
             shopperSessionId = shopperSessionId,
-            buttonType = buttonType.getStringRepresentation(),
+            buttonType = buttonType.stringValue,
         )
 
         braintreeClient.sendAnalyticsEvent(BUTTON_SELECTED, params)
@@ -221,9 +221,10 @@ class ShopperInsightsClient internal constructor(
         return deviceInspector.isVenmoInstalled(context)
     }
 
-    private val analyticsParams: AnalyticsEventParams get() {
-        return AnalyticsEventParams(shopperSessionId = shopperSessionId)
-    }
+    private val analyticsParams: AnalyticsEventParams
+        get() {
+            return AnalyticsEventParams(shopperSessionId = shopperSessionId)
+        }
 
     companion object {
         // Default values

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -446,11 +446,11 @@ class ShopperInsightsClientUnitTest {
         )
 
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails?.type?.formattedExperiment(),
+            experiment = presentmentDetails.type.formattedExperiment(),
             shopperSessionId = shopperSessionId,
-            buttonType = ButtonType.PAYPAL.getStringRepresentation(),
-            buttonOrder = presentmentDetails?.buttonOrder?.getStringRepresentation(),
-            pageType = presentmentDetails?.pageType?.getStringRepresentation()
+            buttonType = ButtonType.PAYPAL.stringValue,
+            buttonOrder = presentmentDetails.buttonOrder.stringValue,
+            pageType = presentmentDetails.pageType.stringValue
         )
         sut.sendPresentedEvent(
             ButtonType.PAYPAL,
@@ -474,11 +474,11 @@ class ShopperInsightsClientUnitTest {
         )
 
         val params = AnalyticsEventParams(
-            experiment = presentmentDetails?.type?.formattedExperiment(),
+            experiment = presentmentDetails.type.formattedExperiment(),
             shopperSessionId = shopperSessionId,
-            buttonType = ButtonType.VENMO.getStringRepresentation(),
-            buttonOrder = presentmentDetails?.buttonOrder?.getStringRepresentation(),
-            pageType = presentmentDetails?.pageType?.getStringRepresentation()
+            buttonType = ButtonType.VENMO.stringValue,
+            buttonOrder = presentmentDetails.buttonOrder.stringValue,
+            pageType = presentmentDetails.pageType.stringValue
         )
         sut.sendPresentedEvent(
             ButtonType.VENMO,
@@ -497,7 +497,7 @@ class ShopperInsightsClientUnitTest {
     fun `test paypal selected analytics event`() {
         val params = AnalyticsEventParams(
             shopperSessionId = shopperSessionId,
-            buttonType = ButtonType.PAYPAL.getStringRepresentation()
+            buttonType = ButtonType.PAYPAL.stringValue
         )
         sut.sendSelectedEvent(
             ButtonType.PAYPAL
@@ -510,7 +510,7 @@ class ShopperInsightsClientUnitTest {
     fun `test venmo selected analytics event`() {
         val params = AnalyticsEventParams(
             shopperSessionId = shopperSessionId,
-            buttonType = ButtonType.VENMO.getStringRepresentation(),
+            buttonType = ButtonType.VENMO.stringValue,
         )
         sut.sendSelectedEvent(
             ButtonType.VENMO,

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
@@ -1,0 +1,105 @@
+package com.braintreepayments.api.shopperinsights.v2
+
+import android.content.Context
+import com.braintreepayments.api.core.AnalyticsClient
+import com.braintreepayments.api.core.AnalyticsEventParams
+import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.DeviceInspector
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.ButtonOrder
+import com.braintreepayments.api.shopperinsights.ButtonType
+import com.braintreepayments.api.shopperinsights.ExperimentType
+import com.braintreepayments.api.shopperinsights.PageType
+import com.braintreepayments.api.shopperinsights.PresentmentDetails
+import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.BUTTON_PRESENTED
+import com.braintreepayments.api.shopperinsights.ShopperInsightsAnalytics.BUTTON_SELECTED
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalBetaApi::class)
+class ShopperInsightsClientV2UnitTest {
+
+    private val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+    private val deviceInspector = mockk<DeviceInspector>(relaxed = true)
+    private val analyticsClient: AnalyticsClient = mockk(relaxed = true)
+
+    private val context = mockk<Context>(relaxed = true)
+
+    private lateinit var subject: ShopperInsightsClientV2
+
+    private val sessionId = "session_id"
+
+    @Before
+    fun setUp() {
+        subject = ShopperInsightsClientV2(
+            braintreeClient = braintreeClient,
+            deviceInspector = deviceInspector,
+            lazy { analyticsClient }
+        )
+    }
+
+    @Test
+    fun `when sendPresentedEvent is called, BUTTON_PRESENTED event is sent`() {
+        subject.sendPresentedEvent(
+            buttonType = ButtonType.PAYPAL,
+            presentmentDetails = PresentmentDetails(
+                type = ExperimentType.CONTROL,
+                buttonOrder = ButtonOrder.FIRST,
+                pageType = PageType.CHECKOUT
+            ),
+            sessionId = sessionId
+        )
+
+        verify {
+            analyticsClient.sendEvent(
+                BUTTON_PRESENTED,
+                AnalyticsEventParams(
+                    experiment = ExperimentType.CONTROL.formattedExperiment(),
+                    shopperSessionId = sessionId,
+                    buttonType = ButtonType.PAYPAL.stringValue,
+                    buttonOrder = ButtonOrder.FIRST.stringValue,
+                    pageType = PageType.CHECKOUT.stringValue
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `when sendSelectedEvent is called, BUTTON_SELECTED event is sent`() {
+        subject.sendSelectedEvent(ButtonType.VENMO, sessionId)
+
+        verify {
+            analyticsClient.sendEvent(
+                BUTTON_SELECTED,
+                AnalyticsEventParams(
+                    shopperSessionId = sessionId,
+                    buttonType = ButtonType.VENMO.stringValue,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `when isPayPalAppInstalled is called, deviceInspector isPayPalInstalled is invoked`() {
+        val payPalInstalled = true
+        every { deviceInspector.isPayPalInstalled(context) } returns payPalInstalled
+
+        val result = subject.isPayPalAppInstalled(context)
+
+        assertEquals(payPalInstalled, result)
+    }
+
+    @Test
+    fun `when isVenmoAppInstalled is called, deviceInspector isVenmoAppInstalled is invoked`() {
+        val venmoInstalled = true
+        every { deviceInspector.isVenmoInstalled(context) } returns venmoInstalled
+
+        val result = subject.isVenmoAppInstalled(context)
+
+        assertEquals(venmoInstalled, result)
+    }
+}


### PR DESCRIPTION
### Summary of changes

 - Add analytics calls and app installed checks to ShopperInsightsClientV2
 - Clean up a few shopper insights enums

### Checklist

 - [ ] Added a changelog entry
 - [X] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

