### PR TITLE
Centralize Java version configuration using Gradle variables

### DIFF
--- a/AmericanExpress/build.gradle
+++ b/AmericanExpress/build.gradle
@@ -31,12 +31,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/BraintreeCore/build.gradle
+++ b/BraintreeCore/build.gradle
@@ -57,12 +57,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -31,12 +31,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/DataCollector/build.gradle
+++ b/DataCollector/build.gradle
@@ -36,12 +36,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -56,8 +56,18 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility versions.javaSourceCompatibility
+        targetCompatibility versions.javaTargetCompatibility
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaTargetCompatibility.toString()
+    }
+
+    kotlin {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
+        }
     }
 
     namespace 'com.braintreepayments.demo'

--- a/GooglePay/build.gradle
+++ b/GooglePay/build.gradle
@@ -36,12 +36,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/LocalPayment/build.gradle
+++ b/LocalPayment/build.gradle
@@ -31,12 +31,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -31,12 +31,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -33,12 +33,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/SEPADirectDebit/build.gradle
+++ b/SEPADirectDebit/build.gradle
@@ -31,12 +31,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/SharedUtils/build.gradle
+++ b/SharedUtils/build.gradle
@@ -32,12 +32,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/ShopperInsights/build.gradle
+++ b/ShopperInsights/build.gradle
@@ -30,12 +30,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/TestUtils/build.gradle
+++ b/TestUtils/build.gradle
@@ -26,12 +26,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/ThreeDSecure/build.gradle
+++ b/ThreeDSecure/build.gradle
@@ -32,12 +32,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -33,12 +33,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }

--- a/VisaCheckout/build.gradle
+++ b/VisaCheckout/build.gradle
@@ -33,12 +33,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = versions.javaTargetCompatibility.toString()
     }
 
     kotlin {
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
+            languageVersion.set(JavaLanguageVersion.of(versions.javaTargetCompatibility.toString()))
         }
     }
 }


### PR DESCRIPTION
Centralize Java version configuration using Gradle variables

In all modules' build.gradle files, replace hard-coded `jvmTarget` and `kotlinOptions` with `version variables defined in the root project.

This change centralizes Java compatibility version configuration in one place, improving project maintainability. Future Java version updates require only one modification.