### PR TITLE
Unify unit test assertions

### DIFF
--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
@@ -55,7 +55,7 @@ class AmericanExpressClientUnitTest {
         verify { amexRewardsCallback.onAmericanExpressResult(capture(amexRewardsSlot)) }
 
         val result = amexRewardsSlot.captured
-        assertTrue { result is AmericanExpressResult.Success }
+        assertTrue(result is AmericanExpressResult.Success)
 
         val rewardsBalance = (result as AmericanExpressResult.Success).rewardsBalance
         assertNotNull(rewardsBalance)
@@ -81,7 +81,7 @@ class AmericanExpressClientUnitTest {
         verify { amexRewardsCallback.onAmericanExpressResult(capture(amexRewardsSlot)) }
 
         val result = amexRewardsSlot.captured
-        assertTrue { result is AmericanExpressResult.Success }
+        assertTrue(result is AmericanExpressResult.Success)
 
         val rewardsBalance = (result as AmericanExpressResult.Success).rewardsBalance
         assertNotNull(rewardsBalance)
@@ -107,7 +107,7 @@ class AmericanExpressClientUnitTest {
         verify { amexRewardsCallback.onAmericanExpressResult(capture(amexRewardsSlot)) }
 
         val result = amexRewardsSlot.captured
-        assertTrue { result is AmericanExpressResult.Success }
+        assertTrue(result is AmericanExpressResult.Success)
 
         val rewardsBalance = (result as AmericanExpressResult.Success).rewardsBalance
         assertNotNull(rewardsBalance)
@@ -134,7 +134,7 @@ class AmericanExpressClientUnitTest {
         verify { amexRewardsCallback.onAmericanExpressResult(capture(amexRewardsSlot)) }
 
         val result = amexRewardsSlot.captured
-        assertTrue { result is AmericanExpressResult.Failure }
+        assertTrue(result is AmericanExpressResult.Failure)
 
         val actualError = (result as AmericanExpressResult.Failure).error
         assertEquals(expectedError, actualError)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -68,7 +68,7 @@ class ConfigurationLoaderUnitTest {
         val successSlot = slot<ConfigurationLoaderResult>()
         verify { callback.onResult(capture(successSlot)) }
 
-        assertTrue { successSlot.captured is ConfigurationLoaderResult.Success }
+        assertTrue(successSlot.captured is ConfigurationLoaderResult.Success)
     }
 
     @Test
@@ -128,7 +128,7 @@ class ConfigurationLoaderUnitTest {
         val errorSlot = slot<ConfigurationLoaderResult>()
         verify { callback.onResult(capture(errorSlot)) }
 
-        assertTrue { (errorSlot.captured as ConfigurationLoaderResult.Failure).error is JSONException }
+        assertTrue((errorSlot.captured as ConfigurationLoaderResult.Failure).error is JSONException)
     }
 
     @Test
@@ -201,7 +201,7 @@ class ConfigurationLoaderUnitTest {
         val successSlot = slot<ConfigurationLoaderResult>()
         verify { callback.onResult(capture(successSlot)) }
 
-        assertTrue { successSlot.captured is ConfigurationLoaderResult.Success }
+        assertTrue(successSlot.captured is ConfigurationLoaderResult.Success)
     }
 
     @Test
@@ -244,7 +244,7 @@ class ConfigurationLoaderUnitTest {
         val successSlot = slot<ConfigurationLoaderResult>()
         verify { callback.onResult(capture(successSlot)) }
 
-        assertTrue { successSlot.captured is ConfigurationLoaderResult.Success }
+        assertTrue(successSlot.captured is ConfigurationLoaderResult.Success)
     }
 
     @Test
@@ -272,7 +272,7 @@ class ConfigurationLoaderUnitTest {
         verify { callback.onResult(capture(errorSlot)) }
 
         val failure = errorSlot.captured as ConfigurationLoaderResult.Failure
-        assertTrue { failure.error is ConfigurationException }
+        assertTrue(failure.error is ConfigurationException)
         assertEquals("Configuration responseBody is null", failure.error.message)
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkUseCaseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/GetReturnLinkUseCaseUnitTest.kt
@@ -53,7 +53,7 @@ class GetReturnLinkUseCaseUnitTest {
 
         val result = subject()
 
-        assertTrue { result is GetReturnLinkUseCase.ReturnLinkResult.Failure }
+        assertTrue(result is GetReturnLinkUseCase.ReturnLinkResult.Failure)
         assertEquals(
             "Deep Link fallback return url is null",
             (result as GetReturnLinkUseCase.ReturnLinkResult.Failure).exception.message
@@ -67,7 +67,7 @@ class GetReturnLinkUseCaseUnitTest {
 
         val result = subject()
 
-        assertTrue { result is GetReturnLinkUseCase.ReturnLinkResult.Failure }
+        assertTrue(result is GetReturnLinkUseCase.ReturnLinkResult.Failure)
         assertEquals(
             "App Link Return Uri is null",
             (result as GetReturnLinkUseCase.ReturnLinkResult.Failure).exception.message

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayRequestUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayRequestUnitTest.kt
@@ -34,12 +34,12 @@ class GooglePayRequestUnitTest {
         request.setEnvironment("production")
         request.googleMerchantName = "google-merchant-name"
 
-        assertTrue { request.allowPrepaidCards }
+        assertTrue(request.allowPrepaidCards)
         assertEquals(GooglePayBillingAddressFormat.FULL, request.billingAddressFormat)
-        assertTrue { request.isBillingAddressRequired }
-        assertTrue { request.isEmailRequired }
-        assertTrue { request.isPhoneNumberRequired }
-        assertTrue { request.isShippingAddressRequired }
+        assertTrue(request.isBillingAddressRequired)
+        assertTrue(request.isEmailRequired)
+        assertTrue(request.isPhoneNumberRequired)
+        assertTrue(request.isShippingAddressRequired)
         assertEquals(shippingAddressRequirements, request.shippingAddressParameters)
         assertEquals("USD", request.currencyCode)
         assertEquals("1.00", request.totalPrice)
@@ -53,13 +53,13 @@ class GooglePayRequestUnitTest {
     fun `sets default values via constructor`() {
         val request = GooglePayRequest("USD", "1.00", GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL)
 
-        assertFalse { request.allowPrepaidCards }
+        assertFalse(request.allowPrepaidCards)
         assertEquals(GooglePayBillingAddressFormat.MIN, request.billingAddressFormat)
-        assertFalse { request.isBillingAddressRequired }
-        assertFalse { request.isEmailRequired }
-        assertFalse { request.isPhoneNumberRequired }
-        assertFalse { request.isShippingAddressRequired }
-        assertTrue { request.allowCreditCards }
+        assertFalse(request.isBillingAddressRequired)
+        assertFalse(request.isEmailRequired)
+        assertFalse(request.isPhoneNumberRequired)
+        assertFalse(request.isShippingAddressRequired)
+        assertTrue(request.allowCreditCards)
         assertNull(request.getEnvironment())
         assertNull(request.googleMerchantName)
     }
@@ -91,13 +91,13 @@ class GooglePayRequestUnitTest {
         assertEquals("1.00", parceled.totalPrice)
         assertEquals(GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL, parceled.totalPriceStatus)
         assertEquals("test", parceled.totalPriceLabel)
-        assertTrue { parceled.isEmailRequired }
-        assertTrue { parceled.isPhoneNumberRequired }
-        assertTrue { parceled.isShippingAddressRequired }
-        assertTrue { parceled.isBillingAddressRequired }
+        assertTrue(parceled.isEmailRequired)
+        assertTrue(parceled.isPhoneNumberRequired)
+        assertTrue(parceled.isShippingAddressRequired)
+        assertTrue(parceled.isBillingAddressRequired)
         assertEquals(GooglePayBillingAddressFormat.FULL, parceled.billingAddressFormat)
         assertTrue { parceled.shippingAddressParameters?.allowedCountryCodes?.contains("US") == true }
-        assertTrue { parceled.allowPrepaidCards }
+        assertTrue(parceled.allowPrepaidCards)
         assertEquals("PRODUCTION", parceled.getEnvironment())
     }
 
@@ -119,13 +119,13 @@ class GooglePayRequestUnitTest {
         assertEquals("USD", parceled.currencyCode)
         assertEquals("1.00", parceled.totalPrice)
         assertEquals(GooglePayTotalPriceStatus.TOTAL_PRICE_STATUS_FINAL, parceled.totalPriceStatus)
-        assertFalse { parceled.isEmailRequired }
-        assertFalse { parceled.isPhoneNumberRequired }
-        assertFalse { parceled.isShippingAddressRequired }
-        assertFalse { parceled.isBillingAddressRequired }
+        assertFalse(parceled.isEmailRequired)
+        assertFalse(parceled.isPhoneNumberRequired)
+        assertFalse(parceled.isShippingAddressRequired)
+        assertFalse(parceled.isBillingAddressRequired)
         assertEquals(GooglePayBillingAddressFormat.FULL, parceled.billingAddressFormat)
         assertTrue { parceled.shippingAddressParameters?.allowedCountryCodes?.contains("US") == true }
-        assertFalse { parceled.allowPrepaidCards }
+        assertFalse(parceled.allowPrepaidCards)
         assertNull(parceled.getEnvironment())
         assertNull(parceled.googleMerchantName)
         assertNull(parceled.totalPriceLabel)

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -136,7 +136,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertTrue(result is ShopperInsightsResult.Failure)
                     assertEquals((result as ShopperInsightsResult.Failure).error, expectedError)
                 }
             )
@@ -156,7 +156,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertTrue(result is ShopperInsightsResult.Failure)
                     assertTrue {
                         (result as ShopperInsightsResult.Failure).error is BraintreeException
                     }
@@ -182,7 +182,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Failure }
+                    assertTrue(result is ShopperInsightsResult.Failure)
                     assertTrue {
                         (result as ShopperInsightsResult.Failure).error is BraintreeException
                     }
@@ -219,7 +219,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertEquals(true, success.response.isPayPalRecommended)
                     assertEquals(true, success.response.isVenmoRecommended)
@@ -251,7 +251,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertEquals(false, success.response.isPayPalRecommended)
                 }
@@ -282,7 +282,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertEquals(false, success.response.isPayPalRecommended)
                 }
@@ -313,7 +313,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertTrue(success.response.isEligibleInPayPalNetwork)
                 }
@@ -344,7 +344,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertTrue(success.response.isEligibleInPayPalNetwork)
                 }
@@ -380,7 +380,7 @@ class ShopperInsightsClientUnitTest {
         verify {
             callback.onResult(
                 withArg { result ->
-                    assertTrue { result is ShopperInsightsResult.Success }
+                    assertTrue(result is ShopperInsightsResult.Success)
                     val success = result as ShopperInsightsResult.Success
                     assertFalse(success.response.isEligibleInPayPalNetwork)
                 }
@@ -426,7 +426,7 @@ class ShopperInsightsClientUnitTest {
 
         val request = ShopperInsightsRequest("some-email", null)
         sut.getRecommendedPaymentMethods(request) { result ->
-            assertTrue { result is ShopperInsightsResult.Failure }
+            assertTrue(result is ShopperInsightsResult.Failure)
             assertTrue {
                 (result as ShopperInsightsResult.Failure).error is BraintreeException
             }
@@ -523,25 +523,25 @@ class ShopperInsightsClientUnitTest {
     @Test
     fun `test isPayPalAppInstalled returns true when deviceInspector returns true`() {
         every { deviceInspector.isPayPalInstalled() } returns true
-        assertTrue { sut.isPayPalAppInstalled(context) }
+        assertTrue(sut.isPayPalAppInstalled(context))
     }
 
     @Test
     fun `test isVenmoAppInstalled returns true when deviceInspector returns true`() {
         every { deviceInspector.isVenmoInstalled(context) } returns true
-        assertTrue { sut.isVenmoAppInstalled(context) }
+        assertTrue(sut.isVenmoAppInstalled(context))
     }
 
     @Test
     fun `test isPayPalAppInstalled returns false when deviceInspector returns false`() {
         every { deviceInspector.isPayPalInstalled() } returns false
-        assertFalse { sut.isPayPalAppInstalled(context) }
+        assertFalse(sut.isPayPalAppInstalled(context))
     }
 
     @Test
     fun `test isVenmoAppInstalled returns false when deviceInspector returns false`() {
         every { deviceInspector.isVenmoInstalled(context) } returns false
-        assertFalse { sut.isVenmoAppInstalled(context) }
+        assertFalse(sut.isVenmoAppInstalled(context))
     }
 
     private fun executeTestForFindEligiblePaymentsApi(

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/ShopperInsightsClientUnitTest.kt
@@ -157,9 +157,9 @@ class ShopperInsightsClientUnitTest {
             callback.onResult(
                 withArg { result ->
                     assertTrue(result is ShopperInsightsResult.Failure)
-                    assertTrue {
+                    assertTrue(
                         (result as ShopperInsightsResult.Failure).error is BraintreeException
-                    }
+                    )
                     assertEquals(
                         "Required fields missing from API response body",
                         (result as ShopperInsightsResult.Failure).error.message
@@ -183,9 +183,9 @@ class ShopperInsightsClientUnitTest {
             callback.onResult(
                 withArg { result ->
                     assertTrue(result is ShopperInsightsResult.Failure)
-                    assertTrue {
+                    assertTrue(
                         (result as ShopperInsightsResult.Failure).error is BraintreeException
-                    }
+                    )
                     assertEquals(
                         "Required fields missing from API response body",
                         (result as ShopperInsightsResult.Failure).error.message
@@ -427,9 +427,9 @@ class ShopperInsightsClientUnitTest {
         val request = ShopperInsightsRequest("some-email", null)
         sut.getRecommendedPaymentMethods(request) { result ->
             assertTrue(result is ShopperInsightsResult.Failure)
-            assertTrue {
+            assertTrue(
                 (result as ShopperInsightsResult.Failure).error is BraintreeException
-            }
+            )
             assertEquals(
                 "Invalid authorization. This feature can only be used with a client token.",
                 (result as ShopperInsightsResult.Failure).error.message

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAdditionalInformationUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAdditionalInformationUnitTest.kt
@@ -225,54 +225,54 @@ class ThreeDSecureAdditionalInformationUnitTest {
 
         val jsonParams = additionalInformation.toJson()
 
-        assertTrue { jsonParams.isNull("shipping_given_name") }
-        assertTrue { jsonParams.isNull("shipping_surname") }
-        assertTrue { jsonParams.isNull("shipping_phone") }
-        assertTrue { jsonParams.isNull("shipping_line1") }
-        assertTrue { jsonParams.isNull("shipping_line2") }
-        assertTrue { jsonParams.isNull("shipping_line3") }
-        assertTrue { jsonParams.isNull("shipping_city") }
-        assertTrue { jsonParams.isNull("shipping_state") }
-        assertTrue { jsonParams.isNull("shipping_postal_code") }
-        assertTrue { jsonParams.isNull("shipping_country_code") }
-        assertTrue { jsonParams.isNull("shipping_method_indicator") }
-        assertTrue { jsonParams.isNull("product_code") }
-        assertTrue { jsonParams.isNull("delivery_timeframe") }
-        assertTrue { jsonParams.isNull("delivery_email") }
-        assertTrue { jsonParams.isNull("reorder_indicator") }
-        assertTrue { jsonParams.isNull("preorder_indicator") }
-        assertTrue { jsonParams.isNull("preorder_date") }
-        assertTrue { jsonParams.isNull("gift_card_amount") }
-        assertTrue { jsonParams.isNull("gift_card_currency_code") }
-        assertTrue { jsonParams.isNull("gift_card_count") }
-        assertTrue { jsonParams.isNull("account_age_indicator") }
-        assertTrue { jsonParams.isNull("account_create_date") }
-        assertTrue { jsonParams.isNull("account_change_indicator") }
-        assertTrue { jsonParams.isNull("account_change_date") }
-        assertTrue { jsonParams.isNull("account_pwd_change_indicator") }
-        assertTrue { jsonParams.isNull("account_pwd_change_date") }
-        assertTrue { jsonParams.isNull("shipping_address_usage_indicator") }
-        assertTrue { jsonParams.isNull("shipping_address_usage_date") }
-        assertTrue { jsonParams.isNull("transaction_count_day") }
-        assertTrue { jsonParams.isNull("transaction_count_year") }
-        assertTrue { jsonParams.isNull("add_card_attempts") }
-        assertTrue { jsonParams.isNull("account_purchases") }
-        assertTrue { jsonParams.isNull("fraud_activity") }
-        assertTrue { jsonParams.isNull("shipping_name_indicator") }
-        assertTrue { jsonParams.isNull("payment_account_indicator") }
-        assertTrue { jsonParams.isNull("payment_account_age") }
-        assertTrue { jsonParams.isNull("address_match") }
-        assertTrue { jsonParams.isNull("account_id") }
-        assertTrue { jsonParams.isNull("ip_address") }
-        assertTrue { jsonParams.isNull("order_description") }
-        assertTrue { jsonParams.isNull("tax_amount") }
-        assertTrue { jsonParams.isNull("user_agent") }
-        assertTrue { jsonParams.isNull("authentication_indicator") }
-        assertTrue { jsonParams.isNull("installment") }
-        assertTrue { jsonParams.isNull("purchase_date") }
-        assertTrue { jsonParams.isNull("recurring_end") }
-        assertTrue { jsonParams.isNull("recurring_frequency") }
-        assertTrue { jsonParams.isNull("sdk_max_timeout") }
-        assertTrue { jsonParams.isNull("work_phone_number") }
+        assertTrue(jsonParams.isNull("shipping_given_name"))
+        assertTrue(jsonParams.isNull("shipping_surname"))
+        assertTrue(jsonParams.isNull("shipping_phone"))
+        assertTrue(jsonParams.isNull("shipping_line1"))
+        assertTrue(jsonParams.isNull("shipping_line2"))
+        assertTrue(jsonParams.isNull("shipping_line3"))
+        assertTrue(jsonParams.isNull("shipping_city"))
+        assertTrue(jsonParams.isNull("shipping_state"))
+        assertTrue(jsonParams.isNull("shipping_postal_code"))
+        assertTrue(jsonParams.isNull("shipping_country_code"))
+        assertTrue(jsonParams.isNull("shipping_method_indicator"))
+        assertTrue(jsonParams.isNull("product_code"))
+        assertTrue(jsonParams.isNull("delivery_timeframe"))
+        assertTrue(jsonParams.isNull("delivery_email"))
+        assertTrue(jsonParams.isNull("reorder_indicator"))
+        assertTrue(jsonParams.isNull("preorder_indicator"))
+        assertTrue(jsonParams.isNull("preorder_date"))
+        assertTrue(jsonParams.isNull("gift_card_amount"))
+        assertTrue(jsonParams.isNull("gift_card_currency_code"))
+        assertTrue(jsonParams.isNull("gift_card_count"))
+        assertTrue(jsonParams.isNull("account_age_indicator"))
+        assertTrue(jsonParams.isNull("account_create_date"))
+        assertTrue(jsonParams.isNull("account_change_indicator"))
+        assertTrue(jsonParams.isNull("account_change_date"))
+        assertTrue(jsonParams.isNull("account_pwd_change_indicator"))
+        assertTrue(jsonParams.isNull("account_pwd_change_date"))
+        assertTrue(jsonParams.isNull("shipping_address_usage_indicator"))
+        assertTrue(jsonParams.isNull("shipping_address_usage_date"))
+        assertTrue(jsonParams.isNull("transaction_count_day"))
+        assertTrue(jsonParams.isNull("transaction_count_year"))
+        assertTrue(jsonParams.isNull("add_card_attempts"))
+        assertTrue(jsonParams.isNull("account_purchases"))
+        assertTrue(jsonParams.isNull("fraud_activity"))
+        assertTrue(jsonParams.isNull("shipping_name_indicator"))
+        assertTrue(jsonParams.isNull("payment_account_indicator"))
+        assertTrue(jsonParams.isNull("payment_account_age"))
+        assertTrue(jsonParams.isNull("address_match"))
+        assertTrue(jsonParams.isNull("account_id"))
+        assertTrue(jsonParams.isNull("ip_address"))
+        assertTrue(jsonParams.isNull("order_description"))
+        assertTrue(jsonParams.isNull("tax_amount"))
+        assertTrue(jsonParams.isNull("user_agent"))
+        assertTrue(jsonParams.isNull("authentication_indicator"))
+        assertTrue(jsonParams.isNull("installment"))
+        assertTrue(jsonParams.isNull("purchase_date"))
+        assertTrue(jsonParams.isNull("recurring_end"))
+        assertTrue(jsonParams.isNull("recurring_frequency"))
+        assertTrue(jsonParams.isNull("sdk_max_timeout"))
+        assertTrue(jsonParams.isNull("work_phone_number"))
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
@@ -195,7 +195,7 @@ class VenmoClientUnitTest {
                 true
             )
         }
-        assertFalse { analyticsSlot.captured.isVaultRequest }
+        assertFalse(analyticsSlot.captured.isVaultRequest)
         assertEquals(expectedAnalyticsParams.appSwitchUrl, analyticsSlot.captured.appSwitchUrl)
         assertEquals(errorDesc, analyticsSlot.captured.errorDescription)
         verify { analyticsParamRepository.reset() }
@@ -311,7 +311,7 @@ class VenmoClientUnitTest {
                 true
             )
         }
-        assertFalse { analyticsSlot.captured.isVaultRequest }
+        assertFalse(analyticsSlot.captured.isVaultRequest)
         assertEquals(expectedAnalyticsParams.appSwitchUrl, analyticsSlot.captured.appSwitchUrl)
         assertEquals("Configuration fetching error", analyticsSlot.captured.errorDescription)
     }
@@ -343,7 +343,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
+        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
         assertEquals(
             "Venmo is not enabled",
             (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error.message
@@ -357,7 +357,7 @@ class VenmoClientUnitTest {
                 true
             )
         }
-        assertFalse { analyticsSlot.captured.isVaultRequest }
+        assertFalse(analyticsSlot.captured.isVaultRequest)
         assertEquals(expectedAnalyticsParams.appSwitchUrl, analyticsSlot.captured.appSwitchUrl)
         assertEquals("Venmo is not enabled", analyticsSlot.captured.errorDescription)
     }
@@ -478,7 +478,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
+        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
         assertEquals(exception, (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error)
     }
 
@@ -657,7 +657,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
+        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
         assertEquals(graphQLError, (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -668,7 +668,7 @@ class VenmoClientUnitTest {
                 true
             )
         }
-        assertFalse { analyticsSlot.captured.isVaultRequest }
+        assertFalse(analyticsSlot.captured.isVaultRequest)
         assertEquals(expectedAnalyticsParams.appSwitchUrl, analyticsSlot.captured.appSwitchUrl)
         assertEquals(graphQLError.message, analyticsSlot.captured.errorDescription)
     }
@@ -735,7 +735,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Cancel)
+        assertTrue { resultSlot.captured is VenmoResult.Cancel }
         verify {
             braintreeClient.sendAnalyticsEvent(
                 VenmoAnalytics.APP_SWITCH_CANCELED,
@@ -775,7 +775,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Success)
+        assertTrue { resultSlot.captured is VenmoResult.Success }
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals("fake-venmo-nonce", nonce.string)
         assertEquals("venmojoe", nonce.username)
@@ -820,7 +820,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Failure)
+        assertTrue { resultSlot.captured is VenmoResult.Failure }
         assertEquals(graphQLError, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -981,7 +981,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Success)
+        assertTrue { resultSlot.captured is VenmoResult.Success }
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals(venmoAccountNonce, nonce)
         verify {
@@ -1027,7 +1027,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Success)
+        assertTrue { resultSlot.captured is VenmoResult.Success }
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals(venmoAccountNonce, nonce)
         verify {
@@ -1068,7 +1068,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Failure)
+        assertTrue { resultSlot.captured is VenmoResult.Failure }
         assertEquals(error, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -1118,7 +1118,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue(resultSlot.captured is VenmoResult.Failure)
+        assertTrue { resultSlot.captured is VenmoResult.Failure }
         assertEquals(error, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
@@ -199,7 +199,7 @@ class VenmoClientUnitTest {
         assertEquals(expectedAnalyticsParams.appSwitchUrl, analyticsSlot.captured.appSwitchUrl)
         assertEquals(errorDesc, analyticsSlot.captured.errorDescription)
         verify { analyticsParamRepository.reset() }
-        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
+        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
         assertEquals(
             errorDesc,
             (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error.message
@@ -246,7 +246,7 @@ class VenmoClientUnitTest {
         }
 
         val paymentAuthRequest = authRequestSlot.captured
-        assertTrue { paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch }
+        assertTrue(paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch)
 
         val params = (paymentAuthRequest as VenmoPaymentAuthRequest.ReadyToLaunch).requestParams
         assertEquals(BraintreeRequestCodes.VENMO.code, params.browserSwitchOptions.requestCode)
@@ -299,7 +299,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
+        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
         assertEquals("Configuration fetching error",
             (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error.message)
 
@@ -343,7 +343,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
+        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
         assertEquals(
             "Venmo is not enabled",
             (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error.message
@@ -396,7 +396,7 @@ class VenmoClientUnitTest {
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
         val paymentAuthRequest = authRequestSlot.captured
-        assertTrue { paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch }
+        assertTrue(paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch)
         val params = (paymentAuthRequest as VenmoPaymentAuthRequest.ReadyToLaunch).requestParams
         val url = params.browserSwitchOptions.url
         assertEquals("merchant-id", url!!.getQueryParameter("braintree_merchant_id"))
@@ -434,7 +434,7 @@ class VenmoClientUnitTest {
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
         val paymentAuthRequest = authRequestSlot.captured
-        assertTrue { paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch }
+        assertTrue(paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch)
         val params = (paymentAuthRequest as VenmoPaymentAuthRequest.ReadyToLaunch).requestParams
         val url = params.browserSwitchOptions.url
         assertEquals("https://example.com/success", url!!.getQueryParameter("x-success"))
@@ -478,7 +478,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
+        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
         assertEquals(exception, (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error)
     }
 
@@ -516,7 +516,7 @@ class VenmoClientUnitTest {
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
         val paymentAuthRequest = authRequestSlot.captured
-        assertTrue { paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch }
+        assertTrue(paymentAuthRequest is VenmoPaymentAuthRequest.ReadyToLaunch)
         val params = (paymentAuthRequest as VenmoPaymentAuthRequest.ReadyToLaunch).requestParams
         val url = params.browserSwitchOptions.url
         assertEquals("second-pwv-profile-id", url!!.getQueryParameter("braintree_merchant_id"))
@@ -657,7 +657,7 @@ class VenmoClientUnitTest {
 
         val authRequestSlot = slot<VenmoPaymentAuthRequest>()
         verify { venmoPaymentAuthRequestCallback.onVenmoPaymentAuthRequest(capture(authRequestSlot)) }
-        assertTrue { authRequestSlot.captured is VenmoPaymentAuthRequest.Failure }
+        assertTrue(authRequestSlot.captured is VenmoPaymentAuthRequest.Failure)
         assertEquals(graphQLError, (authRequestSlot.captured as VenmoPaymentAuthRequest.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -735,7 +735,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Cancel }
+        assertTrue(resultSlot.captured is VenmoResult.Cancel)
         verify {
             braintreeClient.sendAnalyticsEvent(
                 VenmoAnalytics.APP_SWITCH_CANCELED,
@@ -775,7 +775,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Success }
+        assertTrue(resultSlot.captured is VenmoResult.Success)
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals("fake-venmo-nonce", nonce.string)
         assertEquals("venmojoe", nonce.username)
@@ -820,7 +820,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Failure }
+        assertTrue(resultSlot.captured is VenmoResult.Failure)
         assertEquals(graphQLError, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -981,7 +981,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Success }
+        assertTrue(resultSlot.captured is VenmoResult.Success)
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals(venmoAccountNonce, nonce)
         verify {
@@ -1027,7 +1027,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Success }
+        assertTrue(resultSlot.captured is VenmoResult.Success)
         val nonce = (resultSlot.captured as VenmoResult.Success).nonce
         assertEquals(venmoAccountNonce, nonce)
         verify {
@@ -1068,7 +1068,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Failure }
+        assertTrue(resultSlot.captured is VenmoResult.Failure)
         assertEquals(error, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()
@@ -1118,7 +1118,7 @@ class VenmoClientUnitTest {
 
         val resultSlot = slot<VenmoResult>()
         verify { venmoTokenizeCallback.onVenmoResult(capture(resultSlot)) }
-        assertTrue { resultSlot.captured is VenmoResult.Failure }
+        assertTrue(resultSlot.captured is VenmoResult.Failure)
         assertEquals(error, (resultSlot.captured as VenmoResult.Failure).error)
 
         val analyticsSlot = slot<AnalyticsEventParams>()


### PR DESCRIPTION
### Summary of changes

During the unit test conversion, we noticed there was an inconsistency between when we use lambdas for assertions and when we use the standard assertion method calls. This PR unifies the type of assertion we use. Primarily this means removing lambda assertions all together. I opted for this as we are mostly passing simple evaluations in the lambda which feels heavy handed when a simple assertion will have the same result and unified code felt more important.


### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@saralvasquez 

