### PR TITLE
Pass Configuration to `PayPalInternalClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+* PayPal
+  * Reduce configuration calls for PayPal flow
+
 ## 5.11.0 (2025-05-28)
 
 * ThreeDSecure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree Android SDK Release Notes
 
 ## unreleased
+
 * PayPal
   * Reduce configuration calls for PayPal flow
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -117,8 +117,13 @@ class PayPalClient internal constructor(
                     callback,
                     PayPalPaymentAuthRequest.Failure(createPayPalError())
                 )
+            } else if (configuration != null) {
+                sendPayPalRequest(context, payPalRequest, configuration, callback)
             } else {
-                sendPayPalRequest(context, payPalRequest, callback)
+                callbackCreatePaymentAuthFailure(
+                    callback,
+                    PayPalPaymentAuthRequest.Failure(BraintreeException("No configuration or error returned"))
+                )
             }
         }
     }
@@ -127,11 +132,13 @@ class PayPalClient internal constructor(
     private fun sendPayPalRequest(
         context: Context,
         payPalRequest: PayPalRequest,
+        configuration: Configuration,
         callback: PayPalPaymentAuthCallback
     ) {
         internalPayPalClient.sendRequest(
             context,
-            payPalRequest
+            payPalRequest,
+            configuration,
         ) { payPalResponse: PayPalPaymentAuthRequestParams?,
             error: Exception? ->
             if (payPalResponse != null) {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/MockPayPalInternalClientBuilder.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/MockPayPalInternalClientBuilder.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 
 import android.content.Context;
 
+import com.braintreepayments.api.core.Configuration;
+
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -43,7 +45,7 @@ public class MockPayPalInternalClientBuilder {
             @Override
             public Void answer(InvocationOnMock invocation) {
                 PayPalInternalClientCallback callback =
-                        (PayPalInternalClientCallback) invocation.getArguments()[2];
+                        (PayPalInternalClientCallback) invocation.getArguments()[3];
                 if (successResponse != null) {
                     callback.onResult(successResponse, null);
                 } else if (error != null) {
@@ -52,7 +54,7 @@ public class MockPayPalInternalClientBuilder {
                 return null;
             }
         }).when(payPalInternalClient).sendRequest(any(Context.class), any(PayPalRequest.class),
-                any(PayPalInternalClientCallback.class));
+                any(Configuration.class), any(PayPalInternalClientCallback.class));
 
         doAnswer(new Answer<Void>() {
             @Override

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/MockkPayPalInternalClientBuilder.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/MockkPayPalInternalClientBuilder.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.paypal
 
 import android.content.Context
+import com.braintreepayments.api.core.Configuration
 import io.mockk.every
 import io.mockk.mockk
 
@@ -32,10 +33,11 @@ class MockkPayPalInternalClientBuilder {
             payPalInternalClient.sendRequest(
                 any<Context>(),
                 any<PayPalRequest>(),
+                any<Configuration>(),
                 any<PayPalInternalClientCallback>()
             )
         } answers {
-            val callback = invocation.args[2] as PayPalInternalClientCallback
+            val callback = invocation.args[3] as PayPalInternalClientCallback
             if (successResponse != null) {
                 callback.onResult(successResponse, null)
             } else if (error != null) {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -480,6 +480,7 @@ class PayPalClientUnitTest {
             payPalInternalClient.sendRequest(
                 activity,
                 payPalRequest,
+                any<Configuration>(),
                 any<PayPalInternalClientCallback>()
             )
         }
@@ -504,6 +505,7 @@ class PayPalClientUnitTest {
             payPalInternalClient.sendRequest(
                 activity,
                 payPalRequest,
+                any<Configuration>(),
                 any<PayPalInternalClientCallback>()
             )
         }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -135,7 +135,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setShouldOfferCredit(true);
         payPalRequest.setShippingAddressOverride(shippingAddressOverride);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -220,7 +220,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setShouldOfferCredit(true);
         payPalRequest.setShippingAddressOverride(shippingAddressOverride);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -313,7 +313,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setLineItems(Collections.singletonList(item));
         payPalRequest.setShippingAddressOverride(shippingAddressOverride);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -387,7 +387,7 @@ public class PayPalInternalClientUnitTest {
         );
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -428,7 +428,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(false);
         payPalRequest.setDisplayName("");
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -468,7 +468,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setLocaleCode(null);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -508,7 +508,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setMerchantAccountId(null);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -548,7 +548,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setShippingAddressOverride(null);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -591,7 +591,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setShippingAddressEditable(false);
         payPalRequest.setShippingAddressOverride(new PostalAddress());
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -631,7 +631,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
         payPalRequest.setBillingAgreementDescription("");
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -650,8 +650,9 @@ public class PayPalInternalClientUnitTest {
     @Test
     public void sendRequest_withPayPalCheckoutRequest_fallsBackToPayPalConfigurationCurrencyCode()
         throws JSONException {
+        Configuration configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR))
+            .configuration(configuration)
             .build();
 
         when(merchantRepository.getAuthorization()).thenReturn(tokenizationKey);
@@ -670,7 +671,7 @@ public class PayPalInternalClientUnitTest {
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -709,7 +710,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setLineItems(new ArrayList<PayPalLineItem>());
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -752,7 +753,7 @@ public class PayPalInternalClientUnitTest {
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setRiskCorrelationId("risk-correlation-id");
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -788,7 +789,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -824,7 +825,7 @@ public class PayPalInternalClientUnitTest {
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
         payPalRequest.setShouldRequestBillingAgreement(false);
         payPalRequest.setBillingAgreementDescription("Billing agreement description");
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(braintreeClient).sendPOST(
@@ -870,7 +871,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setMerchantAccountId("sample-merchant-account-id");
         payPalRequest.setRiskCorrelationId("sample-client-metadata-id");
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -916,7 +917,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setMerchantAccountId("sample-merchant-account-id");
         payPalRequest.setRiskCorrelationId("sample-client-metadata-id");
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         verify(analyticsParamRepository).setDidPayPalServerAttemptAppSwitch(false);
     }
@@ -950,7 +951,7 @@ public class PayPalInternalClientUnitTest {
 
         when(deviceInspector.isPayPalInstalled(context)).thenReturn(true);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -993,7 +994,7 @@ public class PayPalInternalClientUnitTest {
 
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest(true);
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -1037,7 +1038,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setUserAction(PayPalPaymentUserAction.USER_ACTION_COMMIT);
         payPalRequest.setRiskCorrelationId("sample-client-metadata-id");
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -1079,7 +1080,7 @@ public class PayPalInternalClientUnitTest {
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         verify(payPalInternalClientCallback).onResult(null, httpError);
     }
@@ -1107,38 +1108,10 @@ public class PayPalInternalClientUnitTest {
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         verify(payPalInternalClientCallback).onResult((PayPalPaymentAuthRequestParams) isNull(),
             any(JSONException.class));
-    }
-
-    @Test
-    public void sendRequest_onConfigurationFailure_forwardsError() {
-        Exception configurationError = new Exception("configuration error");
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-            .configurationError(configurationError)
-            .build();
-
-        when(merchantRepository.getAuthorization()).thenReturn(clientToken);
-
-        PayPalInternalClient sut = new PayPalInternalClient(
-            braintreeClient,
-            dataCollector,
-            apiClient,
-            deviceInspector,
-            merchantRepository,
-            getReturnLinkUseCase,
-            setAppSwitchUseCase,
-            analyticsParamRepository,
-            tokenRepository,
-            tokenUseCase
-        );
-
-        PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
-
-        verify(payPalInternalClientCallback).onResult(null, configurationError);
     }
 
     @Test
@@ -1167,7 +1140,7 @@ public class PayPalInternalClientUnitTest {
         );
 
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00", true);
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         verify(payPalInternalClientCallback).onResult(isNull(), eq(exception));
     }
@@ -1287,7 +1260,7 @@ public class PayPalInternalClientUnitTest {
         payPalRequest.setIntent(PayPalPaymentIntent.AUTHORIZE);
         payPalRequest.setMerchantAccountId("sample-merchant-account-id");
 
-        sut.sendRequest(context, payPalRequest, payPalInternalClientCallback);
+        sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
         ArgumentCaptor<DataCollectorInternalRequest> captor = ArgumentCaptor.forClass(
             DataCollectorInternalRequest.class);


### PR DESCRIPTION
### Summary of changes

 - Pass the configuration from the `PayPalClient` to the `PayPalInternalClient` - this reduces 1 configuration fetch on slower networks potential skewing latency data as we would send 3 config analytics events to FPTI. There will be a separate PR to reduce the 2 config calls to 1.
 - Update unit tests

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 