### PR TITLE
Move app switch analytics to the PayPalLauncher class

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -9,7 +9,7 @@ import org.json.JSONObject
  */
 internal class AnalyticsApi(
     private val httpClient: BraintreeHttpClient = BraintreeHttpClient(),
-    private val deviceInspector: DeviceInspector = DeviceInspector(),
+    private val deviceInspector: DeviceInspector = DeviceInspectorProvider().deviceInspector,
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
 ) {
@@ -89,7 +89,7 @@ internal class AnalyticsApi(
     @Throws(JSONException::class)
     private fun mapDeviceMetadataToFPTIBatchParamsJSON(metadata: DeviceMetadata): JSONObject {
         val isVenmoInstalled = deviceInspector.isVenmoInstalled(merchantRepository.applicationContext)
-        val isPayPalInstalled = deviceInspector.isPayPalInstalled(merchantRepository.applicationContext)
+        val isPayPalInstalled = deviceInspector.isPayPalInstalled()
         return metadata.run {
             JSONObject()
                 .put(FPTI_BATCH_KEY_APP_ID, appId)

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/DeviceInspector.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/DeviceInspector.kt
@@ -14,6 +14,7 @@ import com.braintreepayments.api.sharedutils.SignatureVerifier
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DeviceInspector(
+    private val context: Context,
     private val appHelper: AppHelper = AppHelper(),
     private val signatureVerifier: SignatureVerifier = SignatureVerifier(),
 ) {
@@ -58,7 +59,7 @@ class DeviceInspector(
         return isVenmoIntentAvailable && isVenmoSignatureValid
     }
 
-    fun isPayPalInstalled(context: Context?): Boolean {
+    fun isPayPalInstalled(): Boolean {
         return appHelper.isAppInstalled(context, PAYPAL_APP_PACKAGE)
     }
 
@@ -135,6 +136,7 @@ class DeviceInspector(
                     "$VENMO_APP_PACKAGE.$VENMO_APP_SWITCH_ACTIVITY"
                 )
             )
+
         internal fun getDropInVersion(): String? {
             try {
                 val dropInBuildConfigClass = Class.forName("com.braintreepayments.api.dropin.BuildConfig")

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/GetAppSwitchUseCase.kt
@@ -1,5 +1,8 @@
 package com.braintreepayments.api.core
 
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GetAppSwitchUseCase(private val appSwitchRepository: AppSwitchRepository) {
     operator fun invoke(): Boolean {
         return appSwitchRepository.isAppSwitchFlow

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/SdkComponent.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.core
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 
 /**
  * Component class that is created when the BT SDK is launched. It contains dependencies that need to be injected that
@@ -10,6 +11,7 @@ internal class SdkComponent(
     applicationContext: Context,
 ) {
     val configurationCache: ConfigurationCache = ConfigurationCache.getInstance(applicationContext)
+    val deviceInspector: DeviceInspector = DeviceInspector(applicationContext)
 
     companion object {
         private var instance: SdkComponent? = null
@@ -35,4 +37,10 @@ internal class SdkComponent(
 internal class ConfigurationCacheProvider {
     val configurationCache: ConfigurationCache
         get() = SdkComponent.getInstance().configurationCache
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DeviceInspectorProvider {
+    val deviceInspector: DeviceInspector
+        get() = SdkComponent.getInstance().deviceInspector
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/SetAppSwitchUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/SetAppSwitchUseCase.kt
@@ -1,8 +1,30 @@
 package com.braintreepayments.api.core
 
-class SetAppSwitchUseCase(private val appSwitchRepository: AppSwitchRepository) {
+import androidx.annotation.RestrictTo
 
-    operator fun invoke(appSwitchFlow: Boolean) {
-        appSwitchRepository.isAppSwitchFlow = appSwitchFlow
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class SetAppSwitchUseCase(
+    private val appSwitchRepository: AppSwitchRepository,
+    private val deviceInspector: DeviceInspector = DeviceInspectorProvider().deviceInspector
+) {
+
+    /**
+     * Sets the status of the app switch flow. This should be called once the PayPal response is received. Since it is
+     * the final check to see if the app switch flow should be shown.
+     *
+     * App Switch Logic:
+     * 1. Merchant enabled app switch
+     * 2. PayPal app installed
+     * 3. PayPal response indicates an app switch flow
+     *
+     * @param appSwitchFlowFromPayPalResponse whether the PayPal response indicates an app switch flow.
+     */
+    operator fun invoke(
+        merchantEnabledAppSwitch: Boolean,
+        appSwitchFlowFromPayPalResponse: Boolean
+    ) {
+        appSwitchRepository.isAppSwitchFlow = merchantEnabledAppSwitch &&
+            deviceInspector.isPayPalInstalled() &&
+            appSwitchFlowFromPayPalResponse
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
@@ -72,7 +72,7 @@ class AnalyticsApiUnitTest {
             )
         } returns deviceMetadata
         every { deviceInspector.isVenmoInstalled(merchantRepository.applicationContext) } returns false
-        every { deviceInspector.isPayPalInstalled(merchantRepository.applicationContext) } returns false
+        every { deviceInspector.isPayPalInstalled() } returns false
         every { merchantRepository.integrationType } returns integrationType
 
         sut = AnalyticsApi(

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
@@ -10,12 +10,18 @@ import android.content.res.Resources
 import android.net.ConnectivityManager
 import android.os.Build
 import android.os.Build.VERSION
-import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.sharedutils.AppHelper
 import com.braintreepayments.api.sharedutils.SignatureVerifier
-import io.mockk.*
+import com.braintreepayments.api.testutils.Fixtures
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
 import org.json.JSONException
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,8 +53,9 @@ class DeviceInspectorUnitTest {
         every { resources.configuration } returns configuration
 
         sut = DeviceInspector(
-            appHelper,
-            signatureVerifier,
+            context = context,
+            appHelper = appHelper,
+            signatureVerifier = signatureVerifier,
         )
     }
 
@@ -363,7 +370,7 @@ class DeviceInspectorUnitTest {
     @Test
     fun isPayPalInstalled_forwardsIsPayPalInstalledResultFromAppHelper() {
         every { appHelper.isAppInstalled(context, "com.paypal.android.p2pmobile") } returns true
-        assertTrue(sut.isPayPalInstalled(context))
+        assertTrue(sut.isPayPalInstalled())
     }
 
     @Test

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/SetAppSwitchUseCaseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/SetAppSwitchUseCaseUnitTest.kt
@@ -1,0 +1,74 @@
+package com.braintreepayments.api.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.confirmVerified
+import org.junit.Before
+import org.junit.Test
+
+class SetAppSwitchUseCaseUnitTest {
+
+    private lateinit var appSwitchRepository: AppSwitchRepository
+    private lateinit var deviceInspector: DeviceInspector
+    private lateinit var setAppSwitchUseCase: SetAppSwitchUseCase
+
+    @Before
+    fun setUp() {
+        appSwitchRepository = mockk(relaxed = true)
+        deviceInspector = mockk()
+        setAppSwitchUseCase = SetAppSwitchUseCase(appSwitchRepository, deviceInspector)
+    }
+
+    @Test
+    fun `invoke sets isAppSwitchFlow true when all conditions are true`() {
+        every { deviceInspector.isPayPalInstalled() } returns true
+
+        setAppSwitchUseCase.invoke(
+            merchantEnabledAppSwitch = true,
+            appSwitchFlowFromPayPalResponse = true
+        )
+
+        verify { appSwitchRepository.isAppSwitchFlow = true }
+        confirmVerified(appSwitchRepository)
+    }
+
+    @Test
+    fun `invoke sets isAppSwitchFlow false when merchantEnabledAppSwitch is false`() {
+        every { deviceInspector.isPayPalInstalled() } returns true
+
+        setAppSwitchUseCase.invoke(
+            merchantEnabledAppSwitch = false,
+            appSwitchFlowFromPayPalResponse = true
+        )
+
+        verify { appSwitchRepository.isAppSwitchFlow = false }
+        confirmVerified(appSwitchRepository)
+    }
+
+    @Test
+    fun `invoke sets isAppSwitchFlow false when PayPal is not installed`() {
+        every { deviceInspector.isPayPalInstalled() } returns false
+
+        setAppSwitchUseCase.invoke(
+            merchantEnabledAppSwitch = true,
+            appSwitchFlowFromPayPalResponse = true
+        )
+
+        verify { appSwitchRepository.isAppSwitchFlow = false }
+        confirmVerified(appSwitchRepository)
+    }
+
+    @Test
+    fun `invoke sets isAppSwitchFlow false when appSwitchFlowFromPayPalResponse is false`() {
+        every { deviceInspector.isPayPalInstalled() } returns true
+
+        setAppSwitchUseCase.invoke(
+            merchantEnabledAppSwitch = true,
+            appSwitchFlowFromPayPalResponse = false
+        )
+
+        verify { appSwitchRepository.isAppSwitchFlow = false }
+        confirmVerified(appSwitchRepository)
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -9,6 +9,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.DeviceInspector
+import com.braintreepayments.api.core.DeviceInspectorProvider
 import com.braintreepayments.api.core.GetReturnLinkUseCase
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.SetAppSwitchUseCase
@@ -21,7 +22,7 @@ internal class PayPalInternalClient(
     private val braintreeClient: BraintreeClient,
     private val dataCollector: DataCollector = DataCollector(braintreeClient),
     private val apiClient: ApiClient = ApiClient(braintreeClient),
-    private val deviceInspector: DeviceInspector = DeviceInspector(),
+    private val deviceInspector: DeviceInspector = DeviceInspectorProvider().deviceInspector,
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
     private val setAppSwitchUseCase: SetAppSwitchUseCase = SetAppSwitchUseCase(AppSwitchRepository.instance),
@@ -53,7 +54,7 @@ internal class PayPalInternalClient(
                 val url = "/v1/$endpoint"
 
                 if (payPalRequest.enablePayPalAppSwitch) {
-                    payPalRequest.enablePayPalAppSwitch = isPayPalInstalled(context)
+                    payPalRequest.enablePayPalAppSwitch = deviceInspector.isPayPalInstalled()
                 }
 
                 val returnLinkResult = getReturnLinkUseCase()
@@ -132,7 +133,10 @@ internal class PayPalInternalClient(
                 val parsedRedirectUri = Uri.parse(paypalPaymentResource.redirectUrl)
                 analyticsParamRepository.didPayPalServerAttemptAppSwitch = paypalPaymentResource.isAppSwitchFlow
 
-                setAppSwitchUseCase(paypalPaymentResource.isAppSwitchFlow)
+                setAppSwitchUseCase(
+                    merchantEnabledAppSwitch = payPalRequest.enablePayPalAppSwitch,
+                    appSwitchFlowFromPayPalResponse = paypalPaymentResource.isAppSwitchFlow
+                )
                 val paypalContextId = extractPayPalContextId(parsedRedirectUri)
                 payPalSetPaymentTokenUseCase.setPaymentToken(paypalContextId)
                 val clientMetadataId = payPalRequest.riskCorrelationId ?: run {
@@ -159,14 +163,11 @@ internal class PayPalInternalClient(
                     paypalContextId = paypalContextId,
                     successUrl = "$returnLink://onetouch/v1/success"
                 )
-                if (isAppSwitchEnabled(payPalRequest) && isPayPalInstalled(context)) {
+                if (payPalRequest.enablePayPalAppSwitch && deviceInspector.isPayPalInstalled()) {
                     if (!paypalContextId.isNullOrEmpty()) {
-                        paymentAuthRequest.approvalUrl =
-                            createAppSwitchUri(parsedRedirectUri).toString()
+                        paymentAuthRequest.approvalUrl = createAppSwitchUri(parsedRedirectUri).toString()
                     } else {
-                        callback.onResult(
-                            null, BraintreeException("Missing Token for PayPal App Switch.")
-                        )
+                        callback.onResult(null, BraintreeException("Missing Token for PayPal App Switch."))
                     }
                 } else {
                     paymentAuthRequest.approvalUrl = parsedRedirectUri.toString()
@@ -183,12 +184,6 @@ internal class PayPalInternalClient(
             .appendQueryParameter("source", "braintree_sdk")
             .appendQueryParameter("switch_initiated_time", System.currentTimeMillis().toString())
             .build()
-    }
-
-    fun isAppSwitchEnabled(payPalRequest: PayPalRequest) = payPalRequest.enablePayPalAppSwitch
-
-    fun isPayPalInstalled(context: Context): Boolean {
-        return deviceInspector.isPayPalInstalled(context)
     }
 
     private fun extractPayPalContextId(redirectUri: Uri): String? {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -11,7 +11,6 @@ import com.braintreepayments.api.core.BraintreeRequestCodes
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.Configuration.Companion.fromJson
 import com.braintreepayments.api.core.ExperimentalBetaApi
-import com.braintreepayments.api.core.GetAppSwitchUseCase
 import com.braintreepayments.api.core.GetReturnLinkTypeUseCase
 import com.braintreepayments.api.core.GetReturnLinkTypeUseCase.ReturnLinkTypeResult
 import com.braintreepayments.api.core.GetReturnLinkUseCase
@@ -50,7 +49,6 @@ class PayPalClientUnitTest {
     private val getReturnLinkTypeUseCase: GetReturnLinkTypeUseCase =
         mockk<GetReturnLinkTypeUseCase>(relaxed = true)
     private val getReturnLinkUseCase: GetReturnLinkUseCase = mockk(relaxed = true)
-    private val getAppSwitchUseCase: GetAppSwitchUseCase = mockk(relaxed = true)
     private val analyticsParamRepository: AnalyticsParamRepository = mockk(relaxed = true)
 
     @Before
@@ -58,7 +56,6 @@ class PayPalClientUnitTest {
     fun beforeEach() {
         every { merchantRepository.returnUrlScheme } returns "com.braintreepayments.demo"
         every { getReturnLinkUseCase.invoke() } returns AppLink(Uri.parse("www.example.com"))
-        every { getAppSwitchUseCase.invoke() } returns true
         every { getReturnLinkTypeUseCase.invoke() } returns ReturnLinkTypeResult.APP_LINK
     }
 
@@ -510,60 +507,6 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenVaultRequest_sendsAppSwitchStartedEvent() {
-        val payPalVaultRequest = PayPalVaultRequest(true).apply {
-            userAuthenticationEmail = "some@email.com"
-            enablePayPalAppSwitch = true
-            merchantAccountId = "sample-merchant-account-id"
-        }
-
-        val paymentAuthRequest = PayPalPaymentAuthRequestParams(
-            payPalVaultRequest,
-            null,
-            "https://example.com/approval/url",
-            "sample-client-metadata-id",
-            null,
-            "https://example.com/success/url"
-        )
-        val payPalInternalClient =
-            MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest)
-                .build()
-
-        every { payPalInternalClient.isPayPalInstalled(activity) } returns true
-        every { payPalInternalClient.isAppSwitchEnabled(payPalVaultRequest) } returns true
-
-        val braintreeClient =
-            MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
-
-        val sut = testPaypalClient(
-            braintreeClient,
-            payPalInternalClient,
-        )
-        sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback)
-
-        val slot = slot<PayPalPaymentAuthRequest>()
-        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(capture(slot)) }
-
-        val request = slot.captured
-        assertTrue(request is PayPalPaymentAuthRequest.ReadyToLaunch)
-        val paymentAuthRequestCaptured =
-            (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams
-
-        val browserSwitchOptions = paymentAuthRequestCaptured.browserSwitchOptions
-        assertEquals(
-            BraintreeRequestCodes.PAYPAL.code,
-            browserSwitchOptions!!.requestCode
-        )
-        TestCase.assertFalse(browserSwitchOptions.isLaunchAsNewTask)
-
-        val params = AnalyticsEventParams(
-            null,
-            true
-        )
-        verify { braintreeClient.sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_STARTED, params, true) }
-    }
-
-    @Test
     @Throws(JSONException::class)
     fun tokenize_withBillingAgreement_tokenizesResponseOnSuccess() {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
@@ -765,117 +708,6 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenPayPalInternalClientTokenizeResult_sendsAppSwitchSucceededEvents() {
-        val payPalAccountNonce = mockk<PayPalAccountNonce>(relaxed = true)
-        val payPalInternalClient =
-            MockkPayPalInternalClientBuilder().tokenizeSuccess(payPalAccountNonce).build()
-
-        val approvalUrl =
-            "sample-scheme://onetouch/v1/success?" +
-                "PayerID=HERMES-SANDBOX-PAYER-ID" +
-                "&paymentId=HERMES-SANDBOX-PAYMENT-ID" +
-                "&token=EC-HERMES-SANDBOX-EC-TOKEN" +
-                "&switch_initiated_time=17166111926211"
-
-        val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
-
-        every { browserSwitchResult.requestMetadata } returns JSONObject().also {
-            it.put("client-metadata-id", "sample-client-metadata-id")
-            it.put("merchant-account-id", "sample-merchant-account-id")
-            it.put("intent", "authorize").put("approval-url", approvalUrl)
-            it.put("success-url", "https://example.com/success")
-            it.put("payment-type", "single-payment")
-        }
-
-        val uri = Uri.parse(approvalUrl)
-        every { browserSwitchResult.returnUrl } returns uri
-
-        val payPalPaymentAuthResult = PayPalPaymentAuthResult.Success(browserSwitchResult)
-        val braintreeClient = MockkBraintreeClientBuilder().build()
-        val sut = testPaypalClient(
-            braintreeClient,
-            payPalInternalClient,
-        )
-
-        sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback)
-
-        val slot = slot<PayPalResult>()
-        verify { payPalTokenizeCallback.onPayPalResult(capture(slot)) }
-
-        val result = slot.captured
-        assertTrue(result is PayPalResult.Success)
-        assertEquals(payPalAccountNonce, (result as PayPalResult.Success).nonce)
-
-        val params = AnalyticsEventParams("EC-HERMES-SANDBOX-EC-TOKEN")
-        verify {
-            braintreeClient.sendAnalyticsEvent(
-                PayPalAnalytics.TOKENIZATION_SUCCEEDED,
-                params,
-                true
-            )
-        }
-        val appSwitchParams = AnalyticsEventParams(
-            payPalContextId = "EC-HERMES-SANDBOX-EC-TOKEN",
-            isVaultRequest = false,
-            appSwitchUrl = "sample-scheme://onetouch/v1/success?" +
-                "PayerID=HERMES-SANDBOX-PAYER-ID" +
-                "&paymentId=HERMES-SANDBOX-PAYMENT-ID" +
-                "&token=EC-HERMES-SANDBOX-EC-TOKEN" +
-                "&switch_initiated_time=17166111926211"
-        )
-        verify { braintreeClient.sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_SUCCEEDED, appSwitchParams, true) }
-    }
-
-    @Test
-    @Throws(JSONException::class)
-    fun tokenize_whenPayPalNotEnabled_sendsAppSwitchFailedEvents() {
-        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
-        val approvalUrl =
-            "https://some-scheme/onetouch/v1/cancel?switch_initiated_time=17166111926211"
-        val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>()
-
-        every { browserSwitchResult.requestMetadata } returns
-            JSONObject().put("client-metadata-id", "sample-client-metadata-id")
-                .put("merchant-account-id", "sample-merchant-account-id")
-                .put("intent", "authorize").put(
-                    "approval-url",
-                    "https://some-scheme/onetouch/v1/cancel?" +
-                        "token=SOME-BA&switch_initiated_time=17166111926211"
-                )
-                .put("success-url", "https://example.com/cancel")
-                .put("payment-type", "single-payment")
-
-        val uri = Uri.parse(approvalUrl)
-        every { browserSwitchResult.returnUrl } returns uri
-
-        val payPalPaymentAuthResult = PayPalPaymentAuthResult.Success(browserSwitchResult)
-        val braintreeClient = MockkBraintreeClientBuilder().build()
-        val sut = testPaypalClient(
-            braintreeClient,
-            payPalInternalClient,
-        )
-
-        sut.tokenize(payPalPaymentAuthResult, payPalTokenizeCallback)
-
-        val params = AnalyticsEventParams(
-            payPalContextId = "SOME-BA",
-            isVaultRequest = false,
-            errorDescription = PayPalClient.Companion.BROWSER_SWITCH_EXCEPTION_MESSAGE
-        )
-        verify { braintreeClient.sendAnalyticsEvent(PayPalAnalytics.TOKENIZATION_FAILED, params, true) }
-        val appSwitchParams = AnalyticsEventParams(
-            payPalContextId = "SOME-BA",
-            isVaultRequest = false,
-            appSwitchUrl = "https://some-scheme/onetouch/v1/cancel?" +
-                "token=SOME-BA&switch_initiated_time=17166111926211",
-            errorDescription = PayPalClient.Companion.BROWSER_SWITCH_EXCEPTION_MESSAGE
-        )
-        verify { braintreeClient.sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_FAILED, appSwitchParams, true) }
-        verify { analyticsParamRepository.reset() }
-    }
-
-    @Test
-    @Throws(JSONException::class)
     fun tokenize_whenCancelUriReceived_sendsAppSwitchCanceledEvents() {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
@@ -923,7 +755,6 @@ class PayPalClientUnitTest {
         merchantRepository,
         getReturnLinkTypeUseCase,
         getReturnLinkUseCase,
-        getAppSwitchUseCase,
         analyticsParamRepository
     )
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -566,7 +566,7 @@ public class PayPalInternalClientUnitTest {
     }
 
     @Test
-    public void sendRequest_withShippingAddressSpecified_sendsAddressOverrideBasedOnShippingAdressEditability()
+    public void sendRequest_withShippingAddressSpecified_sendsAddressOverrideBasedOnShippingAddressEditability()
         throws JSONException {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
             .configuration(configuration)
@@ -948,9 +948,11 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setUserAuthenticationEmail("example@mail.com");
         payPalRequest.setEnablePayPalAppSwitch(true);
 
-        when(deviceInspector.isPayPalInstalled(context)).thenReturn(true);
+        when(deviceInspector.isPayPalInstalled()).thenReturn(true);
 
         sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+
+        verify(setAppSwitchUseCase).invoke(true,true );
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClient.kt
@@ -6,6 +6,7 @@ import com.braintreepayments.api.core.AnalyticsParamRepository
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.DeviceInspector
+import com.braintreepayments.api.core.DeviceInspectorProvider
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.TokenizationKey
@@ -31,7 +32,7 @@ class ShopperInsightsClient internal constructor(
         EligiblePaymentsApi(braintreeClient, analyticsParamRepository)
     ),
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
-    private val deviceInspector: DeviceInspector = DeviceInspector(),
+    private val deviceInspector: DeviceInspector = DeviceInspectorProvider().deviceInspector,
     private val shopperSessionId: String? = null
 ) {
 
@@ -210,7 +211,7 @@ class ShopperInsightsClient internal constructor(
      * Indicates whether the PayPal App is installed.
      */
     fun isPayPalAppInstalled(context: Context): Boolean {
-        return deviceInspector.isPayPalInstalled(context)
+        return deviceInspector.isPayPalInstalled()
     }
 
     /**
@@ -220,9 +221,10 @@ class ShopperInsightsClient internal constructor(
         return deviceInspector.isVenmoInstalled(context)
     }
 
-    private val analyticsParams: AnalyticsEventParams get() {
-        return AnalyticsEventParams(shopperSessionId = shopperSessionId)
-    }
+    private val analyticsParams: AnalyticsEventParams
+        get() {
+            return AnalyticsEventParams(shopperSessionId = shopperSessionId)
+        }
 
     companion object {
         // Default values

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -421,6 +421,7 @@ class ShopperInsightsClientUnitTest {
             analyticsParamRepository,
             api,
             merchantRepository,
+            deviceInspector
         )
 
         val request = ShopperInsightsRequest("some-email", null)
@@ -521,7 +522,7 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test isPayPalAppInstalled returns true when deviceInspector returns true`() {
-        every { deviceInspector.isPayPalInstalled(context) } returns true
+        every { deviceInspector.isPayPalInstalled() } returns true
         assertTrue { sut.isPayPalAppInstalled(context) }
     }
 
@@ -533,7 +534,7 @@ class ShopperInsightsClientUnitTest {
 
     @Test
     fun `test isPayPalAppInstalled returns false when deviceInspector returns false`() {
-        every { deviceInspector.isPayPalInstalled(context) } returns false
+        every { deviceInspector.isPayPalInstalled() } returns false
         assertFalse { sut.isPayPalAppInstalled(context) }
     }
 


### PR DESCRIPTION
### Summary of changes

 - Move app switch analytics (started and error events) to PayPalLauncher to better reflect the stage the user is in
 - Inject `Context` into `DeviceInspector`
 - Created a `DeviceInspectorProvider` for injecting `DeviceInspector`
 - Update `SetAppSwitchUseCase` logic to store the state of all 3 app switch checks
 - Add Library scope to `GetAppSwitchUseCase` and `SetAppSwitchUseCase`

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

