### PR TITLE
Downgrade gradle from 8.7.3 to 8.6.1 to fix :Demo:lintVitalAnalyzeRel…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.7.3"
+gradle = "8.6.1"
 gradleNexusStagingPlugin = "0.21.2"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"


### PR DESCRIPTION
…ease
### Summary of changes

 - Fix failing `.gradlew :Demo:lintVitalAnalyzeRelease`

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

