### PR TITLE
Fix Crash RBA Demo App

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -173,12 +173,8 @@ public class PayPalRequestFactory {
 
             request.setShouldRequestBillingAgreement(true);
 
-            String taxTotal = "0.50";
-            String shippingTotal = "0.50";
-            String itemTotal = "9.99";
-
             List<PayPalLineItem> lineItems = buildLineItems(
-                    Float.parseFloat(itemTotal),
+                    9.99f,
                     5.00f,
                     3.00f
             );
@@ -186,9 +182,9 @@ public class PayPalRequestFactory {
             request.setLineItems(lineItems);
 
             AmountBreakdown breakdown = new AmountBreakdown(
-                    itemTotal,
-                    taxTotal,
-                    shippingTotal,
+                    "9.99",
+                    "0.50",
+                    "0.50",
                     null,
                     null,
                     null,
@@ -197,7 +193,8 @@ public class PayPalRequestFactory {
 
             request.setAmountBreakdown(breakdown);
 
-            setRecurringBilling(request, String.format("%.2f", itemTotal));
+            setRecurringBilling(request, "9.99");
+            request.setMerchantAccountId("quantumleapsandboxtesting-1");
         }
 
         if (buyerEmailAddress != null && !buyerEmailAddress.isEmpty()) {


### PR DESCRIPTION
### Summary of changes

 - The demo app was not showing RBA metadata in sandbox and crashing with `java.util.IllegalFormatConversionException: f != java.lang.String`
 - Update the demo app so it runs as expected and does not crash with this toggle enabled.

### Checklist

 - ~[ ] Added a changelog entry~
 - ~[ ] Relevant test coverage~
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 