### PR TITLE
Update HttpClient to call OkHttpSynchronusHttpClient and update BraintreeGraphQLClient andBraintreeHttpClient

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeGraphQLClient.kt
@@ -1,16 +1,13 @@
 package com.braintreepayments.api.core
 
 import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.Method
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
-import com.braintreepayments.api.sharedutils.TLSSocketFactory
+import com.braintreepayments.api.sharedutils.OkHttpRequest
 import java.util.Locale
 
 internal class BraintreeGraphQLClient(
-    private val httpClient: HttpClient = HttpClient(
-        socketFactory = TLSSocketFactory(),
-        httpResponseParser = BraintreeGraphQLResponseParser()
-    )
+    private val httpClient: HttpClient = HttpClient()
 ) {
 
     fun post(
@@ -24,17 +21,17 @@ internal class BraintreeGraphQLClient(
             callback.onResult(null, BraintreeException(message))
             return
         }
-        val request = HttpRequest()
-            .method("POST")
-            .path("")
-            .data(data)
-            .baseUrl(configuration.graphQLUrl)
-            .addHeader("User-Agent", "braintree/android/" + BuildConfig.VERSION_NAME)
-            .addHeader(
-                "Authorization",
-                String.format(Locale.US, "Bearer %s", authorization.bearer)
+
+        val request = OkHttpRequest(
+            method = Method.Post(data),
+            url = configuration.graphQLUrl,
+            headers = mapOf(
+                "User-Agent" to "braintree/android/" + BuildConfig.VERSION_NAME,
+                "Authorization" to String.format(Locale.US, "Bearer %s", authorization.bearer),
+                "Braintree-Version" to GraphQLConstants.Headers.API_VERSION
             )
-            .addHeader("Braintree-Version", GraphQLConstants.Headers.API_VERSION)
+        )
+
         httpClient.sendRequest(request, callback)
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -121,11 +121,9 @@ internal class BraintreeHttpClient(
         val headers = mutableMapOf(
             USER_AGENT_HEADER to "braintree/android/" + BuildConfig.VERSION_NAME
         )
-        if (authorization is TokenizationKey) {
-            headers["Client-Key"] = authorization.bearer
-        }
-        authorization?.bearer?.let { token ->
-            headers["Authorization"] = "Bearer $token"
+        when (authorization) {
+            is TokenizationKey -> headers["Client-Key"] = authorization.bearer
+            is ClientToken -> headers["Authorization"] = "Bearer ${authorization.bearer}"
         }
         headers.putAll(additionalHeaders)
         return headers

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeHttpClient.kt
@@ -1,11 +1,10 @@
 package com.braintreepayments.api.core
 
-import android.net.Uri
+import androidx.core.net.toUri
 import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpClient.RetryStrategy
-import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.Method
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
-import com.braintreepayments.api.sharedutils.TLSSocketFactory
+import com.braintreepayments.api.sharedutils.OkHttpRequest
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -13,84 +12,48 @@ import org.json.JSONObject
  * Network request class that handles Braintree request specifics and threading.
  */
 internal class BraintreeHttpClient(
-    private val httpClient: HttpClient = HttpClient(
-        socketFactory = TLSSocketFactory(),
-        httpResponseParser = BraintreeHttpResponseParser()
-    )
+    private val httpClient: HttpClient = HttpClient()
 ) {
 
     /**
      * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
      * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via GET
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param callback [NetworkResponseCallback]
      */
-    operator fun get(
+    fun get(
         path: String,
         configuration: Configuration?,
         authorization: Authorization?,
-        callback: NetworkResponseCallback
-    ) = get(path, configuration, authorization, RetryStrategy.NO_RETRY, callback)
-
-    /**
-     * Make a HTTP GET request to Braintree using the base url, path and authorization provided.
-     * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via GET
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param retryStrategy retry strategy
-     * @param callback [NetworkResponseCallback]
-     */
-    operator fun get(
-        path: String,
-        configuration: Configuration?,
-        authorization: Authorization?,
-        retryStrategy: RetryStrategy,
         callback: NetworkResponseCallback
     ) {
-        if (authorization is InvalidAuthorization) {
-            val message = authorization.errorMessage
-            callback.onResult(null, BraintreeException(message))
+        if (!validateAuthorization(authorization, callback)) return
+
+        val url = try {
+            val urlWithBase = assembleUrl(path, configuration)
+            if (authorization is ClientToken) {
+                urlWithBase.toUri().buildUpon()
+                    .appendQueryParameter(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)
+                    .toString()
+            } else {
+                urlWithBase
+            }
+        } catch (e: BraintreeException) {
+            callback.onResult(null, e)
             return
         }
-        val isRelativeURL = !path.startsWith("http")
-        if (configuration == null && isRelativeURL) {
-            val message =
-                "Braintree HTTP GET request without configuration cannot have a relative path."
-            val relativeURLNotAllowedError = BraintreeException(message)
-            callback.onResult(null, relativeURLNotAllowedError)
-            return
-        }
-        val targetPath = if (authorization is ClientToken) {
-            Uri.parse(path).buildUpon()
-                .appendQueryParameter(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)
-                .toString()
-        } else {
-            path
-        }
-        val request = HttpRequest().method("GET").path(targetPath)
-            .addHeader(USER_AGENT_HEADER, "braintree/android/" + BuildConfig.VERSION_NAME)
-        if (isRelativeURL && configuration != null) {
-            request.baseUrl(configuration.clientApiUrl)
-        }
-        if (authorization is TokenizationKey) {
-            request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
-        }
-        httpClient.sendRequest(request, callback, retryStrategy)
+
+        val request = OkHttpRequest(
+            method = Method.Get,
+            url = url,
+            headers = assembleHeaders(authorization)
+        )
+
+        httpClient.sendRequest(request, callback)
     }
 
     /**
      * Make a HTTP POST request to Braintree.
      * If the path is a full url, it will be used instead of the previously provided url.
-     * @param path The path or url to request from the server via HTTP POST
-     * @param data The body of the POST request
-     * @param configuration configuration for the Braintree Android SDK.
-     * @param authorization
-     * @param callback [NetworkResponseCallback]
      */
-    @Suppress("CyclomaticComplexMethod")
     fun post(
         path: String,
         data: String,
@@ -99,25 +62,13 @@ internal class BraintreeHttpClient(
         additionalHeaders: Map<String, String> = emptyMap(),
         callback: NetworkResponseCallback?
     ) {
-        if (authorization is InvalidAuthorization) {
-            val message = authorization.errorMessage
-            callback?.onResult(null, BraintreeException(message))
-            return
-        }
-        val isRelativeURL = !path.startsWith("http")
-        if (configuration == null && isRelativeURL) {
-            val message =
-                "Braintree HTTP GET request without configuration cannot have a relative path."
-            val relativeURLNotAllowedError = BraintreeException(message)
-            callback?.onResult(null, relativeURLNotAllowedError)
-            return
-        }
-        val requestData = if (authorization is ClientToken) {
+        if (!validateAuthorization(authorization, callback)) return
+
+        val requestBody = if (authorization is ClientToken) {
             try {
-                JSONObject(data).put(
-                    AUTHORIZATION_FINGERPRINT_KEY,
-                    authorization.authorizationFingerprint
-                ).toString()
+                JSONObject(data)
+                    .put(AUTHORIZATION_FINGERPRINT_KEY, authorization.authorizationFingerprint)
+                    .toString()
             } catch (e: JSONException) {
                 callback?.onResult(null, e)
                 return
@@ -125,22 +76,63 @@ internal class BraintreeHttpClient(
         } else {
             data
         }
-        val request = HttpRequest().method("POST").path(path).data(requestData)
-            .addHeader(USER_AGENT_HEADER, "braintree/android/" + BuildConfig.VERSION_NAME)
-        if (isRelativeURL && configuration != null) {
-            request.baseUrl(configuration.clientApiUrl)
+
+        val url = try {
+            assembleUrl(path, configuration)
+        } catch (e: BraintreeException) {
+            callback?.onResult(null, e)
+            return
         }
-        if (authorization is TokenizationKey) {
-            request.addHeader(CLIENT_KEY_HEADER, authorization.bearer)
-        }
-        authorization?.bearer?.let { token -> request.addHeader("Authorization", "Bearer $token") }
-        additionalHeaders.forEach { (name, value) -> request.addHeader(name, value) }
+
+        val request = OkHttpRequest(
+            method = Method.Post(requestBody),
+            url = url,
+            headers = assembleHeaders(authorization, additionalHeaders)
+        )
+
         httpClient.sendRequest(request, callback)
+    }
+
+    private fun validateAuthorization(
+        authorization: Authorization?,
+        callback: NetworkResponseCallback?
+    ): Boolean {
+        if (authorization is InvalidAuthorization) {
+            callback?.onResult(null, BraintreeException(authorization.errorMessage))
+            return false
+        }
+        return true
+    }
+
+    @Throws(BraintreeException::class)
+    private fun assembleUrl(path: String, configuration: Configuration?): String {
+        return if (path.startsWith("http")) {
+            path
+        } else {
+            configuration?.clientApiUrl?.plus(path)
+                ?: throw BraintreeException("Braintree HTTP request without configuration cannot have a relative path.")
+        }
+    }
+
+    private fun assembleHeaders(
+        authorization: Authorization?,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): Map<String, String> {
+        val headers = mutableMapOf(
+            USER_AGENT_HEADER to "braintree/android/" + BuildConfig.VERSION_NAME
+        )
+        if (authorization is TokenizationKey) {
+            headers["Client-Key"] = authorization.bearer
+        }
+        authorization?.bearer?.let { token ->
+            headers["Authorization"] = "Bearer $token"
+        }
+        headers.putAll(additionalHeaders)
+        return headers
     }
 
     companion object {
         private const val AUTHORIZATION_FINGERPRINT_KEY = "authorizationFingerprint"
         private const val USER_AGENT_HEADER = "User-Agent"
-        private const val CLIENT_KEY_HEADER = "Client-Key"
     }
 }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ConfigurationLoader.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api.core
 
 import android.net.Uri
 import android.util.Base64
-import com.braintreepayments.api.sharedutils.HttpClient
 import org.json.JSONException
 
 internal class ConfigurationLoader(
@@ -41,7 +40,9 @@ internal class ConfigurationLoader(
             callback.onResult(ConfigurationLoaderResult.Success(it))
         } ?: run {
             httpClient.get(
-                configUrl, null, authorization, HttpClient.RetryStrategy.RETRY_MAX_3_TIMES
+                path = configUrl,
+                configuration = null,
+                authorization = authorization,
             ) { response, httpError ->
                 val responseBody = response?.body
                 val timing = response?.timing

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeGraphQLClientUnitTest.kt
@@ -1,75 +1,65 @@
 package com.braintreepayments.api.core
 
-import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.Method
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
+import com.braintreepayments.api.sharedutils.OkHttpRequest
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import org.json.JSONException
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.net.MalformedURLException
-import java.net.URISyntaxException
-import java.net.URL
-import java.nio.charset.StandardCharsets
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class BraintreeGraphQLClientUnitTest {
 
     private lateinit var httpClient: HttpClient
-    private lateinit var httpResponseCallback: NetworkResponseCallback
-    private lateinit var configuration: Configuration
-    private lateinit var authorization: Authorization
+    private lateinit var sut: BraintreeGraphQLClient
+    private lateinit var callback: NetworkResponseCallback
 
     @Before
-    @Throws(JSONException::class)
-    fun beforeEach() {
-        httpClient = mockk()
-        httpResponseCallback = mockk()
-        authorization = Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN)
-        configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
+    fun setUp() {
+        httpClient = mockk(relaxed = true)
+        callback = mockk(relaxed = true)
+        sut = BraintreeGraphQLClient(httpClient)
     }
 
     @Test
-    @Throws(MalformedURLException::class, URISyntaxException::class)
-    fun post_withDataAndConfigurationAndCallback_sendsHttpRequest() {
-        val httpRequestSlot = slot<HttpRequest>()
-        every {
-            httpClient.sendRequest(capture(httpRequestSlot), httpResponseCallback)
-        } returns Unit
-
-        val sut = BraintreeGraphQLClient(httpClient)
-        sut.post("data", configuration, authorization, httpResponseCallback)
-
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://example-graphql.com/graphql"), httpRequest.url)
-        assertEquals("data", String(httpRequest.data ?: ByteArray(0), StandardCharsets.UTF_8))
-        assertEquals("POST", httpRequest.method)
-
-        val headers = httpRequest.headers
-        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
-        assertEquals("Bearer encoded_auth_fingerprint", headers["Authorization"])
-        assertEquals("2024-08-23", headers["Braintree-Version"])
+    fun `when post is called with invalid authorization, callback is called with error`() {
+        val invalidAuth = InvalidAuthorization(
+            rawValue = "bad auth",
+            errorMessage = "bad auth"
+        )
+        val config = mockk<Configuration>(relaxed = true)
+        every { config.graphQLUrl } returns "https://graphql.example.com"
+        sut.post("{}", config, invalidAuth, callback)
+        verify { callback.onResult(null, match { it is BraintreeException && it.message == "bad auth" }) }
+        confirmVerified(callback)
     }
 
     @Test
-    fun post_withDataAndConfigurationAndCallback_withInvalidToken_forwardsExceptionToCallback() {
-        val authorization = InvalidAuthorization("invalid", "token invalid")
+    fun `when post is called with valid authorization, request is sent with correct headers and body`() {
+        val auth = mockk<Authorization>(relaxed = true)
+        every { auth.bearer } returns "token123"
+        val config = mockk<Configuration>(relaxed = true)
+        every { config.graphQLUrl } returns "https://graphql.example.com"
+        val slot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(slot), any()) } answers { }
 
-        val exceptionSlot = slot<BraintreeException>()
-        every {
-            httpResponseCallback.onResult(null, capture(exceptionSlot))
-        } returns Unit
+        sut.post("{\"query\":\"test\"}", config, auth, callback)
 
-        val sut = BraintreeGraphQLClient(httpClient)
-        sut.post("sample/path", configuration, authorization, httpResponseCallback)
-
-        val exception = exceptionSlot.captured
-        assertEquals("token invalid", exception.message)
+        val req = slot.captured
+        assertTrue(req.method is Method.Post)
+        assertEquals("{\"query\":\"test\"}", (req.method as Method.Post).body)
+        assertEquals("https://graphql.example.com", req.url)
+        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, req.headers["User-Agent"])
+        assertEquals("Bearer token123", req.headers["Authorization"])
+        assertEquals(GraphQLConstants.Headers.API_VERSION, req.headers["Braintree-Version"])
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeHttpClientUnitTest.kt
@@ -1,8 +1,9 @@
 package com.braintreepayments.api.core
 
 import com.braintreepayments.api.sharedutils.HttpClient
-import com.braintreepayments.api.sharedutils.HttpRequest
+import com.braintreepayments.api.sharedutils.Method
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
+import com.braintreepayments.api.sharedutils.OkHttpRequest
 import com.braintreepayments.api.testutils.Fixtures
 import com.braintreepayments.api.testutils.FixturesHelper
 import io.mockk.every
@@ -12,364 +13,318 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.json.JSONException
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.net.MalformedURLException
-import java.net.URISyntaxException
-import java.net.URL
-import java.nio.charset.StandardCharsets
-import java.util.Locale
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class BraintreeHttpClientUnitTest {
 
     private lateinit var httpClient: HttpClient
-    private lateinit var httpResponseCallback: NetworkResponseCallback
+    private lateinit var configuration: Configuration
+    private lateinit var callback: NetworkResponseCallback
 
     @Before
     fun beforeEach() {
         httpClient = mockk(relaxed = true)
-        httpResponseCallback = mockk()
+        configuration = mockk()
+        callback = mockk(relaxed = true)
+
+        every { configuration.clientApiUrl } returns "https://api.braintreegateway.com/"
     }
 
-    @Test
-    fun get_withNullConfiguration_requiresRequiresRequestToHaveAnAbsolutePath() {
-        val tokenizationKey = mockk<Authorization>()
-        val callback = mockk<NetworkResponseCallback>()
+    // GET method tests
 
-        val exceptionSlot = slot<BraintreeException>()
-        every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
+    @Test
+    fun `when get is called with TokenizationKey, correct request is sent`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.get("sample/path", null, tokenizationKey, callback)
+        sut.get("v1/payment_methods", configuration, tokenizationKey, callback)
 
-        val exception = exceptionSlot.captured
-        assertEquals(
-            "Braintree HTTP GET request without configuration cannot have a relative path.",
-            exception.message
-        )
+        val request = requestSlot.captured
+        assertEquals("https://api.braintreegateway.com/v1/payment_methods", request.url)
+        assertTrue(request.method is Method.Get)
+        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, request.headers["User-Agent"])
+        assertEquals(Fixtures.TOKENIZATION_KEY, request.headers["Client-Key"])
     }
 
     @Test
-    @Throws(Exception::class)
-    fun get_withNullConfigurationAndAbsoluteURL_doesNotSetABaseURLOnTheRequest() {
-        val tokenizationKey: Authorization = TokenizationKey(Fixtures.TOKENIZATION_KEY)
-        val callback = mockk<NetworkResponseCallback>()
-
-        val httpRequestSlot = slot<HttpRequest>()
-        every {
-            httpClient.sendRequest(capture(httpRequestSlot), callback, HttpClient.RetryStrategy.NO_RETRY)
-        } returns Unit
+    fun `when get is called with ClientToken, authorization fingerprint is appended to URL`() {
+        val clientToken = Authorization.fromString(
+            FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
+        ) as ClientToken
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.get("https://example.com/sample/path", null, tokenizationKey, callback)
+        sut.get("v1/payment_methods", configuration, clientToken, callback)
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
+        val request = requestSlot.captured
+        val expectedUrl =
+            "https://api.braintreegateway.com/v1/payment_methods?authorizationFingerprint=${clientToken.bearer}"
+        assertEquals(expectedUrl, request.url)
+        assertNull(request.headers["Client-Key"])
     }
 
     @Test
-    @Throws(MalformedURLException::class, URISyntaxException::class)
-    fun get_withTokenizationKey_forwardsHttpRequestToHttpClient() {
-        val tokenizationKey: Authorization = TokenizationKey(Fixtures.TOKENIZATION_KEY)
-        val configuration = mockk<Configuration>()
-        every { configuration.clientApiUrl } returns "https://example.com"
-
-        val httpRequestSlot = slot<HttpRequest>()
-        val callback = mockk<NetworkResponseCallback>()
-        every {
-            httpClient.sendRequest(capture(httpRequestSlot), callback, HttpClient.RetryStrategy.NO_RETRY)
-        } returns Unit
+    fun `when get is called with absolute URL, configuration base URL is ignored`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.get("sample/path", configuration, tokenizationKey, callback)
+        sut.get("https://example.com/custom/path", configuration, tokenizationKey, callback)
 
-        val httpRequest = httpRequestSlot.captured
-        val headers = httpRequest.headers
-        assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
-        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
-        assertEquals(Fixtures.TOKENIZATION_KEY, headers["Client-Key"])
-        assertEquals("GET", httpRequest.method)
+        val request = requestSlot.captured
+        assertEquals("https://example.com/custom/path", request.url)
     }
 
     @Test
-    @Throws(MalformedURLException::class, URISyntaxException::class)
-    fun get_withClientToken_forwardsHttpRequestToHttpClient() {
-        val clientToken =
-            Authorization.fromString(FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN))
-        val configuration = mockk<Configuration>()
-        every { configuration.clientApiUrl } returns "https://example.com"
-
-        val httpRequestSlot = slot<HttpRequest>()
-        val callback = mockk<NetworkResponseCallback>()
-        every {
-            httpClient.sendRequest(capture(httpRequestSlot), callback, HttpClient.RetryStrategy.NO_RETRY)
-        } returns Unit
+    fun `when get is called with null configuration and relative path, BraintreeException is thrown`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val errorSlot = slot<BraintreeException>()
+        every { callback.onResult(null, capture(errorSlot)) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.get("sample/path", configuration, clientToken, callback)
+        sut.get("v1/payment_methods", null, tokenizationKey, callback)
 
-        val httpRequest = httpRequestSlot.captured
-        val headers = httpRequest.headers
-        val expectedUrlString = String.format(
-            Locale.US,
-            "https://example.com/sample/path?authorizationFingerprint=%s",
-            clientToken.bearer
-        )
-        assertEquals(URL(expectedUrlString), httpRequest.url)
-        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
-        assertNull(headers["Client-Key"])
-        assertEquals("GET", httpRequest.method)
+        verify { callback.onResult(null, any<BraintreeException>()) }
+        assertTrue(errorSlot.captured.message!!.contains("relative path"))
     }
 
     @Test
-    fun get_withInvalidToken_forwardsExceptionToCallback() {
-        val authorization: Authorization =
-            InvalidAuthorization("invalid", "token invalid")
-        val configuration = mockk<Configuration>()
-
-        val exceptionSlot = slot<BraintreeException>()
-        val callback = mockk<NetworkResponseCallback>()
-        every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
+    fun `when get is called with InvalidAuthorization, callback is called with error`() {
+        val invalidAuth = InvalidAuthorization("invalid_token", "Invalid token")
+        val errorSlot = slot<BraintreeException>()
+        every { callback.onResult(null, capture(errorSlot)) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.get("sample/path", configuration, authorization, callback)
+        sut.get("v1/payment_methods", configuration, invalidAuth, callback)
 
-        val exception = exceptionSlot.captured
-        assertEquals("token invalid", exception.message)
+        verify { callback.onResult(null, any<BraintreeException>()) }
+        assertEquals("Invalid token", errorSlot.captured.message)
     }
 
     @Test
-    @Throws(MalformedURLException::class, URISyntaxException::class)
-    fun postAsync_withTokenizationKey_forwardsHttpRequestToHttpClient() {
-        val tokenizationKey: Authorization = TokenizationKey(Fixtures.TOKENIZATION_KEY)
-        val configuration = mockk<Configuration>()
-        every { configuration.clientApiUrl } returns "https://example.com"
+    fun `when get is called with authorization bearer, Authorization header is added`() {
+        val token = UUID.randomUUID().toString()
+        val authorization = mockk<Authorization>()
+        every { authorization.bearer } returns token
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
-        val callback = mockk<NetworkResponseCallback>()
-        val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
+        val sut = BraintreeHttpClient(httpClient)
+        sut.get("v1/payment_methods", configuration, authorization, callback)
+
+        val request = requestSlot.captured
+        assertEquals("Bearer $token", request.headers["Authorization"])
+    }
+
+    // POST method tests
+
+    @Test
+    fun `when post is called with TokenizationKey, correct request is sent`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "{\"test\":\"data\"}", configuration, tokenizationKey, callback = callback)
+
+        val request = requestSlot.captured
+        assertEquals("https://api.braintreegateway.com/v1/payment_methods", request.url)
+        assertTrue(request.method is Method.Post)
+        val postMethod = request.method as Method.Post
+        assertEquals("{\"test\":\"data\"}", postMethod.body)
+        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, request.headers["User-Agent"])
+        assertEquals(Fixtures.TOKENIZATION_KEY, request.headers["Client-Key"])
+    }
+
+    @Test
+    fun `when post is called with ClientToken, authorization fingerprint is added to request body`() {
+        val clientToken = Authorization.fromString(
+            FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
+        ) as ClientToken
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "{}", configuration, clientToken, callback = callback)
+
+        val request = requestSlot.captured
+        val postMethod = request.method as Method.Post
+        assertTrue(postMethod.body.contains("authorizationFingerprint"))
+        assertTrue(postMethod.body.contains(clientToken.authorizationFingerprint))
+        assertNull(request.headers["Client-Key"])
+    }
+
+    @Test
+    fun `when post is called with additional headers, headers are included in request`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val additionalHeaders = mapOf("X-Custom-Header" to "custom-value", "Accept" to "application/json")
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
         sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = configuration,
-            authorization = tokenizationKey,
-            callback = callback
+            "v1/payment_methods",
+            "{}",
+            configuration,
+            tokenizationKey,
+            additionalHeaders,
+            callback
         )
 
-        val httpRequest = httpRequestSlot.captured
-        val headers = httpRequest.headers
-        assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
-        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
-        assertEquals(Fixtures.TOKENIZATION_KEY, headers["Client-Key"])
-        assertEquals("POST", httpRequest.method)
-        assertEquals("{}", String(httpRequest.data ?: ByteArray(0), StandardCharsets.UTF_8))
+        val request = requestSlot.captured
+        assertEquals("custom-value", request.headers["X-Custom-Header"])
+        assertEquals("application/json", request.headers["Accept"])
     }
 
     @Test
-    @Throws(MalformedURLException::class, URISyntaxException::class)
-    fun postAsync_withClientToken_forwardsHttpRequestToHttpClient() {
+    fun `when post is called with absolute URL, configuration base URL is ignored`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("https://example.com/custom/path", "{}", configuration, tokenizationKey, callback = callback)
+
+        val request = requestSlot.captured
+        assertEquals("https://example.com/custom/path", request.url)
+    }
+
+    @Test
+    fun `when post is called with null configuration and relative path, BraintreeException is thrown`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val errorSlot = slot<BraintreeException>()
+        every { callback.onResult(null, capture(errorSlot)) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "{}", null, tokenizationKey, callback = callback)
+
+        verify { callback.onResult(null, any<BraintreeException>()) }
+        assertTrue(errorSlot.captured.message!!.contains("relative path"))
+    }
+
+    @Test
+    fun `when post is called with InvalidAuthorization, callback is called with error`() {
+        val invalidAuth = InvalidAuthorization("invalid_token", "Invalid token")
+        val errorSlot = slot<BraintreeException>()
+        every { callback.onResult(null, capture(errorSlot)) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "{}", configuration, invalidAuth, callback = callback)
+
+        verify { callback.onResult(null, any<BraintreeException>()) }
+        assertEquals("Invalid token", errorSlot.captured.message)
+    }
+
+    @Test
+    fun `when post is called with invalid JSON in ClientToken request body, callback is called with JSONException`() {
+        val clientToken = Authorization.fromString(
+            FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
+        ) as ClientToken
+        val errorSlot = slot<JSONException>()
+        every { callback.onResult(null, capture(errorSlot)) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "invalid json", configuration, clientToken, callback = callback)
+
+        verify { callback.onResult(null, any<JSONException>()) }
+    }
+
+    @Test
+    fun `when post is called with null callback and InvalidAuthorization, request does not crash`() {
+        val invalidAuth = InvalidAuthorization("invalid_token", "Invalid token")
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.post("v1/payment_methods", "{}", configuration, invalidAuth, callback = null)
+
+        // Should not crash
+    }
+
+    @Test
+    fun `when post is called with null callback and JSON exception occurs, request does not crash`() {
         val clientToken = Authorization.fromString(
             FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
         ) as ClientToken
 
-        val configuration = mockk<Configuration>()
-        every { configuration.clientApiUrl } returns "https://example.com"
-
-        val callback = mockk<NetworkResponseCallback>()
-        val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
-
         val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = configuration,
-            authorization = clientToken,
-            callback = callback
-        )
+        sut.post("v1/payment_methods", "invalid json", configuration, clientToken, callback = null)
 
-        val httpRequest = httpRequestSlot.captured
-        val headers = httpRequest.headers
-        assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
-        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, headers["User-Agent"])
-        assertNull(headers["Client-Key"])
-        assertEquals("POST", httpRequest.method)
-        val expectedData =
-            """{"authorizationFingerprint":"${clientToken.authorizationFingerprint}"}"""
-        assertEquals(expectedData, String(httpRequest.data ?: ByteArray(0), StandardCharsets.UTF_8))
+        // Should not crash
     }
 
     @Test
-    fun postAsync_withNullConfiguration_andRelativeUrl_postsCallbackError() {
-        val clientToken = Authorization.fromString(
-            FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
-        ) as ClientToken
-
-        val exceptionSlot = slot<BraintreeException>()
-        val callback = mockk<NetworkResponseCallback>()
-        every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
+    fun `when post is called with null callback and BraintreeException occurs, request does not crash`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = null,
-            authorization = clientToken,
-            callback = callback
-        )
+        sut.post("v1/payment_methods", "{}", null, tokenizationKey, callback = null)
 
-        val exception = exceptionSlot.captured
-        assertEquals(
-            "Braintree HTTP GET request without configuration cannot have a relative path.",
-            exception.message
-        )
+        // Should not crash
+    }
+
+    // Header assembly tests
+
+    @Test
+    fun `when assembleHeaders is called, User-Agent header is included`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
+
+        val sut = BraintreeHttpClient(httpClient)
+        sut.get("v1/payment_methods", configuration, tokenizationKey, callback)
+
+        val request = requestSlot.captured
+        assertEquals("braintree/android/" + BuildConfig.VERSION_NAME, request.headers["User-Agent"])
     }
 
     @Test
-    @Throws(Exception::class)
-    fun postAsync_withNullConfiguration_andAbsoluteURL_doesNotSetABaseURLOnTheRequest() {
-        val clientToken = Authorization.fromString(
-            FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)
-        ) as ClientToken
-
-        val httpRequestSlot = slot<HttpRequest>()
-        val callback = mockk<NetworkResponseCallback>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), callback) } returns Unit
+    fun `when assembleHeaders is called with null bearer, Authorization header is not included`() {
+        val authorization = mockk<Authorization>()
+        every { authorization.bearer } returns null
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "https://example.com/sample/path",
-            data = "{}",
-            configuration = null,
-            authorization = clientToken,
-            callback = callback
-        )
+        sut.get("v1/payment_methods", configuration, authorization, callback)
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://example.com/sample/path"), httpRequest.url)
+        val request = requestSlot.captured
+        assertNull(request.headers["Authorization"])
     }
 
     @Test
-    fun postAsync_withPathAndDataAndCallback_whenClientTokenAuthAndInvalidJSONPayload_postsCallbackError() {
-        val configuration = mockk<Configuration>()
-        every { configuration.clientApiUrl } returns "https://example.com"
-
-        val clientToken =
-            Authorization.fromString(FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN))
-
-        val exceptionSlot = slot<JSONException>()
-        val callback = mockk<NetworkResponseCallback>()
-        every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
+    fun `when get is called with null configuration and absolute URL, base URL is not set`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "not json",
-            configuration = configuration,
-            authorization = clientToken,
-            callback = callback
-        )
+        sut.get("https://example.com/custom/path", null, tokenizationKey, callback)
 
-        val exception = exceptionSlot.captured
-        assertEquals(
-            "Value not of type java.lang.String cannot be converted to JSONObject",
-            exception.message
-        )
+        val request = requestSlot.captured
+        assertEquals("https://example.com/custom/path", request.url)
     }
 
     @Test
-    fun postAsync_withInvalidToken_forwardsExceptionToCallback() {
-        val configuration = mockk<Configuration>()
-        val authorization: Authorization =
-            InvalidAuthorization("invalid", "token invalid")
-
-        val exceptionSlot = slot<BraintreeException>()
-        val callback = mockk<NetworkResponseCallback>()
-        every { callback.onResult(null, capture(exceptionSlot)) } returns Unit
+    fun `when post is called with null configuration and absolute URL, base URL is not set`() {
+        val tokenizationKey = TokenizationKey(Fixtures.TOKENIZATION_KEY)
+        val requestSlot = slot<OkHttpRequest>()
+        every { httpClient.sendRequest(capture(requestSlot), callback) } just runs
 
         val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = configuration,
-            authorization = authorization,
-            callback = callback
-        )
+        sut.post("https://example.com/custom/path", "{}", null, tokenizationKey, callback = callback)
 
-        val exception = exceptionSlot.captured
-        assertEquals("token invalid", exception.message)
-    }
-
-    @Test
-    fun `when post is called with authorization bearer, Authorization header is added to the request`() {
-        val token: String = UUID.randomUUID().toString()
-        val tokenizationKey = mockk<Authorization>()
-        every { tokenizationKey.bearer } returns token
-
-        val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), any()) } just runs
-
-        val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = mockk<Configuration>(relaxed = true),
-            authorization = tokenizationKey,
-            callback = mockk<NetworkResponseCallback>()
-        )
-
-        val headers = httpRequestSlot.captured.headers
-        assertEquals(headers["Authorization"], "Bearer $token")
-    }
-
-    @Test
-    fun `when post is called with null bearer, Authorization header is not added to the request`() {
-        val tokenizationKey = mockk<Authorization>()
-        every { tokenizationKey.bearer } returns null
-
-        val httpRequestSlot = slot<HttpRequest>()
-        every { httpClient.sendRequest(capture(httpRequestSlot), any()) } just runs
-
-        val sut = BraintreeHttpClient(httpClient)
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = mockk<Configuration>(relaxed = true),
-            authorization = tokenizationKey,
-            callback = mockk<NetworkResponseCallback>()
-        )
-
-        val headers = httpRequestSlot.captured.headers
-        assertNull(headers["Authorization"])
-    }
-
-    @Test
-    fun `when post is called with additional headers, headers are added to the request`() {
-        val headers = mapOf("name1" to "value1", "name2" to "value2")
-        val callback = mockk<NetworkResponseCallback>()
-        val sut = BraintreeHttpClient(httpClient)
-
-        sut.post(
-            path = "sample/path",
-            data = "{}",
-            configuration = mockk(relaxed = true),
-            authorization = mockk(relaxed = true),
-            additionalHeaders = headers,
-            callback = callback
-        )
-
-        verify {
-            httpClient.sendRequest(withArg {
-                assertEquals(it.headers["name1"], "value1")
-                assertEquals(it.headers["name2"], "value2")
-            }, callback)
-        }
+        val request = requestSlot.captured
+        assertEquals("https://example.com/custom/path", request.url)
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -1,7 +1,6 @@
 package com.braintreepayments.api.core
 
 import android.util.Base64
-import com.braintreepayments.api.sharedutils.HttpClient
 import com.braintreepayments.api.sharedutils.HttpResponse
 import com.braintreepayments.api.sharedutils.HttpResponseTiming
 import com.braintreepayments.api.sharedutils.NetworkResponseCallback
@@ -55,7 +54,6 @@ class ConfigurationLoaderUnitTest {
                 expectedConfigUrl,
                 null,
                 authorization,
-                HttpClient.RetryStrategy.RETRY_MAX_3_TIMES,
                 capture(callbackSlot)
             )
         }
