### PR TITLE
Change var/function declarations in MockkBuilder and its references, to follow naming conventions

### DIFF
--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
@@ -46,7 +46,7 @@ class AmericanExpressClientUnitTest {
 
     @Test
     fun getRewardsBalance_callsListenerWithRewardsBalanceOnSuccess() {
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETSuccessfulResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_SUCCESS).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -71,7 +71,7 @@ class AmericanExpressClientUnitTest {
 
     @Test
     fun getRewardsBalance_callsListenerWithRewardsBalanceWithErrorCode_OnIneligibleCard() {
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETSuccessfulResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_INELIGIBLE_CARD).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -97,7 +97,7 @@ class AmericanExpressClientUnitTest {
 
     @Test
     fun getRewardsBalance_callsListenerWithRewardsBalanceWithErrorCode_OnInsufficientPoints() {
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETSuccessfulResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_INSUFFICIENT_POINTS).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -124,7 +124,7 @@ class AmericanExpressClientUnitTest {
     @Test
     fun getRewardsBalance_callsBackFailure_OnHttpError() {
         val expectedError = Exception("error")
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETErrorResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetErrorResponse(
             expectedError).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -142,7 +142,7 @@ class AmericanExpressClientUnitTest {
 
     @Test
     fun getRewardsBalance_sendsAnalyticsEventOnSuccess() {
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETSuccessfulResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_SUCCESS).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -157,7 +157,7 @@ class AmericanExpressClientUnitTest {
 
     @Test
     fun getRewardsBalance_sendsAnalyticsEventOnFailure() {
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETErrorResponse(
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetErrorResponse(
             AuthorizationException("Bad fingerprint")).build()
 
         val sut = AmericanExpressClient(braintreeClient)
@@ -175,7 +175,7 @@ class AmericanExpressClientUnitTest {
     @Test
     fun getRewardsBalance_sendsAnalyticsEventOnParseError() {
         val notJson = "Big blob that is not a valid JSON object"
-        val braintreeClient = MockkBraintreeClientBuilder().sendGETSuccessfulResponse(notJson).build()
+        val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(notJson).build()
 
         val sut = AmericanExpressClient(braintreeClient)
         sut.getRewardsBalance("fake-nonce", "USD", amexRewardsCallback)

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
@@ -85,7 +85,7 @@ class LocalPaymentApiUnitTest {
     fun createPaymentMethod_onPOSTError_forwardsErrorToCallback() {
         val error = Exception("error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTErrorResponse(error)
+            .sendPostErrorResponse(error)
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)
@@ -101,7 +101,7 @@ class LocalPaymentApiUnitTest {
     @Test
     fun createPaymentMethod_onJSONError_forwardsJSONErrorToCallback() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.ERROR_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.ERROR_RESPONSE)
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)
@@ -121,7 +121,7 @@ class LocalPaymentApiUnitTest {
     @Test
     fun createPaymentMethod_onPOSTSuccess_returnsResultWithOriginalRequestToCallback() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_CREATE_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_CREATE_RESPONSE)
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)
@@ -184,7 +184,7 @@ class LocalPaymentApiUnitTest {
     fun tokenize_onPOSTError_forwardsErrorToCallback() {
         val error = Exception("error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTErrorResponse(error)
+            .sendPostErrorResponse(error)
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)
@@ -201,7 +201,7 @@ class LocalPaymentApiUnitTest {
     @Test
     fun tokenize_onJSONError_forwardsErrorToCallback() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse("not-json")
+            .sendPostSuccessfulResponse("not-json")
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)
@@ -221,7 +221,7 @@ class LocalPaymentApiUnitTest {
     @Test
     fun tokenize_onPOSTSuccess_returnsResultToCallback() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_RESPONSE)
             .build()
 
         val sut = LocalPaymentApi(braintreeClient, analyticsParamRepository, merchantRepository)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
@@ -180,11 +180,11 @@ class PayPalInternalClientUnitTest {
     ): Pair<PayPalInternalClient, BraintreeClient> {
         val braintreeClient = if (error != null) {
             MockkBraintreeClientBuilder()
-                .sendPOSTErrorResponse(error)
+                .sendPostErrorResponse(error)
                 .build()
         } else {
             MockkBraintreeClientBuilder()
-                .sendPOSTSuccessfulResponse(fixture!!)
+                .sendPostSuccessfulResponse(fixture!!)
                 .build()
         }
         every { merchantRepository.authorization } returns clientToken

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockkBraintreeClientBuilder.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/MockkBraintreeClientBuilder.kt
@@ -13,13 +13,13 @@ import io.mockk.mockk
 class MockkBraintreeClientBuilder {
 
     private var sendGraphQLPostSuccess: String? = null
-    private var sendGraphQLPOSTError: Exception? = null
+    private var sendGraphQLPostError: Exception? = null
 
-    private var sendGETSuccess: String? = null
-    private var sendGETError: Exception? = null
+    private var sendGetSuccess: String? = null
+    private var sendGetError: Exception? = null
 
-    private var sendPOSTSuccess: String? = null
-    private var sendPOSTError: Exception? = null
+    private var sendPostSuccess: String? = null
+    private var sendPostError: Exception? = null
 
     private var configurationSuccess: Configuration? = null
     private var configurationException: Exception? = null
@@ -59,33 +59,33 @@ class MockkBraintreeClientBuilder {
         return this
     }
 
-    fun sendGraphQLPOSTSuccessfulResponse(sendGraphQLPostSuccess: String): MockkBraintreeClientBuilder {
+    fun sendGraphQLPostSuccessfulResponse(sendGraphQLPostSuccess: String): MockkBraintreeClientBuilder {
         this.sendGraphQLPostSuccess = sendGraphQLPostSuccess
         return this
     }
 
-    fun sendGraphQLPOSTErrorResponse(sendGraphQLPOSTError: Exception?): MockkBraintreeClientBuilder {
-        this.sendGraphQLPOSTError = sendGraphQLPOSTError
+    fun sendGraphQLPostErrorResponse(sendGraphQLPostError: Exception?): MockkBraintreeClientBuilder {
+        this.sendGraphQLPostError = sendGraphQLPostError
         return this
     }
 
-    fun sendPOSTSuccessfulResponse(sendPostSuccess: String): MockkBraintreeClientBuilder {
-        this.sendPOSTSuccess = sendPostSuccess
+    fun sendPostSuccessfulResponse(sendPostSuccess: String): MockkBraintreeClientBuilder {
+        this.sendPostSuccess = sendPostSuccess
         return this
     }
 
-    fun sendPOSTErrorResponse(sendPOSTError: Exception?): MockkBraintreeClientBuilder {
-        this.sendPOSTError = sendPOSTError
+    fun sendPostErrorResponse(sendPostError: Exception?): MockkBraintreeClientBuilder {
+        this.sendPostError = sendPostError
         return this
     }
 
-    fun sendGETSuccessfulResponse(sendGETSuccess: String): MockkBraintreeClientBuilder {
-        this.sendGETSuccess = sendGETSuccess
+    fun sendGetSuccessfulResponse(sendGetSuccess: String): MockkBraintreeClientBuilder {
+        this.sendGetSuccess = sendGetSuccess
         return this
     }
 
-    fun sendGETErrorResponse(sendGETError: Exception?): MockkBraintreeClientBuilder {
-        this.sendGETError = sendGETError
+    fun sendGetErrorResponse(sendGetError: Exception?): MockkBraintreeClientBuilder {
+        this.sendGetError = sendGetError
         return this
     }
 
@@ -102,7 +102,7 @@ class MockkBraintreeClientBuilder {
         every { braintreeClient.sendGraphQLPOST(any(), any()) } answers { call ->
             val callback = call.invocation.args[1] as HttpResponseCallback
             sendGraphQLPostSuccess?.let { callback.onResult(it, null) }
-                ?: sendGraphQLPOSTError?.let { callback.onResult(null, it) }
+                ?: sendGraphQLPostError?.let { callback.onResult(null, it) }
         }
 
         every { braintreeClient.getReturnUrlScheme() } returns returnUrlScheme
@@ -113,8 +113,8 @@ class MockkBraintreeClientBuilder {
             braintreeClient.sendPOST(any<String>(), any<String>(), responseCallback = any<HttpResponseCallback>())
         } answers { call ->
             val callback = call.invocation.args[2] as HttpResponseCallback
-            sendPOSTSuccess?.let { callback.onResult(it, null) }
-                ?: sendPOSTError?.let { callback.onResult(null, it) }
+            sendPostSuccess?.let { callback.onResult(it, null) }
+                ?: sendPostError?.let { callback.onResult(null, it) }
         }
 
         every {
@@ -126,15 +126,15 @@ class MockkBraintreeClientBuilder {
             )
         } answers { call ->
             val callback = call.invocation.args[3] as HttpResponseCallback
-            sendPOSTSuccess?.let { callback.onResult(it, null) }
-                ?: sendPOSTError?.let { callback.onResult(null, it) }
+            sendPostSuccess?.let { callback.onResult(it, null) }
+                ?: sendPostError?.let { callback.onResult(null, it) }
         }
 
         every { braintreeClient.sendGET(any<String>(), responseCallback = any<HttpResponseCallback>())
         } answers { call ->
             val callback = call.invocation.args[1] as HttpResponseCallback
-            sendGETSuccess?.let { callback.onResult(it, null) }
-                ?: sendGETError?.let { callback.onResult(null, it) }
+            sendGetSuccess?.let { callback.onResult(it, null) }
+                ?: sendGetError?.let { callback.onResult(null, it) }
         }
 
         return braintreeClient

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
@@ -51,7 +51,7 @@ class ThreeDSecureAPIUnitTest {
     @Test
     fun performLookup_onSuccess_callbackThreeDSecureResult() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE)
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -67,7 +67,7 @@ class ThreeDSecureAPIUnitTest {
     @Test
     fun performLookup_onInvalidJSONResponse_callbackJSONException() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse("invalid json")
+            .sendPostSuccessfulResponse("invalid json")
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -84,7 +84,7 @@ class ThreeDSecureAPIUnitTest {
     fun performLookup_onPOSTFailure_callbackHTTPError() {
         val httpError = Exception("http error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTErrorResponse(httpError)
+            .sendPostErrorResponse(httpError)
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -133,7 +133,7 @@ class ThreeDSecureAPIUnitTest {
     @Test
     fun authenticateCardinalJWT_onSuccess_callbackThreeDSecureResult() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -149,7 +149,7 @@ class ThreeDSecureAPIUnitTest {
     @Test
     fun authenticateCardinalJWT_onThreeDSecureError_callbackThreeDSecureResultWithOriginalLookupNonce() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE_WITH_ERROR)
+            .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE_WITH_ERROR)
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -169,7 +169,7 @@ class ThreeDSecureAPIUnitTest {
     @Test
     fun authenticateCardinalJWT_onInvalidJSONResponse_callbackJSONException() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse("not-json")
+            .sendPostSuccessfulResponse("not-json")
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -190,7 +190,7 @@ class ThreeDSecureAPIUnitTest {
     fun authenticateCardinalJWT_onPOSTFailure_callbackHTTPError() {
         val postError = Exception("post-error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTErrorResponse(postError)
+            .sendPostErrorResponse(postError)
             .build()
         val sut = ThreeDSecureAPI(braintreeClient)
 
@@ -211,7 +211,7 @@ class ThreeDSecureAPIUnitTest {
     fun authenticateCardinalJWT_whenCustomerFailsAuthentication_returnsLookupCardNonce() {
         val authResponseJson = Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTSuccessfulResponse(authResponseJson)
+            .sendPostSuccessfulResponse(authResponseJson)
             .build()
 
         val threeDSecureParams = ThreeDSecureParams.fromJson(
@@ -243,7 +243,7 @@ class ThreeDSecureAPIUnitTest {
     fun authenticateCardinalJWT_whenPostError_returnsException() {
         val exception = Exception("Error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendPOSTErrorResponse(exception)
+            .sendPostErrorResponse(exception)
             .build()
 
         val threeDSecureParams = ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
@@ -342,7 +342,7 @@ class ThreeDSecureClientUnitTest {
 
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(threeDSecureEnabledConfig)
-            .sendPOSTSuccessfulResponse(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)
+            .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)
             .build()
 
         val request = ThreeDSecureRequest().apply {

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
@@ -129,7 +129,7 @@ class VenmoApiUnitTest {
     @Test
     fun createPaymentContext_whenGraphQLPostSuccess_includesPaymentContextID_callsBackNull() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
+            .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
             .build()
         val sut = VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository)
 
@@ -147,7 +147,7 @@ class VenmoApiUnitTest {
     @Test
     fun createPaymentContext_whenGraphQLPostSuccess_missingPaymentContextID_callsBackError() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse(
+            .sendGraphQLPostSuccessfulResponse(
                 Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_RESPONSE_WITHOUT_PAYMENT_CONTEXT_ID
             )
             .build()
@@ -173,7 +173,7 @@ class VenmoApiUnitTest {
     fun createPaymentContext_whenGraphQLPostError_forwardsErrorToCallback() {
         val error = Exception("error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTErrorResponse(error)
+            .sendGraphQLPostErrorResponse(error)
             .build()
         val sut = VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository)
 
@@ -259,7 +259,7 @@ class VenmoApiUnitTest {
     fun createNonceFromPaymentContext_whenGraphQLPostSuccess_forwardsNonceToCallback() {
         val graphQLResponse = Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse(graphQLResponse)
+            .sendGraphQLPostSuccessfulResponse(graphQLResponse)
             .build()
 
         val sut = VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository)
@@ -275,7 +275,7 @@ class VenmoApiUnitTest {
     @Test
     fun createNonceFromPaymentContext_whenGraphQLPostResponseMalformed_callsBackError() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse("not-json")
+            .sendGraphQLPostSuccessfulResponse("not-json")
             .build()
 
         val sut = VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository)
@@ -292,7 +292,7 @@ class VenmoApiUnitTest {
     fun createNonceFromPaymentContext_whenGraphQLPostError_forwardsErrorToCallback() {
         val error = Exception("error")
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTErrorResponse(error)
+            .sendGraphQLPostErrorResponse(error)
             .build()
 
         val sut = VenmoApi(braintreeClient, apiClient, analyticsParamRepository, merchantRepository)

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
@@ -630,7 +630,7 @@ class VenmoClientUnitTest {
         val graphQLError = BraintreeException("GraphQL error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
-            .sendGraphQLPOSTErrorResponse(graphQLError)
+            .sendGraphQLPostErrorResponse(graphQLError)
             .build()
 
         venmoApi = MockkVenmoApiBuilder()
@@ -795,7 +795,7 @@ class VenmoClientUnitTest {
         val graphQLError = BraintreeException("GraphQL error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
-            .sendGraphQLPOSTErrorResponse(graphQLError)
+            .sendGraphQLPostErrorResponse(graphQLError)
             .build()
 
         every { browserSwitchResult.returnUrl } returns SUCCESS_URL
@@ -996,7 +996,7 @@ class VenmoClientUnitTest {
     @Test
     fun tokenize_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
+            .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
             .build()
 
         every { browserSwitchResult.returnUrl } returns SUCCESS_URL
@@ -1086,7 +1086,7 @@ class VenmoClientUnitTest {
     @Test
     fun tokenize_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() {
         val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPOSTSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
+            .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
             .build()
 
         every { browserSwitchResult.returnUrl } returns SUCCESS_URL


### PR DESCRIPTION
### Summary of changes

 - Changed `MockkBraintreeClientBuilder` variables and functions to follow naming conventions 
 - Changed function calls in Unit tests to match the changes
### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> @noguier 

