### PR TITLE
Analytic Events - app switch logic and events for non app switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * PayPal
   * Fix an issue where multiple Chrome Custom Tabs can be opened
   * Fix an issue where the incorrect paypalContextId was being sent in analytics events
+  * Add `paypal:tokenize:browser-presentation:started` event for when the CCT is launched
+  * Only send `paypal:tokenize:browser-login:canceled` for non app switch flows
+  * Fix an issue where non app switch flows were sending app switch events
 * LocalPayment
   * Fix an issue where multiple Chrome Custom Tabs can be opened
 * BraintreeCore

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -6,6 +6,8 @@ internal object PayPalAnalytics {
     const val TOKENIZATION_STARTED = "paypal:tokenize:started"
     const val TOKENIZATION_FAILED = "paypal:tokenize:failed"
     const val TOKENIZATION_SUCCEEDED = "paypal:tokenize:succeeded"
+
+    const val BROWSER_PRESENTATION_STARTED = "paypal:tokenize:browser-presentation:started"
     const val BROWSER_LOGIN_CANCELED = "paypal:tokenize:browser-login:canceled"
     const val BROWSER_PRESENTATION_SUCCEEDED = "paypal:tokenize:browser-presentation:succeeded"
     const val BROWSER_PRESENTATION_FAILED = "paypal:tokenize:browser-presentation:failed"

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -363,10 +363,10 @@ class PayPalClient internal constructor(
         isAppSwitchFlow: Boolean,
         analyticsEventParams: AnalyticsEventParams,
     ) {
-        braintreeClient.sendAnalyticsEvent(PayPalAnalytics.BROWSER_LOGIN_CANCELED, analyticsEventParams)
-
         if (isAppSwitchFlow) {
             braintreeClient.sendAnalyticsEvent(PayPalAnalytics.APP_SWITCH_CANCELED, analyticsEventParams)
+        } else {
+            braintreeClient.sendAnalyticsEvent(PayPalAnalytics.BROWSER_LOGIN_CANCELED, analyticsEventParams)
         }
 
         callback.onPayPalResult(cancel)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -10,6 +10,7 @@ import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.DeviceInspector
 import com.braintreepayments.api.core.DeviceInspectorProvider
+import com.braintreepayments.api.core.GetAppSwitchUseCase
 import com.braintreepayments.api.core.GetReturnLinkUseCase
 import com.braintreepayments.api.core.MerchantRepository
 import com.braintreepayments.api.core.SetAppSwitchUseCase
@@ -26,6 +27,7 @@ internal class PayPalInternalClient(
     private val merchantRepository: MerchantRepository = MerchantRepository.instance,
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
     private val setAppSwitchUseCase: SetAppSwitchUseCase = SetAppSwitchUseCase(AppSwitchRepository.instance),
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(AppSwitchRepository.instance),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
 ) {
 
@@ -154,7 +156,7 @@ internal class PayPalInternalClient(
                     paypalContextId = paypalContextId,
                     successUrl = "$returnLink://onetouch/v1/success"
                 )
-                if (payPalRequest.enablePayPalAppSwitch && deviceInspector.isPayPalInstalled()) {
+                if (getAppSwitchUseCase()) {
                     if (!paypalContextId.isNullOrEmpty()) {
                         paymentAuthRequest.approvalUrl = createAppSwitchUri(parsedRedirectUri).toString()
                     } else {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -59,7 +59,11 @@ class PayPalLauncher internal constructor(
             appSwitchUrl = appSwitchReturnUrl
         )
 
-        analyticsClient.sendEvent(PayPalAnalytics.APP_SWITCH_STARTED, analyticsEventParams)
+        if (isAppSwitch) {
+            analyticsClient.sendEvent(PayPalAnalytics.APP_SWITCH_STARTED, analyticsEventParams)
+        } else {
+            analyticsClient.sendEvent(PayPalAnalytics.BROWSER_PRESENTATION_STARTED, analyticsEventParams)
+        }
 
         try {
             assertCanPerformBrowserSwitch(activity, paymentAuthRequest.requestParams)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.java
@@ -25,6 +25,7 @@ import com.braintreepayments.api.core.BraintreeException;
 import com.braintreepayments.api.core.ClientToken;
 import com.braintreepayments.api.core.Configuration;
 import com.braintreepayments.api.core.DeviceInspector;
+import com.braintreepayments.api.core.GetAppSwitchUseCase;
 import com.braintreepayments.api.core.GetReturnLinkUseCase;
 import com.braintreepayments.api.core.MerchantRepository;
 import com.braintreepayments.api.core.PostalAddress;
@@ -70,9 +71,10 @@ public class PayPalInternalClientUnitTest {
     private GetReturnLinkUseCase getReturnLinkUseCase = mock(GetReturnLinkUseCase.class);
 
     private SetAppSwitchUseCase setAppSwitchUseCase = mock(SetAppSwitchUseCase.class);
+    private GetAppSwitchUseCase getAppSwitchUseCase = mock(GetAppSwitchUseCase.class);
 
     private AnalyticsParamRepository analyticsParamRepository = mock(AnalyticsParamRepository.class);
-    
+
     @Before
     public void beforeEach() throws JSONException {
         context = mock(Context.class);
@@ -108,6 +110,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -191,6 +194,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -269,6 +273,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
         PostalAddress shippingAddressOverride = new PostalAddress();
@@ -373,6 +378,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -411,6 +417,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -449,6 +456,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -487,6 +495,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -525,6 +534,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -564,6 +574,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -604,6 +615,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -643,6 +655,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -679,6 +692,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -719,6 +733,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -754,6 +769,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -787,6 +803,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -830,6 +847,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -874,6 +892,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -895,6 +914,7 @@ public class PayPalInternalClientUnitTest {
 
         when(merchantRepository.getAuthorization()).thenReturn(clientToken);
         when(merchantRepository.getAppLinkReturnUri()).thenReturn(Uri.parse("https://example.com"));
+        when(getAppSwitchUseCase.invoke()).thenReturn(true);
 
         PayPalInternalClient sut = new PayPalInternalClient(
             braintreeClient,
@@ -904,6 +924,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -915,7 +936,7 @@ public class PayPalInternalClientUnitTest {
 
         sut.sendRequest(context, payPalRequest, configuration, payPalInternalClientCallback);
 
-        verify(setAppSwitchUseCase).invoke(true,true );
+        verify(setAppSwitchUseCase).invoke(true, true);
 
         ArgumentCaptor<PayPalPaymentAuthRequestParams> captor = ArgumentCaptor.forClass(
             PayPalPaymentAuthRequestParams.class);
@@ -951,6 +972,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -989,6 +1011,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1034,6 +1057,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1060,6 +1084,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1090,6 +1115,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1113,6 +1139,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1139,6 +1166,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1172,6 +1200,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 
@@ -1199,6 +1228,7 @@ public class PayPalInternalClientUnitTest {
             merchantRepository,
             getReturnLinkUseCase,
             setAppSwitchUseCase,
+            getAppSwitchUseCase,
             analyticsParamRepository
         );
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -130,19 +130,16 @@ class PayPalLauncherUnitTest {
 
         sut.launch(activity, PayPalPaymentAuthRequest.ReadyToLaunch(paymentAuthRequestParams))
 
-        if (isAppSwitch) {
-            // There's no browser switch event equivalent to PayPalAnalytics.APP_SWITCH_STARTED
-            // that's sent on launch()
-            verify {
-                analyticsClient.sendEvent(
-                    PayPalAnalytics.APP_SWITCH_STARTED,
-                    AnalyticsEventParams(
-                        payPalContextId = paymentToken,
-                        appSwitchUrl = returnUrl,
-                    )
+        verify {
+            analyticsClient.sendEvent(
+                if (isAppSwitch) PayPalAnalytics.APP_SWITCH_STARTED else PayPalAnalytics.BROWSER_PRESENTATION_STARTED,
+                AnalyticsEventParams(
+                    payPalContextId = paymentToken,
+                    appSwitchUrl = returnUrl,
                 )
-            }
+            )
         }
+
         verify {
             analyticsClient.sendEvent(
                 if (isAppSwitch) {


### PR DESCRIPTION
### Summary of changes

 - Add `paypal:tokenize:browser-presentation:started` event when opening the CCT (non app switch flows)
 - Only send `paypal:tokenize:browser-login:canceled` for non app switch flows
 - Fix an issue where non app switch flows were sending app switch events

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