@@ -85,7 +83,6 @@ class ConfigurationLoaderUnitTest {
                 expectedConfigUrl,
                 null,
                 authorization,
-                HttpClient.RetryStrategy.RETRY_MAX_3_TIMES,
                 capture(callbackSlot)
             )
         }
@@ -116,7 +113,6 @@ class ConfigurationLoaderUnitTest {
                 ofType(String::class),
                 null,
                 authorization,
-                HttpClient.RetryStrategy.RETRY_MAX_3_TIMES,
                 capture(callbackSlot)
             )
         }
@@ -142,7 +138,6 @@ class ConfigurationLoaderUnitTest {
                 ofType(String::class),
                 null,
                 authorization,
-                HttpClient.RetryStrategy.RETRY_MAX_3_TIMES,
                 capture(callbackSlot)
             )
         }
@@ -193,7 +188,6 @@ class ConfigurationLoaderUnitTest {
                 ofType(String::class),
                 null,
                 authorization,
-                any(),
                 ofType(NetworkResponseCallback::class)
             )
         }
@@ -218,7 +212,6 @@ class ConfigurationLoaderUnitTest {
                 expectedConfigUrl,
                 null,
                 authorization,
-                HttpClient.RetryStrategy.RETRY_MAX_3_TIMES,
                 capture(callbackSlot)
             )
         }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/HttpClient.kt
