### PR TITLE
Track merchant-passed and default UserAction in analytics instrumentation

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -88,6 +88,7 @@ internal class AnalyticsApi(
             .putOpt(FPTI_KEY_PAYPAL_ATTEMPTED_APP_SWITCH, event.didPayPalServerAttemptAppSwitch)
             .putOpt(FPTI_KEY_ERROR_DESC, event.errorDescription)
             .putOpt(FPTI_KEY_CONTEXT_TYPE, if (event.isVaultRequest) "BA-TOKEN" else "EC-TOKEN")
+            .putOpt(FPTI_KEY_MERCHANT_PASSED_USER_ACTION, event.merchantPassedUserAction)
     }
 
     @Throws(JSONException::class)
@@ -144,6 +145,8 @@ internal class AnalyticsApi(
         private const val FPTI_KEY_PAYPAL_ATTEMPTED_APP_SWITCH = "attempted_app_switch"
         private const val FPTI_KEY_ERROR_DESC = "error_desc"
         private const val FPTI_KEY_CONTEXT_TYPE = "context_type"
+        private const val FPTI_KEY_MERCHANT_PASSED_USER_ACTION = "merchant_passed_user_action"
+
 
         private const val FPTI_BATCH_KEY_VENMO_INSTALLED = "venmo_installed"
         private const val FPTI_BATCH_KEY_PAYPAL_INSTALLED = "paypal_installed"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -147,7 +147,6 @@ internal class AnalyticsApi(
         private const val FPTI_KEY_CONTEXT_TYPE = "context_type"
         private const val FPTI_KEY_MERCHANT_PASSED_USER_ACTION = "merchant_passed_user_action"
 
-
         private const val FPTI_BATCH_KEY_VENMO_INSTALLED = "venmo_installed"
         private const val FPTI_BATCH_KEY_PAYPAL_INSTALLED = "paypal_installed"
         private const val FPTI_BATCH_KEY_APP_ID = "app_id"

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsClient.kt
@@ -36,7 +36,8 @@ class AnalyticsClient internal constructor(
             pageType = analyticsEventParams.pageType,
             errorDescription = analyticsEventParams.errorDescription,
             didEnablePayPalAppSwitch = analyticsParamRepository.didEnablePayPalAppSwitch,
-            didPayPalServerAttemptAppSwitch = analyticsParamRepository.didPayPalServerAttemptAppSwitch
+            didPayPalServerAttemptAppSwitch = analyticsParamRepository.didPayPalServerAttemptAppSwitch,
+            merchantPassedUserAction = analyticsParamRepository.merchantPassedUserAction
         )
         if (sendImmediately) {
             configurationLoader.loadConfiguration { result ->

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsEvent.kt
@@ -23,4 +23,5 @@ internal data class AnalyticsEvent(
     val errorDescription: String? = null,
     val didEnablePayPalAppSwitch: Boolean? = null,
     val didPayPalServerAttemptAppSwitch: Boolean? = null,
+    val merchantPassedUserAction: String? = null,
 )

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -25,6 +25,7 @@ class AnalyticsParamRepository(
      */
     var didPayPalServerAttemptAppSwitch: Boolean? = null
 
+    var merchantPassedUserAction: String? = null
     private lateinit var _sessionId: String
 
     /**
@@ -50,6 +51,7 @@ class AnalyticsParamRepository(
         linkType = null
         didEnablePayPalAppSwitch = null
         didPayPalServerAttemptAppSwitch = null
+        merchantPassedUserAction = null
     }
 
     companion object {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -26,7 +26,7 @@ class AnalyticsParamRepository(
     var didPayPalServerAttemptAppSwitch: Boolean? = null
 
     /**
-     * User Action passed by the Merchant to differentiate if it's explicit or default
+     * User Action passed by the Merchant
      */
     var merchantPassedUserAction: String? = null
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -25,7 +25,12 @@ class AnalyticsParamRepository(
      */
     var didPayPalServerAttemptAppSwitch: Boolean? = null
 
+    /**
+     * User Action passed by the Merchant to differentiate if it's explicit or default
+     */
+
     var merchantPassedUserAction: String? = null
+
     private lateinit var _sessionId: String
 
     /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsParamRepository.kt
@@ -28,7 +28,6 @@ class AnalyticsParamRepository(
     /**
      * User Action passed by the Merchant to differentiate if it's explicit or default
      */
-
     var merchantPassedUserAction: String? = null
 
     private lateinit var _sessionId: String

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsClientUnitTest.kt
@@ -60,6 +60,7 @@ class AnalyticsClientUnitTest {
         pageType = analyticsEventParams.pageType,
         didEnablePayPalAppSwitch = true,
         didPayPalServerAttemptAppSwitch = true,
+        merchantPassedUserAction = "none"
     )
 
     @Before
@@ -69,6 +70,7 @@ class AnalyticsClientUnitTest {
         every { analyticsParamRepository.linkType } returns linkType
         every { analyticsParamRepository.didEnablePayPalAppSwitch } returns true
         every { analyticsParamRepository.didPayPalServerAttemptAppSwitch } returns true
+        every { analyticsParamRepository.merchantPassedUserAction } returns "none"
 
         configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * PayPal
   * Add `recurringBillingDetails`, `recurringBillingPlanType`, and `amountBreakdown` properties to `PayPalCheckoutRequest`. Enables RBA metadata to be passed for the PayPal Checkout Vault with Purchase flow
   * Add `userAction` property to `PayPalVaultRequest`
+  * Add `FPTI_KEY_MERCHANT_PASSED_USER_ACTION` to `AnalyticsApi`. Its value can be `continue`, `pay_now`, `setup_now`, or `none`.
+  * Add `merchantPassedUserAction` to `AnalyticsParamRepository`.
+  * Change `userAction` from having a definite initial value to being nullable.
 
 ## unreleased
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -78,7 +78,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     val amount: String,
     override val hasUserLocationConsent: Boolean,
     var intent: PayPalPaymentIntent = PayPalPaymentIntent.AUTHORIZE,
-    override var userAction: PayPalPaymentUserAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT,
+    var userAction: PayPalPaymentUserAction? = null,
     var currencyCode: String? = null,
     var shouldRequestBillingAgreement: Boolean = false,
     var shouldOfferPayLater: Boolean = false,
@@ -203,8 +203,12 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             experienceProfile.put(LOCALE_CODE_KEY, localeCode)
         }
 
+        if (userAction == null) {
+            userAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
+        }
+
         if (userAction != PayPalPaymentUserAction.USER_ACTION_DEFAULT) {
-            experienceProfile.put(USER_ACTION_KEY, userAction.stringValue)
+            experienceProfile.put(USER_ACTION_KEY, userAction?.stringValue)
         }
 
         shippingAddressOverride?.let {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -78,7 +78,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     val amount: String,
     override val hasUserLocationConsent: Boolean,
     var intent: PayPalPaymentIntent = PayPalPaymentIntent.AUTHORIZE,
-    var userAction: PayPalPaymentUserAction? = null,
+    override var userAction: PayPalPaymentUserAction? = null,
     var currencyCode: String? = null,
     var shouldRequestBillingAgreement: Boolean = false,
     var shouldOfferPayLater: Boolean = false,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -203,12 +203,10 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
             experienceProfile.put(LOCALE_CODE_KEY, localeCode)
         }
 
-        if (userAction == null) {
-            userAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
-        }
-
-        if (userAction != PayPalPaymentUserAction.USER_ACTION_DEFAULT) {
-            experienceProfile.put(USER_ACTION_KEY, userAction?.stringValue)
+        userAction?.let {
+            if (it != PayPalPaymentUserAction.USER_ACTION_DEFAULT) {
+                experienceProfile.put(USER_ACTION_KEY, it.stringValue)
+            }
         }
 
         shippingAddressOverride?.let {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -392,11 +392,12 @@ class PayPalClient internal constructor(
         analyticsParamRepository.reset()
     }
 
-    private fun userActionString(payPalRequest: PayPalCheckoutRequest): String = when (payPalRequest.userAction) {
-        PayPalPaymentUserAction.USER_ACTION_DEFAULT -> CONTINUE
-        PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY
-        null -> NONE
-    }
+    private fun userActionString(payPalRequest: PayPalCheckoutRequest): String =
+        when (payPalRequest.userAction) {
+            PayPalPaymentUserAction.USER_ACTION_DEFAULT -> CONTINUE
+            PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY
+            else -> NONE
+        }
 
     companion object {
         internal const val PAYPAL_NOT_ENABLED_MESSAGE = "PayPal is not enabled. " +

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -96,6 +96,10 @@ class PayPalClient internal constructor(
         isVaultRequest = payPalRequest is PayPalVaultRequest
         analyticsParamRepository.didEnablePayPalAppSwitch = payPalRequest.enablePayPalAppSwitch
 
+        if (payPalRequest is PayPalCheckoutRequest) {
+            analyticsParamRepository.merchantPassedUserAction = userActionString(payPalRequest)
+        }
+
         braintreeClient.getConfiguration { configuration: Configuration?, error: Exception? ->
             val analyticsEventParams = AnalyticsEventParams(
                 contextId = null,
@@ -388,11 +392,21 @@ class PayPalClient internal constructor(
         analyticsParamRepository.reset()
     }
 
+    private fun userActionString(payPalRequest: PayPalCheckoutRequest): String = when (payPalRequest.userAction) {
+        PayPalPaymentUserAction.USER_ACTION_DEFAULT -> CONTINUE
+        PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY
+        null -> NONE
+    }
+
     companion object {
         internal const val PAYPAL_NOT_ENABLED_MESSAGE = "PayPal is not enabled. " +
             "See https://developer.paypal.com/braintree/docs/guides/paypal/overview/android/v5 " +
             "for more information."
 
         internal const val BROWSER_SWITCH_EXCEPTION_MESSAGE = "The response contained inconsistent data."
+        internal const val CONTINUE = "continue"
+        internal const val PAY = "pay"
+        internal const val NONE = "none"
+
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -96,9 +96,7 @@ class PayPalClient internal constructor(
         isVaultRequest = payPalRequest is PayPalVaultRequest
         analyticsParamRepository.didEnablePayPalAppSwitch = payPalRequest.enablePayPalAppSwitch
 
-        if (payPalRequest is PayPalCheckoutRequest) {
-            analyticsParamRepository.merchantPassedUserAction = userActionString(payPalRequest)
-        }
+        analyticsParamRepository.merchantPassedUserAction = userActionString(payPalRequest)
 
         braintreeClient.getConfiguration { configuration: Configuration?, error: Exception? ->
             val analyticsEventParams = AnalyticsEventParams(
@@ -392,11 +390,11 @@ class PayPalClient internal constructor(
         analyticsParamRepository.reset()
     }
 
-    private fun userActionString(payPalRequest: PayPalCheckoutRequest): String =
+    private fun userActionString(payPalRequest: PayPalRequest): String =
         when (payPalRequest.userAction) {
             PayPalPaymentUserAction.USER_ACTION_DEFAULT -> CONTINUE
             PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY
-            else -> NONE
+            null -> NONE
         }
 
     companion object {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -393,7 +393,8 @@ class PayPalClient internal constructor(
     private fun userActionString(payPalRequest: PayPalRequest): String =
         when (payPalRequest.userAction) {
             PayPalPaymentUserAction.USER_ACTION_DEFAULT -> CONTINUE
-            PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY
+            PayPalPaymentUserAction.USER_ACTION_COMMIT -> PAY_NOW
+            PayPalPaymentUserAction.USER_ACTION_SETUP_NOW -> SETUP_NOW
             null -> NONE
         }
 
@@ -404,8 +405,8 @@ class PayPalClient internal constructor(
 
         internal const val BROWSER_SWITCH_EXCEPTION_MESSAGE = "The response contained inconsistent data."
         internal const val CONTINUE = "continue"
-        internal const val PAY = "pay"
+        internal const val PAY_NOW = "pay_now"
         internal const val NONE = "none"
-
+        internal const val SETUP_NOW = "setup_now"
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -99,6 +99,8 @@ abstract class PayPalRequest internal constructor(
     open var userPhoneNumber: PayPalPhoneNumber? = null,
     open var recurringBillingDetails: PayPalRecurringBillingDetails? = null,
     open var recurringBillingPlanType: PayPalRecurringBillingPlanType? = null,
+    open var userAction: PayPalPaymentUserAction? = null,
+
 
     @property:ExperimentalBetaApi
     open var shopperSessionId: String? = null,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -99,13 +99,11 @@ abstract class PayPalRequest internal constructor(
     open var userPhoneNumber: PayPalPhoneNumber? = null,
     open var recurringBillingDetails: PayPalRecurringBillingDetails? = null,
     open var recurringBillingPlanType: PayPalRecurringBillingPlanType? = null,
-    open var userAction: PayPalPaymentUserAction? = null,
-
 
     @property:ExperimentalBetaApi
     open var shopperSessionId: String? = null,
     open var lineItems: List<PayPalLineItem> = emptyList(),
-    open var userAction: PayPalPaymentUserAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
+    open var userAction: PayPalPaymentUserAction? = null,
 ) : Parcelable {
 
     @Throws(JSONException::class)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalVaultRequest.kt
@@ -46,7 +46,7 @@ class PayPalVaultRequest
     override var userAuthenticationEmail: String? = null,
     override var userPhoneNumber: PayPalPhoneNumber? = null,
     override var lineItems: List<PayPalLineItem> = emptyList(),
-    override var userAction: PayPalPaymentUserAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
+    override var userAction: PayPalPaymentUserAction? = null
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -118,8 +118,10 @@ class PayPalVaultRequest
             experienceProfile.put(LOCALE_CODE_KEY, localeCode)
         }
 
-        if (userAction != PayPalPaymentUserAction.USER_ACTION_DEFAULT) {
-            experienceProfile.put(USER_ACTION_KEY, userAction.stringValue)
+        userAction?.let {
+            if (it != PayPalPaymentUserAction.USER_ACTION_DEFAULT) {
+                experienceProfile.put(USER_ACTION_KEY, it.stringValue)
+            }
         }
 
         if (shippingAddressOverride != null) {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
@@ -381,7 +381,6 @@ class PayPalCheckoutRequestUnitTest {
         assertFalse(experienceProfile.has("user_action"))
     }
 
-
     @Test
     @Throws(JSONException::class)
     fun `creates requestBody and does not set userAction when it is USER_ACTION_DEFAULT`() {
@@ -424,9 +423,11 @@ class PayPalCheckoutRequestUnitTest {
 
         val experienceProfile = jsonObject.getJSONObject("experience_profile")
         assertTrue(experienceProfile.has("user_action"))
+        assertEquals(
+            PayPalPaymentUserAction.USER_ACTION_COMMIT.stringValue,
+            experienceProfile.getString("user_action")
+        )
     }
-
-
 
     @Test
     fun `creates requestBody and does not set amountBreakdown values when null`() {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
@@ -360,6 +360,75 @@ class PayPalCheckoutRequestUnitTest {
     }
 
     @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set userAction when it is null`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = null
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertTrue(jsonObject.has("experience_profile"))
+
+        val experienceProfile = jsonObject.getJSONObject("experience_profile")
+        assertFalse(experienceProfile.has("user_action"))
+    }
+
+
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set userAction when it is USER_ACTION_DEFAULT`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertTrue(jsonObject.has("experience_profile"))
+
+        val experienceProfile = jsonObject.getJSONObject("experience_profile")
+        assertFalse(experienceProfile.has("user_action"))
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and sets userAction when it is USER_ACTION_COMMIT`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = PayPalPaymentUserAction.USER_ACTION_COMMIT
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertTrue(jsonObject.has("experience_profile"))
+
+        val experienceProfile = jsonObject.getJSONObject("experience_profile")
+        assertTrue(experienceProfile.has("user_action"))
+    }
+
+
+
+    @Test
     fun `creates requestBody and does not set amountBreakdown values when null`() {
         val request = PayPalCheckoutRequest("1.00", false)
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -821,7 +821,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenUserActionIsCommit_setsMerchantPassedUserActionToPay() {
+    fun createPaymentAuthRequest_whenUserActionIsCommit_setsMerchantPassedUserActionToPayNow() {
         val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true).apply {
             userAction = PayPalPaymentUserAction.USER_ACTION_COMMIT
         }
@@ -833,7 +833,24 @@ class PayPalClientUnitTest {
         sut.createPaymentAuthRequest(activity, payPalCheckoutRequest, paymentAuthCallback)
 
         verify {
-            analyticsParamRepository.merchantPassedUserAction = "pay"
+            analyticsParamRepository.merchantPassedUserAction = "pay_now"
+        }
+    }
+
+    @Test
+    fun createPaymentAuthRequest_whenUserActionIsSetupNow_setsMerchantPassedUserActionToSetupNow() {
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = PayPalPaymentUserAction.USER_ACTION_SETUP_NOW
+        }
+
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+        val braintreeClient = MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient)
+        sut.createPaymentAuthRequest(activity, payPalCheckoutRequest, paymentAuthCallback)
+
+        verify {
+            analyticsParamRepository.merchantPassedUserAction = "setup_now"
         }
     }
 
@@ -853,5 +870,4 @@ class PayPalClientUnitTest {
             analyticsParamRepository.merchantPassedUserAction = "none"
         }
     }
-
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -802,4 +802,56 @@ class PayPalClientUnitTest {
         getReturnLinkUseCase,
         analyticsParamRepository
     )
+
+    @Test
+    fun createPaymentAuthRequest_whenUserActionIsDefault_setsMerchantPassedUserActionToContinue() {
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = PayPalPaymentUserAction.USER_ACTION_DEFAULT
+        }
+
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+        val braintreeClient = MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient)
+        sut.createPaymentAuthRequest(activity, payPalCheckoutRequest, paymentAuthCallback)
+
+        verify {
+            analyticsParamRepository.merchantPassedUserAction = "continue"
+        }
+    }
+
+    @Test
+    fun createPaymentAuthRequest_whenUserActionIsCommit_setsMerchantPassedUserActionToPay() {
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = PayPalPaymentUserAction.USER_ACTION_COMMIT
+        }
+
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+        val braintreeClient = MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient)
+        sut.createPaymentAuthRequest(activity, payPalCheckoutRequest, paymentAuthCallback)
+
+        verify {
+            analyticsParamRepository.merchantPassedUserAction = "pay"
+        }
+    }
+
+    @Test
+    fun createPaymentAuthRequest_whenUserActionIsNull_setsMerchantPassedUserActionToNone() {
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true).apply {
+            userAction = null
+        }
+
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+        val braintreeClient = MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient)
+        sut.createPaymentAuthRequest(activity, payPalCheckoutRequest, paymentAuthCallback)
+
+        verify {
+            analyticsParamRepository.merchantPassedUserAction = "none"
+        }
+    }
+
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalVaultRequestUnitTest.kt
@@ -398,4 +398,54 @@ class PayPalVaultRequestUnitTest {
 
         assertTrue(requestBody.contains("\"payer_phone\":{\"country_code\":\"1\",\"national_number\":\"1231231234\"}"))
     }
+
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and sets user_action when it is USER_ACTION_SETUP_NOW`() {
+        val request = PayPalVaultRequest(
+            hasUserLocationConsent = true,
+            userAction = PayPalPaymentUserAction.USER_ACTION_SETUP_NOW
+        )
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertTrue(jsonObject.has("experience_profile"))
+
+        val experienceProfile = jsonObject.getJSONObject("experience_profile")
+        assertTrue(experienceProfile.has("user_action"))
+        assertEquals(
+            PayPalPaymentUserAction.USER_ACTION_SETUP_NOW.stringValue,
+            experienceProfile.getString("user_action")
+        )
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set userAction when it is null`() {
+        val request = PayPalVaultRequest(
+            hasUserLocationConsent = true,
+            userAction = null
+        )
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertTrue(jsonObject.has("experience_profile"))
+
+        val experienceProfile = jsonObject.getJSONObject("experience_profile")
+        assertFalse(experienceProfile.has("user_action"))
+    }
 }


### PR DESCRIPTION
### Summary of changes
Add the merchant-passed user action to the analytics event payload. Ensuring both explicit and default values are handled and logged for every event. 

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Author
Muskan Sanghai

<img width="2016" height="278" alt="image (1)" src="https://github.com/user-attachments/assets/267c1b49-2c2b-46f3-b0f3-efdb625eba41" />
<img width="2016" height="278" alt="image (2)" src="https://github.com/user-attachments/assets/811ac46b-ffdf-4c8c-917c-e9b8ee6ad488" />
<img width="2016" height="278" alt="image (3)" src="https://github.com/user-attachments/assets/a8c2f713-88c1-40de-853b-9aa31a5d6d0c" />