### PR TITLE
Add PayPal campaign support for Shopper Insights v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 * GooglePay
    * Add optional `DisplayItems` in GooglePay request
-    
+
+* ShopperInsights
+    * Add optional PayPal co-marketing campaign support (`PayPalCampaign` / `paypal_campaigns`) for Shopper Insights v2 customer session and recommendations APIs
+
 ## 5.25.0 (2026-03-31)
 
 * BraintreeCore

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
@@ -10,6 +10,8 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
  * @property payPalAppInstalled If the PayPal app is installed on the device.
  * @property venmoAppInstalled If the Venmo app is installed on the device.
  * @property purchaseUnits List of purchase units containing the amount and currency code.
+ * @property payPalCampaigns Optional campaigns; encoded on the wire as `paypal_campaigns` (aligned with iOS
+ * `BTCustomerSessionRequest`). Omitted when null or empty.
  *
  * Warning: This feature is in beta. It's public API may change or be removed in future releases.
  */
@@ -20,4 +22,5 @@ data class CustomerSessionRequest(
     var payPalAppInstalled: Boolean? = null,
     var venmoAppInstalled: Boolean? = null,
     var purchaseUnits: List<PurchaseUnit>? = null,
+    var payPalCampaigns: List<PayPalCampaign>? = null,
 )

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PayPalCampaign.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PayPalCampaign.kt
@@ -1,0 +1,16 @@
+package com.braintreepayments.api.shopperinsights.v2
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+
+/**
+ * PayPal campaign details; aligns with iOS `BTPayPalCampaign`. Each entry serializes as `{ "id": "<campaign-id>" }`.
+ *
+ * Included under the `paypal_campaigns` key in Shopper Insights v2 request variables (create/update session,
+ * generate recommendations).
+ *
+ * Warning: This feature is in beta. It's public API may change or be removed in future releases.
+ */
+@ExperimentalBetaApi
+data class PayPalCampaign(
+    val id: String,
+)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2.kt
@@ -141,6 +141,8 @@ class ShopperInsightsClientV2 internal constructor(
      *
      * @param customerSessionRequest Optional: a [CustomerSessionRequest] object containing the request parameters
      * @param sessionId Optional: The shopper session ID
+     * @param payPalCampaigns Optional: PayPal campaigns (`paypal_campaigns` on the wire); if null, uses
+     * [CustomerSessionRequest.payPalCampaigns] when [customerSessionRequest] is non-null.
      * @param customerRecommendationsCallback: a callback that returns the result of the
      * customer recommendation generation
      *
@@ -149,10 +151,15 @@ class ShopperInsightsClientV2 internal constructor(
     fun generateCustomerRecommendations(
         customerSessionRequest: CustomerSessionRequest? = null,
         sessionId: String? = null,
+        payPalCampaigns: List<PayPalCampaign>? = null,
         customerRecommendationsCallback: (customerRecommendationsResult: CustomerRecommendationsResult) -> Unit
     ) {
         coroutineScope.launch {
-            val result = generateCustomerRecommendations(customerSessionRequest, sessionId)
+            val result = generateCustomerRecommendations(
+                customerSessionRequest,
+                sessionId,
+                payPalCampaigns
+            )
             customerRecommendationsCallback(result)
         }
     }
@@ -160,11 +167,16 @@ class ShopperInsightsClientV2 internal constructor(
     private suspend fun generateCustomerRecommendations(
         customerSessionRequest: CustomerSessionRequest? = null,
         sessionId: String? = null,
+        payPalCampaigns: List<PayPalCampaign>? = null,
     ): CustomerRecommendationsResult {
         analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
         return when (
             val generateCustomerRecommendationsResult =
-                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+                generateCustomerRecommendationsApi.execute(
+                    customerSessionRequest,
+                    sessionId,
+                    payPalCampaigns
+                )
         ) {
             is GenerateCustomerRecommendationsResult.Success -> {
                 analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_SUCCEEDED)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApi.kt
@@ -56,6 +56,7 @@ internal class CreateCustomerSessionApi(
         val input = JSONObject().apply {
             put(CUSTOMER, jsonRequestObjects.customer)
             putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+            putOpt(PAYPAL_CAMPAIGNS, jsonRequestObjects.payPalCampaigns)
         }
 
         return JSONObject().put(INPUT, input)
@@ -67,6 +68,8 @@ internal class CreateCustomerSessionApi(
         private const val INPUT = "input"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        /** Matches iOS `Variables` encoding key; wire name is snake_case. */
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val CREATE_CUSTOMER_SESSION = "createCustomerSession"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -14,6 +15,7 @@ class CustomerSessionRequestBuilder {
     internal data class JsonRequestObjects(
         val customer: JSONObject,
         val purchaseUnits: JSONArray?,
+        val payPalCampaigns: JSONArray? = null,
     )
 
     internal fun createRequestObjects(customerSessionRequest: CustomerSessionRequest): JsonRequestObjects {
@@ -42,7 +44,22 @@ class CustomerSessionRequestBuilder {
                 }
             }
 
-        return JsonRequestObjects(customer, purchaseUnits)
+        val payPalCampaigns = payPalCampaignsToJson(customerSessionRequest.payPalCampaigns)
+
+        return JsonRequestObjects(customer, purchaseUnits, payPalCampaigns)
+    }
+
+    /**
+     * Builds the JSON array for `paypal_campaigns` (each element `{ "id": "..." }`, same as iOS `BTPayPalCampaign`).
+     */
+    internal fun payPalCampaignsToJson(payPalCampaigns: List<PayPalCampaign>?): JSONArray? {
+        return payPalCampaigns?.takeIf { it.isNotEmpty() }?.let { campaigns ->
+            JSONArray().apply {
+                campaigns.forEach { campaign ->
+                    put(JSONObject().put(CAMPAIGN_ID_KEY, campaign.id))
+                }
+            }
+        }
     }
 
     private companion object {
@@ -53,5 +70,6 @@ class CustomerSessionRequestBuilder {
         private const val AMOUNT = "amount"
         private const val VALUE = "value"
         private const val CURRENCY_CODE = "currencyCode"
+        private const val CAMPAIGN_ID_KEY = "id"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
@@ -4,6 +4,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
 import org.json.JSONException
 import org.json.JSONObject
@@ -28,7 +29,8 @@ internal class GenerateCustomerRecommendationsApi(
 
     suspend fun execute(
         customerSessionRequest: CustomerSessionRequest?,
-        sessionId: String?
+        sessionId: String?,
+        payPalCampaigns: List<PayPalCampaign>? = null,
     ): GenerateCustomerRecommendationsResult {
         return try {
             val params = JSONObject()
@@ -47,7 +49,10 @@ internal class GenerateCustomerRecommendationsApi(
                 """.trimIndent()
             )
 
-            params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
+            params.put(
+                VARIABLES,
+                assembleVariables(sessionId, customerSessionRequest, payPalCampaigns)
+            )
 
             try {
                 val responseBody = braintreeClient.sendGraphQLPOST(params)
@@ -64,10 +69,16 @@ internal class GenerateCustomerRecommendationsApi(
     @Throws(JSONException::class)
     private fun assembleVariables(
         sessionId: String?,
-        customerSessionRequest: CustomerSessionRequest?
+        customerSessionRequest: CustomerSessionRequest?,
+        payPalCampaigns: List<PayPalCampaign>?,
     ): JSONObject {
         val input = JSONObject().apply {
             putOpt(SESSION_ID, sessionId)
+
+            val campaignsJson = customerSessionRequestBuilder.payPalCampaignsToJson(
+                payPalCampaigns ?: customerSessionRequest?.payPalCampaigns
+            )
+            putOpt(PAYPAL_CAMPAIGNS, campaignsJson)
 
             if (customerSessionRequest != null) {
                 val jsonRequestObjects = customerSessionRequestBuilder.createRequestObjects(customerSessionRequest)
@@ -114,6 +125,8 @@ internal class GenerateCustomerRecommendationsApi(
         private const val SESSION_ID = "sessionId"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        /** Matches iOS `Variables` encoding key; wire name is snake_case. */
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val GENERATE_CUSTOMER_RECOMMENDATIONS = "generateCustomerRecommendations"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -63,6 +63,7 @@ internal class UpdateCustomerSessionApi(
             put(SESSION_ID, sessionId)
             put(CUSTOMER, jsonRequestObjects.customer)
             putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+            putOpt(PAYPAL_CAMPAIGNS, jsonRequestObjects.payPalCampaigns)
         }
 
         return JSONObject().put(INPUT, input)
@@ -75,6 +76,7 @@ internal class UpdateCustomerSessionApi(
         private const val SESSION_ID = "sessionId"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val UPDATE_CUSTOMER_SESSION = "updateCustomerSession"
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
@@ -226,7 +226,7 @@ class ShopperInsightsClientV2UnitTest {
         val recommendations = mockk<CustomerRecommendations>()
 
         coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
         } answers {
             GenerateCustomerRecommendationsResult.Success(recommendations)
         }
@@ -247,7 +247,7 @@ class ShopperInsightsClientV2UnitTest {
         val error = Exception("Test error")
 
         coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
         } answers {
             GenerateCustomerRecommendationsResult.Error(error)
         }
@@ -348,7 +348,7 @@ class ShopperInsightsClientV2UnitTest {
         val recommendations = mockk<CustomerRecommendations>()
 
         coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
         } answers {
             GenerateCustomerRecommendationsResult.Success(recommendations)
         }
@@ -370,7 +370,7 @@ class ShopperInsightsClientV2UnitTest {
         val error = Exception("Test error")
 
         coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
         } answers {
             GenerateCustomerRecommendationsResult.Error(error)
         }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.CreateCustomerSessionApi.CreateCustomerSessionResult
 import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
@@ -221,4 +222,79 @@ class CreateCustomerSessionApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
+        runTest(testDispatcher) {
+            val requestWithCampaigns = customerSessionRequest.copy(
+                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+            )
+
+            val responseBody = """
+            {
+                "data": {
+                    "createCustomerSession": {
+                        "sessionId": "test-session-id"
+                    }
+                }
+            }
+            """.trimIndent()
+
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
+
+            val createCustomerSessionApi = CreateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                responseParser = mockk {
+                    every { parseSessionId(responseBody, "createCustomerSession") } returns "test-session-id"
+                }
+            )
+
+            createCustomerSessionApi.execute(requestWithCampaigns)
+            advanceUntilIdle()
+
+            val expectedRequestBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation CreateCustomerSession(${'$'}input: CreateCustomerSessionInput!) {
+                    createCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put("input", JSONObject().apply {
+                            put("customer", JSONObject().apply {
+                                put("hashedEmail", "hashedEmail")
+                                put("hashedPhoneNumber", "hashedPhoneNumber")
+                                put("paypalAppInstalled", true)
+                                put("venmoAppInstalled", false)
+                            })
+                            put(
+                                "paypal_campaigns",
+                                JSONArray().apply {
+                                    put(
+                                        JSONObject().apply {
+                                            put("id", "PPL-MOCK-CAMPAIGN")
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+                })
+            }
+        }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import org.json.JSONArray
 import org.json.JSONObject
@@ -76,5 +77,45 @@ class CustomerSessionRequestBuilderUnitTest {
 
         JSONAssert.assertEquals(expectedCustomer, result.customer, false)
         assertNull(result.purchaseUnits)
+    }
+
+    @Test
+    fun `createRequestObjects includes payPalCampaigns when provided`() {
+        val customerSessionRequest = CustomerSessionRequest(
+            hashedEmail = "hashedEmail",
+            hashedPhoneNumber = "hashedPhoneNumber",
+            payPalAppInstalled = true,
+            venmoAppInstalled = false,
+            purchaseUnits = null,
+            payPalCampaigns = listOf(
+                PayPalCampaign(id = "PPL-TT-10OFF"),
+                PayPalCampaign(id = "PPL-OTHER-MOCK")
+            )
+        )
+
+        val result = requestBuilder.createRequestObjects(customerSessionRequest)
+
+        val expectedCampaigns = JSONArray().apply {
+            put(JSONObject().put("id", "PPL-TT-10OFF"))
+            put(JSONObject().put("id", "PPL-OTHER-MOCK"))
+        }
+
+        JSONAssert.assertEquals(expectedCampaigns, result.payPalCampaigns, false)
+    }
+
+    @Test
+    fun `createRequestObjects omits payPalCampaigns when null or empty`() {
+        val withNull = CustomerSessionRequest(
+            hashedEmail = "e",
+            hashedPhoneNumber = "p",
+            payPalAppInstalled = false,
+            venmoAppInstalled = false,
+            purchaseUnits = null,
+            payPalCampaigns = null
+        )
+        assertNull(requestBuilder.createRequestObjects(withNull).payPalCampaigns)
+
+        val withEmpty = withNull.copy(payPalCampaigns = emptyList())
+        assertNull(requestBuilder.createRequestObjects(withEmpty).payPalCampaigns)
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -4,6 +4,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult
@@ -241,4 +242,64 @@ class GenerateCustomerRecommendationsApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with sessionId and payPalCampaigns only, GraphQL variables include campaigns`() =
+        runTest(testDispatcher) {
+            val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+            val realBuilder = CustomerSessionRequestBuilder()
+            val generateApi = GenerateCustomerRecommendationsApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = realBuilder
+            )
+
+            generateApi.execute(
+                customerSessionRequest = null,
+                sessionId = "test-session-id",
+                payPalCampaigns = listOf(PayPalCampaign(id = "RECOMMENDED_OFFER_1"))
+            )
+            advanceUntilIdle()
+
+            val expectedBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                    generateCustomerRecommendations(input: ${'$'}input) {
+                        sessionId
+                        isInPayPalNetwork
+                        paymentRecommendations {
+                            paymentOption
+                            recommendedPriority
+                        }
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put(
+                            "input",
+                            JSONObject().apply {
+                                put("sessionId", "test-session-id")
+                                put(
+                                    "paypal_campaigns",
+                                    JSONArray().apply {
+                                        put(JSONObject().put("id", "RECOMMENDED_OFFER_1"))
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actual ->
+                    JSONAssert.assertEquals(expectedBody, actual, false)
+                })
+            }
+        }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.UpdateCustomerSessionApi.UpdateCustomerSessionResult
 import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
@@ -203,4 +204,80 @@ class UpdateCustomerSessionApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
+        runTest(testDispatcher) {
+            val requestWithCampaigns = customerSessionRequest.copy(
+                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+            )
+
+            val responseBody = """
+            {
+                "data": {
+                    "updateCustomerSession": {
+                        "sessionId": "$sessionId"
+                    }
+                }
+            }
+            """.trimIndent()
+
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
+
+            val updateCustomerSessionApi = UpdateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                responseParser = mockk {
+                    every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+                }
+            )
+
+            updateCustomerSessionApi.execute(requestWithCampaigns, sessionId)
+            advanceUntilIdle()
+
+            val expectedRequestBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
+                    updateCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put("input", JSONObject().apply {
+                            put("sessionId", sessionId)
+                            put("customer", JSONObject().apply {
+                                put("hashedEmail", "hashedEmail")
+                                put("hashedPhoneNumber", "hashedPhoneNumber")
+                                put("paypalAppInstalled", true)
+                                put("venmoAppInstalled", false)
+                            })
+                            put(
+                                "paypal_campaigns",
+                                JSONArray().apply {
+                                    put(
+                                        JSONObject().apply {
+                                            put("id", "PPL-MOCK-CAMPAIGN")
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+                })
+            }
+        }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

1. Add public PayPalCampaign (id) for Shopper Insights v2, aligned with iOS BTPayPalCampaign encoding ({ "id": "..." } per entry).
2. Extend CustomerSessionRequest with optional payPalCampaigns and wire it through CustomerSessionRequestBuilder.
3. Include paypal_campaigns in GraphQL variables for create session, update session, and generate customer recommendations APIs.
4. Extend ShopperInsightsClientV2 so generateCustomerRecommendations (and related overloads) accept optional payPalCampaigns, merging with the request when present.
5. Add/update unit tests asserting paypal_campaigns appears correctly in request JSON.


### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

