### PR TITLE
Add postcal code to demo app address

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -51,6 +51,7 @@ public class PayPalRequestFactory {
             postalAddress.setLocality("San Francisco");
             postalAddress.setRegion("CA");
             postalAddress.setCountryCodeAlpha2("US");
+            postalAddress.setPostalCode("94103");
 
             request.setShippingAddressOverride(postalAddress);
         }


### PR DESCRIPTION
### Summary of changes
It seems there is a new validation check for postal code in the address for a vaulted transaction. This PR adds the postal code to the PayPal address used for testing in the demo app

 - added postal code to address in `PayPalRequestFactory`

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

