### PR TITLE
Remove stale gradle-nexus-staging-plugin dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 
     dependencies {
         classpath libs.gradle
-        classpath libs.gradle.nexus.staging.plugin
         classpath libs.kotlin.gradle.plugin
         classpath libs.androidx.navigation.safe.args.gradle.plugin
         classpath libs.dokka.gradle.plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 gradle = "8.6.1"
-gradleNexusStagingPlugin = "0.21.2"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"
 kotlin = "1.9.10"
@@ -69,7 +68,6 @@ kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", vers
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
-gradle-nexus-staging-plugin = { module = "io.codearte.gradle.nexus:gradle-nexus-staging-plugin", version.ref = "gradleNexusStagingPlugin" }
 browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
 cardinal = { group = "org.jfrog.cardinalcommerce.gradle", name = "cardinalmobilesdk", version.ref = "cardinal" }
 paypal-messages = { module = "com.paypal.messages:paypal-messages", version.ref = "paypalMessages" }


### PR DESCRIPTION
### Summary of changes

 - Remove the stale `gradle-nexus-staging-plugin`

### Checklist

 - [ ] Added a changelog entry
 - [ ] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

