### PR TITLE
Updated SSL cert expiration date

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Braintree SDK requires Java 11 and uses Kotlin 1.9.10.
 
 ## 📣 Announcements
 
-**Upgrade your integration to continue accepting Braintree payments** The SSL certificates for the Android SDK are set to expire by March 30, 2025. Upgrade to v4.45.0+ or v5.0.0+ to continue processing payments using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_android/issues/993)
+**Upgrade your integration to continue accepting Braintree payments** The SSL certificates for the Android SDK are set to expire by March 30, 2026. Upgrade to v4.45.0+ or v5.0.0+ to continue processing payments using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_android/issues/993)
 
 ## Adding It To Your Project
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Braintree SDK requires Java 11 and uses Kotlin 1.9.10.
 
 ## 📣 Announcements
 
-**Upgrade your integration to continue accepting Braintree payments** The SSL certificates for the Android SDK are set to expire by June 31, 2025. Upgrade to v4.45.0+ to continue using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_android/issues/993)
+**Upgrade your integration to continue accepting Braintree payments** The SSL certificates for the Android SDK are set to expire by March 30, 2025. Upgrade to v4.45.0+ or v5.0.0+ to continue processing payments using the Braintree SDK. ![Click here for more details](https://github.com/braintree/braintree_android/issues/993)
 
 ## Adding It To Your Project
 


### PR DESCRIPTION
SSL cert expiration date has been extended to March 30, 2026

### Summary of changes

 - Updated README

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@stechiu 