### PR TITLE
Bump PayPal Messages SDK to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* PayPal Messaging
+    * Bump `paypal-messages` to version `1.0.4`
+
 ## 5.12.0 (2025-06-16)
 
 * PayPal

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation libs.androidx.core.ktx
     implementation libs.kotlin.stdlib
     implementation libs.androidx.appcompat
-    implementation('com.paypal.messages:paypal-messages:1.0.3')
+    implementation(libs.paypal.messages)
 
     testImplementation libs.robolectric
     testImplementation libs.json.assert

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ coroutines = "1.7.1"
 browserSwitch = "3.0.0"
 cardinal = "2.2.7-7"
 navigationSafeArgsGradlePlugin = "2.5.0"
+paypalMessages = "1.0.4"
 playServices = "19.4.0"
 junit = "4.13.2"
 testParameterInjector = "1.18"
@@ -70,6 +71,7 @@ gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gradle-nexus-staging-plugin = { module = "io.codearte.gradle.nexus:gradle-nexus-staging-plugin", version.ref = "gradleNexusStagingPlugin" }
 browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
 cardinal = { group = "org.jfrog.cardinalcommerce.gradle", name = "cardinalmobilesdk", version.ref = "cardinal" }
+paypal-messages = { module = "com.paypal.messages:paypal-messages", version.ref = "paypalMessages" }
 play-services-wallet = { group = "com.google.android.gms", name = "play-services-wallet", version.ref = "playServices" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
### Summary of changes

 - Bump paypal-messages SDK to 1.0.4

### Checklist

 - [X] Added a changelog entry
 - [ ] Relevant test coverage
 - [X] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

