### PR TITLE
Add UpdateCustomerSessionApi

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
@@ -1,0 +1,57 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Builder for creating the JSON request objects for the Shopper Insights v2 APIs.
+ */
+@ExperimentalBetaApi
+class CustomerSessionRequestBuilder {
+
+    internal data class JsonRequestObjects(
+        val customer: JSONObject,
+        val purchaseUnits: JSONArray?,
+    )
+
+    internal fun createRequestObjects(customerSessionRequest: CustomerSessionRequest): JsonRequestObjects {
+        val customer = JSONObject().apply {
+            putOpt(HASHED_EMAIL, customerSessionRequest.hashedEmail)
+            putOpt(HASHED_PHONE_NUMBER, customerSessionRequest.hashedPhoneNumber)
+            putOpt(PAYPAL_APP_INSTALLED, customerSessionRequest.payPalAppInstalled)
+            putOpt(VENMO_APP_INSTALLED, customerSessionRequest.venmoAppInstalled)
+        }
+
+        val purchaseUnits = customerSessionRequest.purchaseUnits
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { purchaseUnits ->
+                JSONArray().apply {
+                    purchaseUnits.forEach { purchaseUnit ->
+                        put(
+                            JSONObject().put(
+                                AMOUNT,
+                                JSONObject().apply {
+                                    put(VALUE, purchaseUnit.amount)
+                                    put(CURRENCY_CODE, purchaseUnit.currencyCode)
+                                }
+                            )
+                        )
+                    }
+                }
+            }
+
+        return JsonRequestObjects(customer, purchaseUnits)
+    }
+
+    private companion object {
+        private const val HASHED_EMAIL = "hashedEmail"
+        private const val HASHED_PHONE_NUMBER = "hashedPhoneNumber"
+        private const val PAYPAL_APP_INSTALLED = "paypalAppInstalled"
+        private const val VENMO_APP_INSTALLED = "venmoAppInstalled"
+        private const val AMOUNT = "amount"
+        private const val VALUE = "value"
+        private const val CURRENCY_CODE = "currencyCode"
+    }
+}

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParser.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParser.kt
@@ -1,0 +1,22 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Parser for Shopper Insights v2 API responses.
+ */
+internal class ShopperInsightsResponseParser {
+
+    @Throws(JSONException::class)
+    fun parseSessionId(responseBody: String, graphQLCall: String): String {
+        val data = JSONObject(responseBody).getJSONObject(DATA)
+        val sessionObject = data.getJSONObject(graphQLCall)
+        return sessionObject.getString(SESSION_ID)
+    }
+
+    companion object {
+        private const val DATA = "data"
+        private const val SESSION_ID = "sessionId"
+    }
+}

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -1,0 +1,81 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * API to update an existing customer session using the `UpdateCustomerSession` GraphQL mutation.
+ */
+@ExperimentalBetaApi
+internal class UpdateCustomerSessionApi(
+    private val braintreeClient: BraintreeClient,
+    private val customerSessionRequestBuilder: CustomerSessionRequestBuilder = CustomerSessionRequestBuilder(),
+    private val responseParser: ShopperInsightsResponseParser = ShopperInsightsResponseParser()
+) {
+
+    sealed class UpdateCustomerSessionResult {
+        data class Success(val sessionId: String) : UpdateCustomerSessionResult()
+        data class Error(val error: Exception) : UpdateCustomerSessionResult()
+    }
+
+    fun execute(
+        customerSessionRequest: CustomerSessionRequest,
+        sessionId: String,
+        callback: (UpdateCustomerSessionResult) -> Unit
+    ) {
+        try {
+            val params = JSONObject()
+            params.put(
+                QUERY, """
+                mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
+                    updateCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                """.trimIndent()
+            )
+
+            params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
+
+            braintreeClient.sendGraphQLPOST(params) { responseBody: String?, httpError: Exception? ->
+                if (responseBody != null) {
+                    val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
+                    callback(UpdateCustomerSessionResult.Success(sessionId))
+                } else if (httpError != null) {
+                    callback(UpdateCustomerSessionResult.Error(httpError))
+                }
+            }
+        } catch (e: JSONException) {
+            callback(UpdateCustomerSessionResult.Error(e))
+        }
+    }
+
+    @Throws(JSONException::class)
+    private fun assembleVariables(
+        sessionId: String,
+        customerSessionRequest: CustomerSessionRequest
+    ): JSONObject {
+        val jsonRequestObjects = customerSessionRequestBuilder.createRequestObjects(customerSessionRequest)
+
+        val input = JSONObject().apply {
+            put(SESSION_ID, sessionId)
+            put(CUSTOMER, jsonRequestObjects.customer)
+            putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+        }
+
+        return JSONObject().put(INPUT, input)
+    }
+
+    companion object {
+        private const val QUERY = "query"
+        private const val VARIABLES = "variables"
+        private const val INPUT = "input"
+        private const val SESSION_ID = "sessionId"
+        private const val CUSTOMER = "customer"
+        private const val PURCHASE_UNITS = "purchaseUnits"
+        private const val UPDATE_CUSTOMER_SESSION = "updateCustomerSession"
+    }
+}

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
@@ -1,7 +1,9 @@
-package com.braintreepayments.api.shopperinsights.v2
+package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
 import io.mockk.every
 import io.mockk.mockk
