### PR TITLE
Update paypal messages version in 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ThreeDSecure
     * Fix an issue where the `ThreeDSecureTokenizeCallback` would return a `Failure` and `Success` result (fixes #1321)
+* PayPal Messaging
+    * Bump `paypal-messages` to version `1.0.3`
 
 ## 5.10.0 (2025-04-29)
 

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation libs.androidx.core.ktx
     implementation libs.kotlin.stdlib
     implementation libs.androidx.appcompat
-    implementation('com.paypal.messages:paypal-messages:1.0.1')
+    implementation('com.paypal.messages:paypal-messages:1.0.3')
 
     testImplementation libs.robolectric
     testImplementation libs.json.assert


### PR DESCRIPTION
### Summary of changes

 - upgrade paypal-messages from 1.0.1 to 1.0.3

### Checklist

 - [x] Added a changelog entry
 - [ ] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@saralvasquez 

