### PR TITLE
Fix path for SEPA APIs

### DIFF
--- a/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApi.kt
+++ b/SEPADirectDebit/src/main/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApi.kt
@@ -15,7 +15,7 @@ internal class SEPADirectDebitApi(private val braintreeClient: BraintreeClient) 
         try {
             val jsonObject =
                 buildCreateMandateRequest(sepaDirectDebitRequest, returnUrlScheme)
-            val url = "v1/sepa_debit"
+            val url = "/v1/sepa_debit"
             braintreeClient.sendPOST(
                 url,
                 jsonObject.toString()
@@ -46,7 +46,7 @@ internal class SEPADirectDebitApi(private val braintreeClient: BraintreeClient) 
         try {
             val jsonObject =
                 buildTokenizeRequest(ibanLastFour, customerId, bankReferenceToken, mandateType)
-            val url = "v1/payment_methods/sepa_debit_accounts"
+            val url = "/v1/payment_methods/sepa_debit_accounts"
             braintreeClient.sendPOST(
                 url,
                 jsonObject.toString()

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApiUnitTest.java
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitApiUnitTest.java
@@ -184,7 +184,7 @@ public class SEPADirectDebitApiUnitTest {
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(mockBraintreeClient).sendPOST(
-                eq("v1/sepa_debit"),
+                eq("/v1/sepa_debit"),
                 captor.capture(),
                 any(),
                 any(HttpResponseCallback.class)


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Add missing `/` for SEPA APIs

### Checklist

 - [ ] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

