### PR TITLE
Update paypal messages version in 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## Unreleased
+* PayPal Messaging
+  * Bump `paypal-messages` to version `1.0.3`
+
 ## 4.50.0 (2025-04-17)
 
 * BraintreeCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree Android SDK Release Notes
 
-## Unreleased
+## unreleased
+
 * PayPal Messaging
   * Bump `paypal-messages` to version `1.0.3`
 

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation deps.coreKtx
     implementation deps.kotlinStdLib
     implementation deps.appCompat
-    implementation('com.paypal.messages:paypal-messages:1.0.1')
+    implementation('com.paypal.messages:paypal-messages:1.0.3')
 
     testImplementation deps.robolectric
     testImplementation deps.jsonAssert


### PR DESCRIPTION
### Summary of changes

 - upgrade paypal-messages from 1.0.1 to 1.0.3

### Checklist

 - [x] Added a changelog entry
 - [ ] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@saralvasquez 