@@ -9,6 +11,7 @@ import io.mockk.verify
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import org.junit.Before
 import org.junit.Test
 import org.skyscreamer.jsonassert.JSONAssert
 
@@ -22,6 +25,43 @@ class CreateCustomerSessionApiUnitTest {
         venmoAppInstalled = false,
         purchaseUnits = null
     )
+
+    private val customerSessionRequestWithPurchaseUnits = customerSessionRequest.copy(
+        purchaseUnits = listOf(
+            PurchaseUnit(amount = "100.00", currencyCode = "USD"),
+            PurchaseUnit(amount = "200.00", currencyCode = "EUR")
+        )
+    )
+
+    private val expectedJsonRequestObjects = CustomerSessionRequestBuilder.JsonRequestObjects(
+        customer = JSONObject().apply {
+            put("hashedEmail", "hashedEmail")
+            put("hashedPhoneNumber", "hashedPhoneNumber")
+            put("paypalAppInstalled", true)
+            put("venmoAppInstalled", false)
+        },
+        purchaseUnits = JSONArray().apply {
+            put(JSONObject().apply {
+                put("amount", JSONObject().apply {
+                    put("value", "100.00")
+                    put("currencyCode", "USD")
+                })
+            })
+            put(JSONObject().apply {
+                put("amount", JSONObject().apply {
+                    put("value", "200.00")
+                    put("currencyCode", "EUR")
+                })
+            })
+        }
+    )
+
+    lateinit var braintreeClient: BraintreeClient
+
+    @Before
+    fun setup() {
+        braintreeClient = mockk<BraintreeClient>(relaxed = true)
+    }
 
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() {
@@ -40,7 +80,16 @@ class CreateCustomerSessionApiUnitTest {
             .sendGraphQLPOSTSuccessfulResponse(responseBody)
             .build()
 
-        val createCustomerSessionApi = CreateCustomerSessionApi(braintreeClient)
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+        val responseParser = mockk<ShopperInsightsResponseParser> {
+            every { parseSessionId(responseBody, "createCustomerSession") } returns sessionId
+        }
+
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
 
         val callback = mockk<(CreateCustomerSessionApi.CreateCustomerSessionResult) -> Unit>(relaxed = true)
         createCustomerSessionApi.execute(customerSessionRequest, callback)
@@ -56,7 +105,14 @@ class CreateCustomerSessionApiUnitTest {
             .sendGraphQLPOSTErrorResponse(error)
             .build()
 
-        val createCustomerSessionApi = CreateCustomerSessionApi(braintreeClient)
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
 
         val callback = mockk<(CreateCustomerSessionApi.CreateCustomerSessionResult) -> Unit>(relaxed = true)
         createCustomerSessionApi.execute(customerSessionRequest, callback)
@@ -67,11 +123,18 @@ class CreateCustomerSessionApiUnitTest {
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() {
         val exception = JSONException("Test exception")
-        val createCustomerSessionApi = CreateCustomerSessionApi(mockk())
-        val callback = mockk<(CreateCustomerSessionApi.CreateCustomerSessionResult) -> Unit>(relaxed = true)
-        val customerSessionRequest = mockk<CustomerSessionRequest>(relaxed = true)
-        every { customerSessionRequest.hashedEmail } throws exception
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(any()) } throws exception
+        }
+        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
 
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
+
+        val callback = mockk<(CreateCustomerSessionApi.CreateCustomerSessionResult) -> Unit>(relaxed = true)
         createCustomerSessionApi.execute(customerSessionRequest, callback)
 
         verify { callback.invoke(CreateCustomerSessionApi.CreateCustomerSessionResult.Error(exception)) }
@@ -79,15 +142,9 @@ class CreateCustomerSessionApiUnitTest {
 
     @Test
     fun `when execute is called, the correct GraphQL request body is sent`() {
-        val braintreeClient = mockk<BraintreeClient>(relaxed = true)
-        val createCustomerSessionApi = CreateCustomerSessionApi(braintreeClient)
-
-        val customerSessionRequestWithPurchaseUnits = customerSessionRequest.copy(
-            purchaseUnits = listOf(
-                PurchaseUnit(amount = "100.00", currencyCode = "USD"),
-                PurchaseUnit(amount = "200.00", currencyCode = "EUR")
-            )
-        )
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(customerSessionRequestWithPurchaseUnits) } returns expectedJsonRequestObjects
+        }
 
         val expectedRequestBody = JSONObject().apply {
             put(
@@ -129,8 +186,13 @@ class CreateCustomerSessionApiUnitTest {
             )
         }
 
-        val callback = mockk<(CreateCustomerSessionApi.CreateCustomerSessionResult) -> Unit>(relaxed = true)
-        createCustomerSessionApi.execute(customerSessionRequestWithPurchaseUnits, callback)
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        )
+
+        createCustomerSessionApi.execute(customerSessionRequestWithPurchaseUnits, mockk(relaxed = true))
 
         verify {
             braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
@@ -1,0 +1,80 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import kotlin.test.assertNull
+
+@ExperimentalBetaApi
+class CustomerSessionRequestBuilderUnitTest {
+
+    private val requestBuilder = CustomerSessionRequestBuilder()
+
+    @Test
+    fun `createRequestObjects builds correct JSON objects when purchaseUnits are provided`() {
+        val customerSessionRequest = CustomerSessionRequest(
+            hashedEmail = "hashedEmail",
+            hashedPhoneNumber = "hashedPhoneNumber",
+            payPalAppInstalled = true,
+            venmoAppInstalled = false,
+            purchaseUnits = listOf(
+                PurchaseUnit(amount = "100.00", currencyCode = "USD"),
+                PurchaseUnit(amount = "200.00", currencyCode = "EUR")
+            )
+        )
+
+        val result = requestBuilder.createRequestObjects(customerSessionRequest)
+
+        val expectedCustomer = JSONObject().apply {
+            put("hashedEmail", "hashedEmail")
+            put("hashedPhoneNumber", "hashedPhoneNumber")
+            put("paypalAppInstalled", true)
+            put("venmoAppInstalled", false)
+        }
+
+        val expectedPurchaseUnits = JSONArray().apply {
+            put(JSONObject().apply {
+                put("amount", JSONObject().apply {
+                    put("value", "100.00")
+                    put("currencyCode", "USD")
+                })
+            })
+            put(JSONObject().apply {
+                put("amount", JSONObject().apply {
+                    put("value", "200.00")
+                    put("currencyCode", "EUR")
+                })
+            })
+        }
+
+        JSONAssert.assertEquals(expectedCustomer, result.customer, false)
+        JSONAssert.assertEquals(expectedPurchaseUnits, result.purchaseUnits, false)
+    }
+
+    @Test
+    fun `createRequestObjects builds correct JSON objects when purchaseUnits are null`() {
+        val customerSessionRequest = CustomerSessionRequest(
+            hashedEmail = "hashedEmail",
+            hashedPhoneNumber = "hashedPhoneNumber",
+            payPalAppInstalled = true,
+            venmoAppInstalled = false,
+            purchaseUnits = null
+        )
+
+        val result = requestBuilder.createRequestObjects(customerSessionRequest)
+
+        val expectedCustomer = JSONObject().apply {
+            put("hashedEmail", "hashedEmail")
+            put("hashedPhoneNumber", "hashedPhoneNumber")
+            put("paypalAppInstalled", true)
+            put("venmoAppInstalled", false)
+        }
+
+        JSONAssert.assertEquals(expectedCustomer, result.customer, false)
+        assertNull(result.purchaseUnits)
+    }
+}

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParserUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParserUnitTest.kt
@@ -1,0 +1,64 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import org.json.JSONException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ShopperInsightsResponseParserUnitTest {
+
+    private val responseParser = ShopperInsightsResponseParser()
+
+    @Test
+    fun `parseSessionId returns sessionId when response is valid`() {
+        val responseBody = """
+            {
+                "data": {
+                    "createCustomerSession": {
+                        "sessionId": "test-session-id"
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val sessionId = responseParser.parseSessionId(responseBody, "createCustomerSession")
+        assertEquals("test-session-id", sessionId)
+    }
+
+    @Test
+    fun `parseSessionId throws JSONException when response is missing sessionId`() {
+        val responseBody = """
+            {
+                "data": {
+                    "createCustomerSession": {}
+                }
+            }
+        """.trimIndent()
+
+        assertThrows(JSONException::class.java) {
+            responseParser.parseSessionId(responseBody, "createCustomerSession")
+        }
+    }
+
+    @Test
+    fun `parseSessionId throws JSONException when response is missing data`() {
+        val responseBody = """
+            {
+                "invalidKey": {}
+            }
+        """.trimIndent()
+
+        assertThrows(JSONException::class.java) {
+            responseParser.parseSessionId(responseBody, "createCustomerSession")
+        }
+    }
+
+    @Test
+    fun `parseSessionId throws JSONException when response is malformed`() {
+        val responseBody = "invalid-json"
+
+        assertThrows(JSONException::class.java) {
+            responseParser.parseSessionId(responseBody, "createCustomerSession")
+        }
+    }
+}

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
@@ -1,0 +1,182 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
+import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Test
+import org.skyscreamer.jsonassert.JSONAssert
+
+@OptIn(ExperimentalBetaApi::class)
+class UpdateCustomerSessionApiUnitTest {
+
+    private val customerSessionRequest = CustomerSessionRequest(
+        hashedEmail = "hashedEmail",
+        hashedPhoneNumber = "hashedPhoneNumber",
+        payPalAppInstalled = true,
+        venmoAppInstalled = false,
+        purchaseUnits = null
+    )
+
+    private val expectedJsonRequestObjects = CustomerSessionRequestBuilder.JsonRequestObjects(
+        customer = JSONObject().apply {
+            put("hashedEmail", "hashedEmail")
+            put("hashedPhoneNumber", "hashedPhoneNumber")
+            put("paypalAppInstalled", true)
+            put("venmoAppInstalled", false)
+        },
+        purchaseUnits = JSONArray().apply {
+            put(JSONObject().apply {
+                put("amount", JSONObject().apply {
+                    put("value", "100.00")
+                    put("currencyCode", "USD")
+                })
+            })
+        }
+    )
+
+    private val sessionId = "updated-session-id"
+
+    @Test
+    fun `when execute is called and a responseBody is returned, callback with Success is invoked`() {
+        val responseBody = """
+            {
+                "data": {
+                    "updateCustomerSession": {
+                        "sessionId": "$sessionId"
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPOSTSuccessfulResponse(responseBody)
+            .build()
+
+        val responseParser = mockk<ShopperInsightsResponseParser> {
+            every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+        }
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
+            responseParser = responseParser
+        )
+
+        val callback = mockk<(UpdateCustomerSessionApi.UpdateCustomerSessionResult) -> Unit>(relaxed = true)
+        updateCustomerSessionApi.execute(customerSessionRequest, sessionId, callback)
+
+        verify { callback.invoke(UpdateCustomerSessionApi.UpdateCustomerSessionResult.Success(sessionId)) }
+    }
+
+    @Test
+    fun `when execute is called and an error is returned, callback with Error is invoked`() {
+        val error = Exception("Network error")
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPOSTErrorResponse(error)
+            .build()
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
+            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        )
+
+        val callback = mockk<(UpdateCustomerSessionApi.UpdateCustomerSessionResult) -> Unit>(relaxed = true)
+        updateCustomerSessionApi.execute(customerSessionRequest, sessionId, callback)
+
+        verify { callback.invoke(UpdateCustomerSessionApi.UpdateCustomerSessionResult.Error(error)) }
+    }
+
+    @Test
+    fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() {
+        val exception = JSONException("Test exception")
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(any()) } throws exception
+        }
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = mockk<BraintreeClient>(relaxed = true),
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        )
+
+        val callback = mockk<(UpdateCustomerSessionApi.UpdateCustomerSessionResult) -> Unit>(relaxed = true)
+        updateCustomerSessionApi.execute(customerSessionRequest, sessionId, callback)
+
+        verify { callback.invoke(UpdateCustomerSessionApi.UpdateCustomerSessionResult.Error(exception)) }
+    }
+
+    @Test
+    fun `when execute is called, the correct GraphQL request body is sent`() {
+        val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+
+        val customerSessionRequestWithPurchaseUnits = customerSessionRequest.copy(
+            purchaseUnits = listOf(
+                PurchaseUnit(amount = "100.00", currencyCode = "USD")
+            )
+        )
+
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(customerSessionRequestWithPurchaseUnits) } returns expectedJsonRequestObjects
+        }
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        )
+
+        val expectedRequestBody = JSONObject().apply {
+            put(
+                "query",
+                """
+                mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
+                    updateCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                """.trimIndent()
+            )
+            put(
+                "variables",
+                JSONObject().apply {
+                    put("input", JSONObject().apply {
+                        put("customer", JSONObject().apply {
+                            put("hashedEmail", "hashedEmail")
+                            put("hashedPhoneNumber", "hashedPhoneNumber")
+                            put("paypalAppInstalled", true)
+                            put("venmoAppInstalled", false)
+                        })
+                        put("purchaseUnits", JSONArray().apply {
+                            put(JSONObject().apply {
+                                put("amount", JSONObject().apply {
+                                    put("value", "100.00")
+                                    put("currencyCode", "USD")
+                                })
+                            })
+                        })
+                        put("sessionId", sessionId)
+                    })
+                }
+            )
+        }
+
+        val callback = mockk<(UpdateCustomerSessionApi.UpdateCustomerSessionResult) -> Unit>(relaxed = true)
+        updateCustomerSessionApi.execute(customerSessionRequestWithPurchaseUnits, sessionId, callback)
+
+        verify {
+            braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+            }, any())
+        }
+    }
+}


### PR DESCRIPTION
extract request and response logic to CustomerSessionRequestBuilder and ShopperInsightsResponseParser

### Summary of changes

 - Add UpdateCustomerSessionApi for updating a customer session via the GraphQL mutation
 - Extract request json building to CustomerSessionRequestBuilder
 - Extract response parsing to ShopperInsightsResponseParser
 - Move API related classes to an `internal` package

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

