### PR TITLE
Surround the 3DS success callback when an error exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ThreeDSecure
+    * Fix an issue where the `ThreeDSecureTokenizeCallback` would return a `Failure` and `Success` result (fixes #1321)
+
 ## 5.10.0 (2025-04-29)
 
 * PayPal

--- a/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
+++ b/ThreeDSecure/src/main/java/com/braintreepayments/api/threedsecure/ThreeDSecureClient.kt
@@ -349,10 +349,11 @@ class ThreeDSecureClient internal constructor(
                                     threeDSecureResult.threeDSecureNonce
                                 )
                             )
-                        }
-                        threeDSecureResult.threeDSecureNonce?.let {
-                            braintreeClient.sendAnalyticsEvent(ThreeDSecureAnalytics.JWT_AUTH_SUCCEEDED)
-                            callbackTokenizeSuccess(callback, ThreeDSecureResult.Success(it))
+                        } else {
+                            threeDSecureResult.threeDSecureNonce?.let {
+                                braintreeClient.sendAnalyticsEvent(ThreeDSecureAnalytics.JWT_AUTH_SUCCEEDED)
+                                callbackTokenizeSuccess(callback, ThreeDSecureResult.Success(it))
+                            }
                         }
                     } else if (error != null) {
                         braintreeClient.sendAnalyticsEvent(

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
@@ -754,7 +754,7 @@ class ThreeDSecureClientUnitTest {
         sut.tokenize(paymentAuthResult, threeDSecureTokenizeCallback)
 
         val captorList = mutableListOf<ThreeDSecureResult>()
-        verify { threeDSecureTokenizeCallback.onThreeDSecureResult(capture(captorList)) }
+        verify(exactly = 1) { threeDSecureTokenizeCallback.onThreeDSecureResult(capture(captorList)) }
         val result = captorList.first()
         assertTrue(result is ThreeDSecureResult.Failure)
         assertEquals(result.nonce, paymentAuthResult.threeDSecureParams?.threeDSecureNonce)


### PR DESCRIPTION
### Summary of changes

 - Resolves https://github.com/braintree/braintree_android/issues/1321

There was a missing else block when a 3DS error is returned. The error callback was invoked along with the success callback.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

