### PR TITLE
update docs on when to use onNewIntent

### DIFF
--- a/v5_MIGRATION_GUIDE.md
+++ b/v5_MIGRATION_GUIDE.md
@@ -158,12 +158,14 @@ class MyActivity : FragmentActivity() {
 +       venmoClient = VenmoClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN")
     }
     
-    // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
+    // See [Android developer docs](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.
+    content.Intent)) on when to use `onNewIntent`. Understand the role of `onNewIntent` for different [launch modes](https://developer.android.com/guide/components/activities/tasks-and-back-stack#ManifestForTasks)
+    (https://developer.android.com/guide/components/activities/tasks-and-back-stack#launch-modes).
     override fun onNewIntent(intent: Intent) {
 +       handleReturnToApp(intent)
     }
     
-    // ALL OTHER ACTIVITY LAUNCH MODES 
+    // Standard activity launch mode
     override fun onResume() {
 +       handleReturnToApp(intent)
     }
@@ -404,12 +406,12 @@ class MyActivity : FragmentActivity() {
 +       payPalLauncher = PayPalLauncher()
     }
     
-    // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
+    // See [Android developer docs](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) on when to use `onNewIntent`. Understand the role of `onNewIntent` for different [launch modes](https://developer.android.com/guide/components/activities/tasks-and-back-stack#ManifestForTasks).
     override fun onNewIntent(intent: Intent) {
 +       handleReturnToApp(intent)
     }
     
-    // ALL OTHER ACTIVITY LAUNCH MODES 
+    // Standard activity launch mode
     override fun onResume() {
 +       handleReturnToApp(intent)
     }
@@ -507,12 +509,12 @@ class MyActivity : FragmentActivity() {
 +       localPaymentLauncher = LocalPaymentLauncher()
     }
 
-    // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
+    // See [Android developer docs](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) on when to use `onNewIntent`. Understand the role of `onNewIntent` for different [launch modes](https://developer.android.com/guide/components/activities/tasks-and-back-stack#ManifestForTasks).
     override fun onNewIntent(intent: Intent) {
 +       handleReturnToApp(intent)
     }
     
-    // ALL OTHER ACTIVITY LAUNCH MODES 
+    // Standard activity launch mode
     override fun onResume() {
 +       handleReturnToApp(intent)
     }
@@ -602,12 +604,12 @@ class MyActivity : FragmentActivity() {
 +       sepaDirectDebitLauncher = SEPADirectDebitLauncher() 
     }
 
-    // ONLY REQUIRED IF YOUR ACTIVITY LAUNCH MODE IS SINGLE_TOP
+    // See [Android developer docs](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) on when to use `onNewIntent`. Understand the role of `onNewIntent` for different [launch modes](https://developer.android.com/guide/components/activities/tasks-and-back-stack#ManifestForTasks).
     override fun onNewIntent(intent: Intent) {
 +       handleReturnToApp(intent)
     }
 
-    // ALL OTHER ACTIVITY LAUNCH MODES 
+    // Standard activity launch mode
     override fun onResume() {
 +       handleReturnToApp(intent)
     }


### PR DESCRIPTION
### Summary of changes

 - Pointing to Android developer docs on when to use `onNewIntent`.
 - The older suggestion of using it _only_ in case of SINGLE_TOP is misleading as there seem to be other cases when `onNewIntent()` is called and needs to be handled appropriately.

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

