### PR TITLE
Feature: Add Payment ID to PayPal Nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * PayPal
   * Fix an issue where `PayPalRequest` was sending `phone_number` instead of `payer_phone`
   * Add `merchant` and `flow_type` as query parameters to the app switch URL.
+  * Add `paymentId` to `PayPalAccountNonce`
 * GooglePay
     * Add `softwareInfo` details to the `merchantInfo` field in the `loadPaymentData` request.
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAccountNonce.kt
@@ -27,6 +27,7 @@ import org.json.JSONObject
  * @property authenticateUrl The URL used to authenticate the customer during two-factor
  * authentication flows. This property will only be present if two-factor authentication is
  * required.
+ * @property paymentId The payment ID associated with this transaction.
  */
 @Parcelize
 data class PayPalAccountNonce internal constructor(
@@ -42,6 +43,7 @@ data class PayPalAccountNonce internal constructor(
     val payerId: String,
     val creditFinancing: PayPalCreditFinancing?,
     val authenticateUrl: String?,
+    val paymentId: String?
 ) : PaymentMethodNonce(
     string = string,
     isDefault = isDefault,
@@ -69,6 +71,7 @@ data class PayPalAccountNonce internal constructor(
         private const val PHONE_KEY = "phone"
         private const val PAYER_ID_KEY = "payerId"
         private const val CLIENT_METADATA_ID_KEY = "correlationId"
+        private const val PAYMENT_TOKEN_KEY = "paymentToken"
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Throws(JSONException::class)
@@ -101,6 +104,7 @@ data class PayPalAccountNonce internal constructor(
             val details = json.getJSONObject(DETAILS_KEY)
             var email = Json.optString(details, EMAIL_KEY, null)
             val clientMetadataId = Json.optString(details, CLIENT_METADATA_ID_KEY, null)
+            val paymentId = Json.optString(details, PAYMENT_TOKEN_KEY, null)
 
             var payPalCreditFinancing: PayPalCreditFinancing? = null
             var shippingAddress: PostalAddress
@@ -137,7 +141,7 @@ data class PayPalAccountNonce internal constructor(
                 shippingAddress = PostalAddress()
             }
 
-            // shipping address should be overriden when 'PAYMENT_METHOD_DATA_KEY' is present at the top-level;
+            // shipping address should be overridden when 'PAYMENT_METHOD_DATA_KEY' is present at the top-level;
             // this occurs when parsing a GooglePay PayPal Account Nonce
             if (getShippingAddressFromTopLevel) {
                 val shippingAddressJson = json.optJSONObject(SHIPPING_ADDRESS_KEY)
@@ -158,7 +162,8 @@ data class PayPalAccountNonce internal constructor(
                 email = email,
                 payerId = payerId,
                 creditFinancing = payPalCreditFinancing,
-                authenticateUrl = authenticateUrl
+                authenticateUrl = authenticateUrl,
+                paymentId = paymentId
             )
         }
     }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAccountNonceUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAccountNonceUnitTest.kt
@@ -34,6 +34,7 @@ class PayPalAccountNonceUnitTest {
         assertEquals("CA", payPalAccountNonce.billingAddress.region)
         assertEquals("94602", payPalAccountNonce.billingAddress.postalCode)
         assertEquals("US", payPalAccountNonce.billingAddress.countryCodeAlpha2)
+        assertEquals("fake-order-id", payPalAccountNonce.paymentId)
         payPalAccountNonce.creditFinancing?.let {
             assertFalse(it.isCardAmountImmutable)
             assertEquals("USD", it.monthlyPayment?.currency)

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
@@ -1753,6 +1753,7 @@ object Fixtures {
               "securityQuestions": [],
               "details": {
                 "email": "paypalaccount@example.com",
+                "paymentToken": "fake-order-id",
                 "payerInfo": {
                   "accountAddress": {
                     "street1": "123 Fake St.",


### PR DESCRIPTION
### Summary of changes

- Add `paymentId` to `PayPalAccountNonce` - tested and verified we are getting this value as expected in sandbox
- iOS PR: https://github.com/braintree/braintree_ios/pull/1643

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors

@jaxdesmarais 