### PR TITLE
Add Generate Recommendations Api

### DIFF
--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
@@ -1,0 +1,120 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendationsResult
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * API to return customer recommendations using the `GenerateCustomerRecommendations` GraphQL mutation.
+ */
+@ExperimentalBetaApi
+internal class GenerateCustomerRecommendationsApi(
+    private val braintreeClient: BraintreeClient,
+    private val customerSessionRequestBuilder: CustomerSessionRequestBuilder = CustomerSessionRequestBuilder(),
+) {
+
+    sealed class GenerateCustomerRecommendationsResult {
+        data class Success(
+            val recommendationsResult: CustomerRecommendationsResult
+        ) : GenerateCustomerRecommendationsResult()
+
+        data class Error(val error: Exception) : GenerateCustomerRecommendationsResult()
+    }
+
+    fun execute(
+        customerSessionRequest: CustomerSessionRequest?,
+        sessionId: String?,
+        callback: (GenerateCustomerRecommendationsResult) -> Unit
+    ) {
+        try {
+            val params = JSONObject()
+            params.put(
+                QUERY, """
+                mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                    generateCustomerRecommendations(input: ${'$'}input) {
+                        sessionId
+                        isInPayPalNetwork
+                        paymentRecommendations {
+                            paymentOption
+                            recommendedPriority
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+
+            params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
+
+            braintreeClient.sendGraphQLPOST(params) { responseBody: String?, httpError: Exception? ->
+                if (responseBody != null) {
+                    val recommendationsResult = parseRecommendationsResponse(responseBody)
+                    callback(GenerateCustomerRecommendationsResult.Success(recommendationsResult))
+                } else if (httpError != null) {
+                    callback(GenerateCustomerRecommendationsResult.Error(httpError))
+                }
+            }
+        } catch (e: JSONException) {
+            callback(GenerateCustomerRecommendationsResult.Error(e))
+        }
+    }
+
+    @Throws(JSONException::class)
+    private fun assembleVariables(
+        sessionId: String?,
+        customerSessionRequest: CustomerSessionRequest?
+    ): JSONObject {
+        val input = JSONObject().apply {
+            putOpt(SESSION_ID, sessionId)
+
+            if (customerSessionRequest != null) {
+                val jsonRequestObjects = customerSessionRequestBuilder.createRequestObjects(customerSessionRequest)
+                put(CUSTOMER, jsonRequestObjects.customer)
+                putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+            }
+        }
+
+        return JSONObject().put(INPUT, input)
+    }
+
+    @Throws(JSONException::class)
+    private fun parseRecommendationsResponse(responseBody: String): CustomerRecommendationsResult {
+        val jsonObject = JSONObject(responseBody)
+        val data = jsonObject.getJSONObject("data")
+        val recommendations = data.getJSONObject(GENERATE_CUSTOMER_RECOMMENDATIONS)
+
+        val sessionId = recommendations.getString(SESSION_ID)
+        val isInPayPalNetwork = recommendations.getBoolean("isInPayPalNetwork")
+        val paymentRecommendations = recommendations.getJSONArray("paymentRecommendations")
+
+        val paymentOptions = mutableListOf<PaymentOptions>()
+        for (i in 0 until paymentRecommendations.length()) {
+            val recommendation = paymentRecommendations.getJSONObject(i)
+            paymentOptions.add(
+                PaymentOptions(
+                    paymentOption = recommendation.getString("paymentOption"),
+                    recommendedPriority = recommendation.getInt("recommendedPriority")
+                )
+            )
+        }
+
+        return CustomerRecommendationsResult(
+            sessionId = sessionId,
+            isInPayPalNetwork = isInPayPalNetwork,
+            paymentRecommendations = paymentOptions
+        )
+    }
+
+    companion object {
+        private const val QUERY = "query"
+        private const val VARIABLES = "variables"
+        private const val INPUT = "input"
+        private const val SESSION_ID = "sessionId"
+        private const val CUSTOMER = "customer"
+        private const val PURCHASE_UNITS = "purchaseUnits"
+        private const val GENERATE_CUSTOMER_RECOMMENDATIONS = "generateCustomerRecommendations"
+    }
+}

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -1,0 +1,230 @@
+package com.braintreepayments.api.shopperinsights.v2.internal
+
+import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendationsResult
+import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
+import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
+import com.braintreepayments.api.shopperinsights.v2.internal.CustomerSessionRequestBuilder.JsonRequestObjects
+import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.skyscreamer.jsonassert.JSONAssert
+
+@OptIn(ExperimentalBetaApi::class)
+class GenerateCustomerRecommendationsApiUnitTest {
+
+    private val customerSessionRequest = CustomerSessionRequest(
+        hashedEmail = "hashedEmail",
+        hashedPhoneNumber = "hashedPhoneNumber",
+        payPalAppInstalled = true,
+        venmoAppInstalled = false,
+        purchaseUnits = listOf(
+            PurchaseUnit(
+                amount = "100.00",
+                currencyCode = "USD"
+            ),
+            PurchaseUnit(
+                amount = "200.00",
+                currencyCode = "EUR"
+            )
+        )
+    )
+
+    private val jsonRequestObjects = JsonRequestObjects(
+        customer = JSONObject().apply {
+            put("hashedEmail", "hashedEmail")
+            put("hashedPhoneNumber", "hashedPhoneNumber")
+            put("paypalAppInstalled", true)
+            put("venmoAppInstalled", false)
+        },
+        purchaseUnits = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("amount", JSONObject().apply {
+                        put("value", "100.00")
+                        put("currencyCode", "USD")
+                    })
+                }
+            )
+            put(
+                JSONObject().apply {
+                    put("amount", JSONObject().apply {
+                        put("value", "200.00")
+                        put("currencyCode", "EUR")
+                    })
+                }
+            )
+        }
+    )
+
+    private val expectedRequestBody = JSONObject().apply {
+        put(
+            "query",
+            """
+                mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                    generateCustomerRecommendations(input: ${'$'}input) {
+                        sessionId
+                        isInPayPalNetwork
+                        paymentRecommendations {
+                            paymentOption
+                            recommendedPriority
+                        }
+                    }
+                }
+                """.trimIndent()
+        )
+        put(
+            "variables",
+            JSONObject().apply {
+                put("input", JSONObject().apply {
+                    put("sessionId", "test-session-id")
+                    put("customer", JSONObject().apply {
+                        put("hashedEmail", "hashedEmail")
+                        put("hashedPhoneNumber", "hashedPhoneNumber")
+                        put("paypalAppInstalled", true)
+                        put("venmoAppInstalled", false)
+                    })
+                    put("purchaseUnits", JSONArray().apply {
+                        put(JSONObject().apply {
+                            put("amount", JSONObject().apply {
+                                put("value", "100.00")
+                                put("currencyCode", "USD")
+                            })
+                        })
+                        put(JSONObject().apply {
+                            put("amount", JSONObject().apply {
+                                put("value", "200.00")
+                                put("currencyCode", "EUR")
+                            })
+                        })
+                    })
+                })
+            }
+        )
+    }
+
+    private lateinit var customerSessionRequestBuilder: CustomerSessionRequestBuilder
+    private lateinit var callback: (GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult) -> Unit
+
+    @Before
+    fun setup() {
+        customerSessionRequestBuilder = mockk(relaxed = true)
+        callback = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `when execute is called and a responseBody is returned, callback with Success is invoked`() {
+        val sessionId = "test-session-id"
+        val responseBody = """
+            {
+                "data": {
+                    "generateCustomerRecommendations": {
+                        "sessionId": "$sessionId",
+                        "isInPayPalNetwork": true,
+                        "paymentRecommendations": [
+                            {
+                                "paymentOption": "PAYPAL",
+                                "recommendedPriority": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPOSTSuccessfulResponse(responseBody)
+            .build()
+
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id", callback)
+
+        val expectedResult = CustomerRecommendationsResult(
+            sessionId = sessionId,
+            isInPayPalNetwork = true,
+            paymentRecommendations = listOf(
+                PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
+            )
+        )
+
+        verify {
+            callback.invoke(
+                GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult.Success(expectedResult)
+            )
+        }
+    }
+
+    @Test
+    fun `when execute is called and an error is returned, callback with Error is invoked`() {
+        val error = Exception("Network error")
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPOSTErrorResponse(error)
+            .build()
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id", callback)
+
+        verify {
+            callback.invoke(GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult.Error(error))
+        }
+    }
+
+    @Test
+    fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() {
+        val exception = JSONException("Test exception")
+        val braintreeClient = mockk<BraintreeClient> {
+            every { sendGraphQLPOST(any(), any()) } throws exception
+        }
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id", callback)
+
+        verify {
+            callback.invoke(
+                GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult.Error(exception)
+            )
+        }
+    }
+
+    @Test
+    fun `when execute is called, the correct GraphQL request body is sent`() {
+        val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+
+        every { customerSessionRequestBuilder.createRequestObjects(customerSessionRequest) } returns jsonRequestObjects
+
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+        )
+
+        generateCustomerRecommendationsApi.execute(
+            customerSessionRequest = customerSessionRequest,
+            sessionId = "test-session-id",
+            callback = mockk(relaxed = true)
+        )
+
+        verify {
+            braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+            }, any())
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes

 - Add GenerateRecommendationsApi for the GenerateCustomerRecommendations GraphQL mutation

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

