### PR TITLE
send button presented event

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
@@ -144,7 +144,6 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
             Text(if (recommendations.isNotEmpty()) "Recommendations = $recommendations" else "")
             val isInPayPalNetwork = viewModel.isInPayPalNetwork.collectAsState().value
             if (isInPayPalNetwork && recommendations.first().paymentOption == "PAYPAL") {
-                viewModel.sendButtonPresentedEvent(ButtonType.PAYPAL, sessionId)
                 Button(
                     enabled = true,
                     onClick = { launchPayPalVault(emailText, countryCodeText, nationalNumberText, sessionId) }
@@ -153,7 +152,6 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 }
             }
             if (isInPayPalNetwork && recommendations.first().paymentOption == "VENMO") {
-                viewModel.sendButtonPresentedEvent(ButtonType.VENMO, sessionId)
                 Button(
                     enabled = true,
                     onClick = { launchVenmo(emailText, countryCodeText, nationalNumberText, sessionId) }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
@@ -74,6 +74,17 @@ class ShopperInsightsV2ViewModel : ViewModel() {
                     result.customerRecommendations.paymentRecommendations?.let { recommendations ->
                         this@ShopperInsightsV2ViewModel.recommendations.update { recommendations }
                     }
+                    if (isInPayPalNetwork.value == true) {
+                        val paymentOption = this@ShopperInsightsV2ViewModel.recommendations.value.first().paymentOption
+                        val buttonType = if (paymentOption == "PAYPAL") {
+                            ButtonType.PAYPAL
+                        } else if (paymentOption == "VENMO") {
+                            ButtonType.VENMO
+                        } else {
+                            ButtonType.OTHER
+                        }
+                        sendButtonPresentedEvent(buttonType, sessionId)
+                    }
                 }
                 is CustomerRecommendationsResult.Failure -> {
                     this@ShopperInsightsV2ViewModel.error.update { "GetRecommendations failed: ${result.error}" }


### PR DESCRIPTION
### Summary of changes

 - Move some logic into ViewModel
 - Send `shopperInsightsClient.sendPresentedEvent()` analytics event in the demo

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