@@ -1,97 +1,32 @@
 package com.braintreepayments.api.sharedutils
 
 import androidx.annotation.RestrictTo
-import java.net.MalformedURLException
-import java.net.URISyntaxException
-import java.net.URL
-import javax.net.ssl.SSLSocketFactory
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class HttpClient internal constructor(
-    private val syncHttpClient: SynchronousHttpClient,
-    private val scheduler: Scheduler
+    private val okHttpSynchronousHttpClient: OkHttpSynchronousHttpClient = OkHttpSynchronousHttpClient(),
+    private val scheduler: Scheduler = ThreadScheduler()
 ) {
-    enum class RetryStrategy { NO_RETRY, RETRY_MAX_3_TIMES }
 
-    private val retryCountMap: MutableMap<URL, Int> = HashMap()
-
-    constructor(
-        socketFactory: SSLSocketFactory,
-        httpResponseParser: HttpResponseParser
-    ) : this(
-        syncHttpClient = SynchronousHttpClient(socketFactory, httpResponseParser),
+    constructor() : this(
+        okHttpSynchronousHttpClient = OkHttpSynchronousHttpClient(),
         scheduler = ThreadScheduler()
     )
 
-    @Throws(Exception::class)
-    fun sendRequest(request: HttpRequest): String {
-        return syncHttpClient.request(request).body ?: ""
-    }
-
-    fun sendRequest(
-        request: HttpRequest,
-        callback: NetworkResponseCallback?,
-        retryStrategy: RetryStrategy = RetryStrategy.NO_RETRY,
-    ) {
-        scheduleRequest(request, retryStrategy, callback)
-    }
-
     @Suppress("TooGenericExceptionCaught")
-    private fun scheduleRequest(
-        request: HttpRequest,
-        retryStrategy: RetryStrategy,
-        callback: NetworkResponseCallback?
+    fun sendRequest(
+        request: OkHttpRequest,
+        callback: NetworkResponseCallback?,
     ) {
-        resetRetryCount(request)
-
         scheduler.runOnBackground {
             try {
-                val httpResponse = syncHttpClient.request(request)
+                val httpResponse = okHttpSynchronousHttpClient.executeRequest(request)
                 callback?.let {
                     scheduler.runOnMain { callback.onResult(httpResponse, null) }
                 }
             } catch (e: Exception) {
-                when (retryStrategy) {
-                    RetryStrategy.NO_RETRY -> notifyErrorOnMainThread(callback, e)
-                    RetryStrategy.RETRY_MAX_3_TIMES -> retryGet(request, retryStrategy, callback)
-                }
+                notifyErrorOnMainThread(callback, e)
             }
-        }
-    }
-
-    private fun retryGet(
-        request: HttpRequest,
-        retryStrategy: RetryStrategy,
-        callback: NetworkResponseCallback?
-    ) {
-        var url: URL? = null
-        try {
-            url = request.url
-        } catch (ignore: MalformedURLException) {
-        } catch (ignore: URISyntaxException) {
-        }
-
-        if (url != null) {
-            val retryCount = getCurrentRetryCount(url)
-            val shouldRetry = ((retryCount + 1) < MAX_RETRY_ATTEMPTS)
-            if (shouldRetry) {
-                scheduleRequest(request, retryStrategy, callback)
-                retryCountMap[url] = retryCount + 1
-            } else {
-                val message = "Retry limit has been exceeded. Try again later."
-                val retryLimitException = HttpClientException(message)
-                notifyErrorOnMainThread(callback, retryLimitException)
-            }
-        }
-    }
-
-    private fun getCurrentRetryCount(url: URL) = retryCountMap[url] ?: 0
-
-    private fun resetRetryCount(request: HttpRequest) {
-        try {
-            request.url?.let { retryCountMap.remove(it) }
-        } catch (ignore: MalformedURLException) {
-        } catch (ignore: URISyntaxException) {
         }
     }
 
@@ -99,9 +34,5 @@ class HttpClient internal constructor(
         if (callback != null) {
             scheduler.runOnMain { callback.onResult(null, e) }
         }
-    }
-
-    companion object {
-        private const val MAX_RETRY_ATTEMPTS: Int = 3
     }
 }

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Method.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/Method.kt
@@ -1,5 +1,7 @@
 package com.braintreepayments.api.sharedutils
 
+import androidx.annotation.RestrictTo
+
 /**
  * Represents an HTTP method for network requests.
  *
@@ -7,7 +9,8 @@ package com.braintreepayments.api.sharedutils
  *
  * @property stringValue The string representation of the HTTP method (e.g., "GET", "POST").
  */
-internal sealed class Method(val stringValue: String) {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed class Method(val stringValue: String) {
     /**
      * Represents the HTTP GET method.
      */

--- a/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/OkHttpRequest.kt
+++ b/SharedUtils/src/main/java/com/braintreepayments/api/sharedutils/OkHttpRequest.kt
@@ -1,6 +1,6 @@
 package com.braintreepayments.api.sharedutils
 
-import java.net.URL
+import androidx.annotation.RestrictTo
 
 /**
  * NOTE THIS CLASS WILL BE RENAMED TO `HttpRequest` TO REPLACE THE EXISTING [HttpRequest] CLASS.
@@ -13,8 +13,9 @@ import java.net.URL
  * @property method The HTTP method to use for the request (GET, POST, etc.).
  * @property headers A map of header key-value pairs to include in the request.
  */
-internal data class OkHttpRequest(
-    val url: URL,
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class OkHttpRequest(
+    val url: String,
     val method: Method,
     val headers: Map<String, String> = emptyMap(),
 )

--- a/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/OkHttpSynchronousHttpClientTest.kt
+++ b/SharedUtils/src/test/java/com/braintreepayments/api/sharedutils/OkHttpSynchronousHttpClientTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import java.net.URL
 
 class OkHttpSynchronousHttpClientTest {
 
@@ -50,7 +49,7 @@ class OkHttpSynchronousHttpClientTest {
 
     @Test
     fun `when request is GET and response is successful, executeRequest returns HttpResponse`() {
-        val url = URL("https://example.com")
+        val url = "https://example.com"
         val okHttpRequest = OkHttpRequest(url, Method.Get)
         every { okHttpClient.newCall(any()) } returns call
         every { call.execute() } returns response
@@ -65,7 +64,7 @@ class OkHttpSynchronousHttpClientTest {
 
     @Test
     fun `when request is POST and response is successful, executeRequest returns HttpResponse`() {
-        val url = URL("https://example.com")
+        val url = "https://example.com"
         val okHttpRequest = OkHttpRequest(url, Method.Post("{\"key\":\"value\"}"))
         every { okHttpClient.newCall(any()) } returns call
         every { call.execute() } returns response
@@ -79,7 +78,7 @@ class OkHttpSynchronousHttpClientTest {
 
     @Test(expected = IOException::class)
     fun `when response is unsuccessful, executeRequest throws IOException`() {
-        val url = URL("https://example.com")
+        val url = "https://example.com"
         val okHttpRequest = OkHttpRequest(url, Method.Get)
         every { okHttpClient.newCall(any()) } returns call
         every { call.execute() } returns response
@@ -90,7 +89,7 @@ class OkHttpSynchronousHttpClientTest {
 
     @Test
     fun `when headers are provided, executeRequest sets headers on OkHttp Request`() {
-        val url = URL("https://example.com")
+        val url = "https://example.com"
         val headers = mapOf("Authorization" to "Bearer token", "Custom" to "Value")
         val okHttpRequest = OkHttpRequest(url, Method.Get, headers)
         every { okHttpClient.newCall(any()) } returns call


### PR DESCRIPTION
### Summary of changes

 - Update HttpClient to call OkHttpSynchronusHttpClient
 - Update BraintreeGraphQLClient and BraintreeHttpClient to assemble `OkHttpRequest`s

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

