### PR TITLE
LI- Fix crashes caused by uncaught exception

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * This API call sends analytic events to FPTI.
@@ -43,7 +44,7 @@ internal class AnalyticsApi(
                     authorization = merchantRepository.authorization,
                 )
             } catch (e: Exception) {
-                // no op - failure to send analytics should not impact the user experience
+                if (e is CancellationException) throw e
             }
         }
     }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/AnalyticsApi.kt
@@ -11,6 +11,7 @@ import org.json.JSONObject
 /**
  * This API call sends analytic events to FPTI.
  */
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
 internal class AnalyticsApi(
     private val httpClient: BraintreeHttpClient = BraintreeHttpClient(),
     private val deviceInspector: DeviceInspector = DeviceInspectorProvider().deviceInspector,
@@ -34,12 +35,16 @@ internal class AnalyticsApi(
         val analyticsRequest =
             createFPTIPayload(merchantRepository.authorization, jsonEvents, metadata)
         coroutineScope.launch {
-            httpClient.post(
-                path = FPTI_ANALYTICS_URL,
-                data = analyticsRequest.toString(),
-                configuration = null,
-                authorization = merchantRepository.authorization,
-            )
+            try {
+                httpClient.post(
+                    path = FPTI_ANALYTICS_URL,
+                    data = analyticsRequest.toString(),
+                    configuration = null,
+                    authorization = merchantRepository.authorization,
+                )
+            } catch (e: Exception) {
+                // no op - failure to send analytics should not impact the user experience
+            }
         }
     }
 

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -93,8 +93,8 @@ class BraintreeClient internal constructor(
         // It ensures that the configuration is loaded and ready for use in subsequent requests.
         coroutineScope.launch {
             try {
-                val config = getConfiguration()
-            } catch (e: IOException) {
+                getConfiguration()
+            } catch (e: Exception) {
                 // no op
             }
         }

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/BraintreeClient.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Core Braintree class that handles network requests.
@@ -95,7 +96,7 @@ class BraintreeClient internal constructor(
             try {
                 getConfiguration()
             } catch (e: Exception) {
-                // no op
+                if (e is CancellationException) throw e
             }
         }
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AnalyticsApiUnitTest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.core
 
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +9,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import java.net.UnknownHostException
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -174,6 +176,21 @@ class AnalyticsApiUnitTest {
                 authorization = tokenizationKey
             )
         }
+    }
+
+    @Test
+    fun `when httpClient post throws UnknownHostException, execute does not crash`() = runTest {
+        every { merchantRepository.authorization } returns tokenizationKey
+        coEvery {
+            httpClient.post(any(), any(), any(), any())
+        } throws UnknownHostException("Unable to resolve host \"api-m.paypal.com\"")
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val testScope = TestScope(testDispatcher)
+        sut = createAnalyticsApi(testDispatcher, testScope)
+
+        sut.execute(listOf(tokenizationKeyEvent), configuration)
+        advanceUntilIdle()
     }
 
     @Suppress("LongMethod")

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
@@ -116,6 +116,22 @@ class BraintreeClientUnitTest {
     }
 
     @Test
+    fun prefetchConfiguration_whenConfigurationLoaderThrowsJSONException_doesNotCrash() = runTest(testDispatcher) {
+        val jsonException = JSONException("malformed JSON")
+        val configurationLoader = MockkConfigurationLoaderBuilder()
+            .configurationError(jsonException)
+            .build()
+
+        createBraintreeClient(
+            configurationLoader = configurationLoader,
+            testDispatcher = testDispatcher,
+            testScope = testScope
+        )
+
+        advanceUntilIdle()
+    }
+
+    @Test
     fun configuration_whenInvalidAuth_callsBackAuthError() = runTest(testDispatcher) {
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(expectedAuthException)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * GooglePay
    * Add optional `DisplayItems` in GooglePay request
+* BraintreeCore
+  * Fix crashes caused by uncaught exceptions in the configuration and analytics flows
     
 ## 5.25.0 (2026-03-31)
 


### PR DESCRIPTION
### Summary of changes

 Fix uncaught exceptions in analytics and config prefetch coroutines   
AnalyticsApi.execute() launched a fire-and-forget coroutine with no
   exception handling, causing UnknownHostException (and any other network
   error) to propagate to the thread's uncaught exception handler and
   terminate the host app. Wrap the httpClient.post() call in try-catch
   since analytics delivery is best-effort.

   BraintreeClient.prefetchConfiguration() only caught IOException, but
   ConfigurationLoader can also return a JSONException (malformed config
   response) which is not an IOException subtype and would similarly crash
   the app. Broaden the catch to Exception.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
@saralvasquez 
