### PR TITLE
Add CustomerRecommendationsResult and PaymentOptions

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerRecommendationsResult.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerRecommendationsResult.kt
@@ -1,0 +1,19 @@
+package com.braintreepayments.api.shopperinsights.v2
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+
+/**
+ * Customer recommendations for what payment options to show.
+ *
+ * @property sessionId The session ID for the customer session.
+ * @property isInPayPalNetwork Whether the customer is in the PayPal network.
+ * @property paymentRecommendations The payment recommendations for the shopper.
+ *
+ * Warning: This feature is in beta. It's public API may change or be removed in future releases.
+ */
+@ExperimentalBetaApi
+data class CustomerRecommendationsResult(
+    val sessionId: String?,
+    val isInPayPalNetwork: Boolean?,
+    val paymentRecommendations: List<PaymentOptions>?
+)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
@@ -10,6 +10,8 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
  * @property payPalAppInstalled If the PayPal app is installed on the device.
  * @property venmoAppInstalled If the Venmo app is installed on the device.
  * @property purchaseUnits List of purchase units containing the amount and currency code.
+ *
+ * Warning: This feature is in beta. It's public API may change or be removed in future releases.
  */
 @ExperimentalBetaApi
 data class CustomerSessionRequest(

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PaymentOptions.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PaymentOptions.kt
@@ -1,0 +1,17 @@
+package com.braintreepayments.api.shopperinsights.v2
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+
+/**
+ * A single payment recommendation
+ *
+ * @property paymentOption The payment option type
+ * @property recommendedPriority The rank of the payment option
+ *
+ * Warning: This feature is in beta. It's public API may change or be removed in future releases.
+ */
+@ExperimentalBetaApi
+data class PaymentOptions(
+    val paymentOption: String,
+    val recommendedPriority: Int
+)


### PR DESCRIPTION
### Summary of changes

 - Add `CustomerRecommendationsResult` and `PaymentOptions`
 - Add warning copy to `CustomerSessionRequest`'s doc string

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

