### PR TITLE
adding paypal campaign support for shopper insights v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * GooglePay
    * Add optional `DisplayItems` in GooglePay request
+
+* ShopperInsights
+    * Add optional PayPal co-marketing campaign support (`PayPalCampaign` / `paypal_campaigns`) for Shopper Insights v2 customer session and recommendations APIs
     
 ## 5.25.0 (2026-03-31)
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
@@ -8,17 +8,26 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
@@ -91,10 +100,15 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
 
     @Composable
     private fun MainContent() {
-        Column(modifier = Modifier.padding(8.dp)) {
+        Column(
+            modifier = Modifier
+                .padding(8.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
             var emailText by rememberSaveable { mutableStateOf("PR1_merchantname@personal.example.com") }
             var countryCodeText by rememberSaveable { mutableStateOf("1") }
             var nationalNumberText by rememberSaveable { mutableStateOf("4082321001") }
+            var payPalCampaignInput by rememberSaveable { mutableStateOf("") }
 
             TextField(
                 value = emailText,
@@ -129,6 +143,64 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 enabled = true,
                 modifier = Modifier.padding(4.dp)
             )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextField(
+                    value = payPalCampaignInput,
+                    onValueChange = { payPalCampaignInput = it },
+                    label = { Text("PayPal Campaign") },
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(4.dp)
+                )
+                Button(
+                    onClick = {
+                        viewModel.addPayPalCampaign(payPalCampaignInput)
+                        payPalCampaignInput = ""
+                    }
+                ) {
+                    Text(text = "Add")
+                }
+            }
+
+            val payPalCampaigns = viewModel.payPalCampaigns.collectAsState().value
+            payPalCampaigns.forEachIndexed { index, campaign ->
+                key(index, campaign) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp, vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextField(
+                            value = campaign,
+                            onValueChange = {},
+                            readOnly = true,
+                            singleLine = true,
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(44.dp)
+                                .padding(end = 4.dp)
+                        )
+                        Button(
+                            onClick = { viewModel.removePayPalCampaignAt(index) },
+                            modifier = Modifier.height(44.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = "Remove",
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    }
+                }
+            }
 
             Button(
                 enabled = shopperInsightsClientSuccessfullyInstantiated,
@@ -185,9 +257,11 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 }
             }
 
-            val error = viewModel.error.collectAsState().value
-            if (error.isNotEmpty()) {
-                Toast.makeText(LocalContext.current, error, Toast.LENGTH_LONG).show()
+            val context = LocalContext.current
+            LaunchedEffect(Unit) {
+                viewModel.userErrors.collect { message ->
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+                }
             }
         }
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
@@ -110,6 +110,12 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
             var nationalNumberText by rememberSaveable { mutableStateOf("4082321001") }
             var payPalCampaignInput by rememberSaveable { mutableStateOf("") }
 
+            val vmSessionId by viewModel.sessionId.collectAsState()
+            var sessionIdText by rememberSaveable { mutableStateOf("") }
+            LaunchedEffect(vmSessionId) {
+                sessionIdText = vmSessionId
+            }
+
             TextField(
                 value = emailText,
                 onValueChange = { newValue -> emailText = newValue },
@@ -135,12 +141,10 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 )
             }
 
-            val currentSessionId = viewModel.sessionId.collectAsState().value
             TextField(
-                value = currentSessionId,
-                onValueChange = {},
+                value = sessionIdText,
+                onValueChange = { sessionIdText = it },
                 label = { Text("Session ID") },
-                enabled = true,
                 modifier = Modifier.padding(4.dp)
             )
 
@@ -215,7 +219,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 enabled = shopperInsightsClientSuccessfullyInstantiated,
                 onClick = {
                     viewModel.resetRecommendationsCompleted()
-                    handleUpdateCustomerSession(emailText, nationalNumberText, currentSessionId)
+                    handleUpdateCustomerSession(emailText, nationalNumberText, sessionIdText)
                 }
             ) {
                 Text(text = "Update customer session")
@@ -223,12 +227,11 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
             Button(
                 enabled = shopperInsightsClientSuccessfullyInstantiated,
                 onClick = {
-                    handleGetRecommendations(viewModel.sessionId.value)
+                    handleGetRecommendations(sessionIdText)
                 }
             ) {
                 Text(text = "Get recommendations")
             }
-            val sessionId = viewModel.sessionId.collectAsState().value
             val recommendations = viewModel.recommendations.collectAsState().value
 
             val recommendationsCompleted = viewModel.recommendationsCompleted.collectAsState().value
@@ -238,7 +241,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 if (isInPayPalNetwork && recommendations.first().paymentOption == "PAYPAL") {
                     Button(
                         enabled = true,
-                        onClick = { launchPayPalVault(emailText, countryCodeText, nationalNumberText, sessionId) }
+                        onClick = { launchPayPalVault(emailText, countryCodeText, nationalNumberText, sessionIdText) }
                     ) {
                         Text(text = "PayPal")
                     }
@@ -246,7 +249,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 if (isInPayPalNetwork && recommendations.first().paymentOption == "VENMO") {
                     Button(
                         enabled = true,
-                        onClick = { launchVenmo(sessionId) }
+                        onClick = { launchVenmo(sessionIdText) }
                     ) {
                         Text(text = "Venmo")
                     }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.demo
 
 import android.content.Context
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.ButtonOrder
 import com.braintreepayments.api.shopperinsights.ButtonType
@@ -11,12 +12,17 @@ import com.braintreepayments.api.shopperinsights.PresentmentDetails
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendationsResult
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionResult
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
 import com.braintreepayments.api.shopperinsights.v2.ShopperInsightsClientV2
 import java.security.MessageDigest
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalBetaApi::class)
 class ShopperInsightsV2ViewModel : ViewModel() {
@@ -24,11 +30,16 @@ class ShopperInsightsV2ViewModel : ViewModel() {
 
     private val _sessionId = MutableStateFlow<String>("94f0b2db-5323-4d86-add3-paypal000000")
     val sessionId: StateFlow<String> = _sessionId
+
+    private val _payPalCampaigns = MutableStateFlow<List<String>>(emptyList())
+    val payPalCampaigns: StateFlow<List<String>> = _payPalCampaigns
     @OptIn(ExperimentalBetaApi::class)
     var recommendations = MutableStateFlow<List<PaymentOptions>>(emptyList())
     var isInPayPalNetwork = MutableStateFlow<Boolean>(false)
-    var error = MutableStateFlow<String>("")
     var recommendationsCompleted = MutableStateFlow<Boolean>(false)
+
+    private val _userErrors = MutableSharedFlow<String>()
+    val userErrors: SharedFlow<String> = _userErrors.asSharedFlow()
 
     fun initShopperInsightsClient(context: Context, authString: String) {
         shopperInsightsClient = ShopperInsightsClientV2(context, authString)
@@ -36,8 +47,9 @@ class ShopperInsightsV2ViewModel : ViewModel() {
 
     fun handleCreateCustomerSession(emailText: String, nationalNumberText: String) {
         val customerSessionRequest = CustomerSessionRequest(
-            hashedEmail = emailText.sha256(),
-            hashedPhoneNumber = nationalNumberText.sha256()
+            hashedEmail = emailText.sha256Hex(),
+            hashedPhoneNumber = nationalNumberText.sha256Hex(),
+            payPalCampaigns = _payPalCampaigns.value.map { PayPalCampaign(it) }
         )
 
         _sessionId.update { "" }
@@ -48,8 +60,8 @@ class ShopperInsightsV2ViewModel : ViewModel() {
                     _sessionId.update { result.sessionId }
                 }
                 is CustomerSessionResult.Failure -> {
-                    this@ShopperInsightsV2ViewModel.error.update {
-                        "CreateCustomerSession failed: ${result.error}"
+                    viewModelScope.launch {
+                        _userErrors.emit("CreateCustomerSession failed: ${result.error}")
                     }
                 }
             }
@@ -62,8 +74,8 @@ class ShopperInsightsV2ViewModel : ViewModel() {
         sessionId: String
     ) {
         val customerSessionRequest = CustomerSessionRequest(
-            hashedEmail = emailText.sha256(),
-            hashedPhoneNumber = nationalNumberText.sha256()
+            hashedEmail = emailText.sha256Hex(),
+            hashedPhoneNumber = nationalNumberText.sha256Hex()
         )
 
         _sessionId.update { "" }
@@ -74,7 +86,9 @@ class ShopperInsightsV2ViewModel : ViewModel() {
                     _sessionId.update { result.sessionId }
                 }
                 is CustomerSessionResult.Failure -> {
-                    error.update { "UpdateCustomerSession failed: ${result.error}" }
+                    viewModelScope.launch {
+                        _userErrors.emit("UpdateCustomerSession failed: ${result.error}")
+                    }
                 }
             }
         }
@@ -106,7 +120,9 @@ class ShopperInsightsV2ViewModel : ViewModel() {
                 is CustomerRecommendationsResult.Failure -> {
                     recommendationsCompleted.value = true
 
-                    this@ShopperInsightsV2ViewModel.error.update { "GetRecommendations failed: ${result.error}" }
+                    viewModelScope.launch {
+                        _userErrors.emit("GetRecommendations failed: ${result.error}")
+                    }
                 }
             }
         }
@@ -130,15 +146,20 @@ class ShopperInsightsV2ViewModel : ViewModel() {
     fun resetRecommendationsCompleted() {
         recommendationsCompleted.value = false
     }
+
+    fun addPayPalCampaign(campaign: String) {
+        val trimmed = campaign.trim()
+        if (trimmed.isNotEmpty()) {
+            _payPalCampaigns.update { it + trimmed }
+        }
+    }
+
+    fun removePayPalCampaignAt(index: Int) {
+        _payPalCampaigns.update { list -> list.filterIndexed { i, _ -> i != index } }
+    }
 }
 
-private fun String.sha256(): String {
-    return hashString(this, "SHA-256")
-}
-
-private fun hashString(input: String, algorithm: String = "SHA-256"): String {
-    return MessageDigest
-        .getInstance(algorithm)
-        .digest(input.toByteArray())
-        .toString()
+private fun String.sha256Hex(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(toByteArray(Charsets.UTF_8))
+    return digest.joinToString("") { byte -> "%02x".format(0xFF and byte.toInt()) }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
@@ -75,7 +75,8 @@ class ShopperInsightsV2ViewModel : ViewModel() {
     ) {
         val customerSessionRequest = CustomerSessionRequest(
             hashedEmail = emailText.sha256Hex(),
-            hashedPhoneNumber = nationalNumberText.sha256Hex()
+            hashedPhoneNumber = nationalNumberText.sha256Hex(),
+            payPalCampaigns = _payPalCampaigns.value.map { PayPalCampaign(it) }
         )
 
         _sessionId.update { "" }
@@ -95,7 +96,10 @@ class ShopperInsightsV2ViewModel : ViewModel() {
     }
 
     fun handleGetRecommendations(sessionId: String) {
-        shopperInsightsClient.generateCustomerRecommendations(sessionId = sessionId) { result ->
+        shopperInsightsClient.generateCustomerRecommendations(
+            sessionId = sessionId,
+            payPalCampaigns = _payPalCampaigns.value.map { PayPalCampaign(it) }
+        ) { result ->
             when (result) {
                 is CustomerRecommendationsResult.Success -> {
                     isInPayPalNetwork.update { result.customerRecommendations.isInPayPalNetwork == true }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerSessionRequest.kt
@@ -10,6 +10,8 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
  * @property payPalAppInstalled If the PayPal app is installed on the device.
  * @property venmoAppInstalled If the Venmo app is installed on the device.
  * @property purchaseUnits List of purchase units containing the amount and currency code.
+ * @property payPalCampaigns Optional campaigns; encoded on the wire as `paypal_campaigns` (aligned with iOS
+ * `BTCustomerSessionRequest`). Omitted when null or empty.
  *
  * Warning: This feature is in beta. It's public API may change or be removed in future releases.
  */
@@ -20,4 +22,5 @@ data class CustomerSessionRequest(
     var payPalAppInstalled: Boolean? = null,
     var venmoAppInstalled: Boolean? = null,
     var purchaseUnits: List<PurchaseUnit>? = null,
+    var payPalCampaigns: List<PayPalCampaign>? = null,
 )

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PayPalCampaign.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/PayPalCampaign.kt
@@ -1,0 +1,16 @@
+package com.braintreepayments.api.shopperinsights.v2
+
+import com.braintreepayments.api.core.ExperimentalBetaApi
+
+/**
+ * PayPal campaign details; aligns with iOS `BTPayPalCampaign`. Each entry serializes as `{ "id": "<campaign-id>" }`.
+ *
+ * Included under the `paypal_campaigns` key in Shopper Insights v2 request variables (create/update session,
+ * generate recommendations).
+ *
+ * Warning: This feature is in beta. It's public API may change or be removed in future releases.
+ */
+@ExperimentalBetaApi
+data class PayPalCampaign(
+    val id: String,
+)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2.kt
@@ -141,6 +141,8 @@ class ShopperInsightsClientV2 internal constructor(
      *
      * @param customerSessionRequest Optional: a [CustomerSessionRequest] object containing the request parameters
      * @param sessionId Optional: The shopper session ID
+     * @param payPalCampaigns Optional: PayPal campaigns (`paypal_campaigns` on the wire); if null, uses
+     * [CustomerSessionRequest.payPalCampaigns] when [customerSessionRequest] is non-null.
      * @param customerRecommendationsCallback: a callback that returns the result of the
      * customer recommendation generation
      *
@@ -149,10 +151,15 @@ class ShopperInsightsClientV2 internal constructor(
     fun generateCustomerRecommendations(
         customerSessionRequest: CustomerSessionRequest? = null,
         sessionId: String? = null,
+        payPalCampaigns: List<PayPalCampaign>? = null,
         customerRecommendationsCallback: (customerRecommendationsResult: CustomerRecommendationsResult) -> Unit
     ) {
         coroutineScope.launch {
-            val result = generateCustomerRecommendations(customerSessionRequest, sessionId)
+            val result = generateCustomerRecommendations(
+                customerSessionRequest,
+                sessionId,
+                payPalCampaigns
+            )
             customerRecommendationsCallback(result)
         }
     }
@@ -160,11 +167,16 @@ class ShopperInsightsClientV2 internal constructor(
     private suspend fun generateCustomerRecommendations(
         customerSessionRequest: CustomerSessionRequest? = null,
         sessionId: String? = null,
+        payPalCampaigns: List<PayPalCampaign>? = null,
     ): CustomerRecommendationsResult {
         analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
         return when (
             val generateCustomerRecommendationsResult =
-                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+                generateCustomerRecommendationsApi.execute(
+                    customerSessionRequest,
+                    sessionId,
+                    payPalCampaigns
+                )
         ) {
             is GenerateCustomerRecommendationsResult.Success -> {
                 analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_SUCCEEDED)

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApi.kt
@@ -56,6 +56,7 @@ internal class CreateCustomerSessionApi(
         val input = JSONObject().apply {
             put(CUSTOMER, jsonRequestObjects.customer)
             putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+            putOpt(PAYPAL_CAMPAIGNS, jsonRequestObjects.payPalCampaigns)
         }
 
         return JSONObject().put(INPUT, input)
@@ -67,6 +68,8 @@ internal class CreateCustomerSessionApi(
         private const val INPUT = "input"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        /** Matches iOS `Variables` encoding key; wire name is snake_case. */
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val CREATE_CUSTOMER_SESSION = "createCustomerSession"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -14,6 +15,7 @@ class CustomerSessionRequestBuilder {
     internal data class JsonRequestObjects(
         val customer: JSONObject,
         val purchaseUnits: JSONArray?,
+        val payPalCampaigns: JSONArray? = null,
     )
 
     internal fun createRequestObjects(customerSessionRequest: CustomerSessionRequest): JsonRequestObjects {
@@ -42,7 +44,22 @@ class CustomerSessionRequestBuilder {
                 }
             }
 
-        return JsonRequestObjects(customer, purchaseUnits)
+        val payPalCampaigns = payPalCampaignsToJson(customerSessionRequest.payPalCampaigns)
+
+        return JsonRequestObjects(customer, purchaseUnits, payPalCampaigns)
+    }
+
+    /**
+     * Builds the JSON array for `paypal_campaigns` (each element `{ "id": "..." }`, same as iOS `BTPayPalCampaign`).
+     */
+    internal fun payPalCampaignsToJson(payPalCampaigns: List<PayPalCampaign>?): JSONArray? {
+        return payPalCampaigns?.takeIf { it.isNotEmpty() }?.let { campaigns ->
+            JSONArray().apply {
+                campaigns.forEach { campaign ->
+                    put(JSONObject().put(CAMPAIGN_ID_KEY, campaign.id))
+                }
+            }
+        }
     }
 
     private companion object {
@@ -53,5 +70,6 @@ class CustomerSessionRequestBuilder {
         private const val AMOUNT = "amount"
         private const val VALUE = "value"
         private const val CURRENCY_CODE = "currencyCode"
+        private const val CAMPAIGN_ID_KEY = "id"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
@@ -4,6 +4,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
 import org.json.JSONException
 import org.json.JSONObject
@@ -28,7 +29,8 @@ internal class GenerateCustomerRecommendationsApi(
 
     suspend fun execute(
         customerSessionRequest: CustomerSessionRequest?,
-        sessionId: String?
+        sessionId: String?,
+        payPalCampaigns: List<PayPalCampaign>? = null,
     ): GenerateCustomerRecommendationsResult {
         return try {
             val params = JSONObject()
@@ -47,7 +49,10 @@ internal class GenerateCustomerRecommendationsApi(
                 """.trimIndent()
             )
 
-            params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
+            params.put(
+                VARIABLES,
+                assembleVariables(sessionId, customerSessionRequest, payPalCampaigns)
+            )
 
             try {
                 val responseBody = braintreeClient.sendGraphQLPOST(params)
@@ -64,10 +69,16 @@ internal class GenerateCustomerRecommendationsApi(
     @Throws(JSONException::class)
     private fun assembleVariables(
         sessionId: String?,
-        customerSessionRequest: CustomerSessionRequest?
+        customerSessionRequest: CustomerSessionRequest?,
+        payPalCampaigns: List<PayPalCampaign>?,
     ): JSONObject {
         val input = JSONObject().apply {
             putOpt(SESSION_ID, sessionId)
+
+            val campaignsJson = customerSessionRequestBuilder.payPalCampaignsToJson(
+                payPalCampaigns ?: customerSessionRequest?.payPalCampaigns
+            )
+            putOpt(PAYPAL_CAMPAIGNS, campaignsJson)
 
             if (customerSessionRequest != null) {
                 val jsonRequestObjects = customerSessionRequestBuilder.createRequestObjects(customerSessionRequest)
@@ -114,6 +125,8 @@ internal class GenerateCustomerRecommendationsApi(
         private const val SESSION_ID = "sessionId"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        /** Matches iOS `Variables` encoding key; wire name is snake_case. */
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val GENERATE_CUSTOMER_RECOMMENDATIONS = "generateCustomerRecommendations"
     }
 }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -40,13 +40,13 @@ internal class UpdateCustomerSessionApi(
 
             params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
 
-        try {
-            val responseBody = braintreeClient.sendGraphQLPOST(params)
-            val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
-            UpdateCustomerSessionResult.Success(sessionId)
-        } catch (e: Exception) {
-            UpdateCustomerSessionResult.Error(e)
-        }
+            try {
+                val responseBody = braintreeClient.sendGraphQLPOST(params)
+                val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
+                UpdateCustomerSessionResult.Success(sessionId)
+            } catch (e: Exception) {
+                UpdateCustomerSessionResult.Error(e)
+            }
         } catch (e: JSONException) {
             UpdateCustomerSessionResult.Error(e)
         }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -40,13 +40,13 @@ internal class UpdateCustomerSessionApi(
 
             params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
 
-            try {
-                val responseBody = braintreeClient.sendGraphQLPOST(params)
-                val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
-                UpdateCustomerSessionResult.Success(sessionId)
-            } catch (e: Exception) {
-                UpdateCustomerSessionResult.Error(e)
-            }
+                try {
+                    val responseBody = braintreeClient.sendGraphQLPOST(params)
+                    val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
+                    UpdateCustomerSessionResult.Success(sessionId)
+                } catch (e: Exception) {
+                    UpdateCustomerSessionResult.Error(e)
+                }
         } catch (e: JSONException) {
             UpdateCustomerSessionResult.Error(e)
         }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -40,13 +40,13 @@ internal class UpdateCustomerSessionApi(
 
             params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
 
-            try {
-                val responseBody = braintreeClient.sendGraphQLPOST(params)
-                val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
-                UpdateCustomerSessionResult.Success(sessionId)
-            } catch (e: Exception) {
-                UpdateCustomerSessionResult.Error(e)
-            }
+        try {
+            val responseBody = braintreeClient.sendGraphQLPOST(params)
+            val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
+            UpdateCustomerSessionResult.Success(sessionId)
+        } catch (e: Exception) {
+            UpdateCustomerSessionResult.Error(e)
+        }
         } catch (e: JSONException) {
             UpdateCustomerSessionResult.Error(e)
         }

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApi.kt
@@ -40,13 +40,13 @@ internal class UpdateCustomerSessionApi(
 
             params.put(VARIABLES, assembleVariables(sessionId, customerSessionRequest))
 
-                try {
-                    val responseBody = braintreeClient.sendGraphQLPOST(params)
-                    val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
-                    UpdateCustomerSessionResult.Success(sessionId)
-                } catch (e: Exception) {
-                    UpdateCustomerSessionResult.Error(e)
-                }
+            try {
+                val responseBody = braintreeClient.sendGraphQLPOST(params)
+                val sessionId = responseParser.parseSessionId(responseBody, UPDATE_CUSTOMER_SESSION)
+                UpdateCustomerSessionResult.Success(sessionId)
+            } catch (e: Exception) {
+                UpdateCustomerSessionResult.Error(e)
+            }
         } catch (e: JSONException) {
             UpdateCustomerSessionResult.Error(e)
         }
@@ -63,6 +63,7 @@ internal class UpdateCustomerSessionApi(
             put(SESSION_ID, sessionId)
             put(CUSTOMER, jsonRequestObjects.customer)
             putOpt(PURCHASE_UNITS, jsonRequestObjects.purchaseUnits)
+            putOpt(PAYPAL_CAMPAIGNS, jsonRequestObjects.payPalCampaigns)
         }
 
         return JSONObject().put(INPUT, input)
@@ -75,6 +76,7 @@ internal class UpdateCustomerSessionApi(
         private const val SESSION_ID = "sessionId"
         private const val CUSTOMER = "customer"
         private const val PURCHASE_UNITS = "purchaseUnits"
+        private const val PAYPAL_CAMPAIGNS = "paypal_campaigns"
         private const val UPDATE_CUSTOMER_SESSION = "updateCustomerSession"
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
@@ -136,129 +136,129 @@ class ShopperInsightsClientV2UnitTest {
 
     @Test
     fun `when createCustomerSession is called and succeeds, callback is invoked with Success`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
 
-            coEvery {
-                createCustomerSessionApi.execute(customerSessionRequest)
-            } answers {
-                CreateCustomerSessionResult.Success(sessionId)
-            }
-
-            var result: CustomerSessionResult? = null
-            subject.createCustomerSession(customerSessionRequest) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerSessionResult.Success)
-            assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
+        coEvery {
+            createCustomerSessionApi.execute(customerSessionRequest)
+        } answers {
+            CreateCustomerSessionResult.Success(sessionId)
         }
+
+        var result: CustomerSessionResult? = null
+        subject.createCustomerSession(customerSessionRequest) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerSessionResult.Success)
+        assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
+    }
 
     @Test
     fun `when createCustomerSession is called and fails, callback is invoked with Failure`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val error = Exception("Test error")
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val error = Exception("Test error")
 
-            coEvery {
-                createCustomerSessionApi.execute(customerSessionRequest)
-            } answers {
-                CreateCustomerSessionResult.Error(error)
-            }
-
-            var result: CustomerSessionResult? = null
-            subject.createCustomerSession(customerSessionRequest) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerSessionResult.Failure)
-            assertEquals(error, (result as CustomerSessionResult.Failure).error)
+        coEvery {
+            createCustomerSessionApi.execute(customerSessionRequest)
+        } answers {
+            CreateCustomerSessionResult.Error(error)
         }
+
+        var result: CustomerSessionResult? = null
+        subject.createCustomerSession(customerSessionRequest) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerSessionResult.Failure)
+        assertEquals(error, (result as CustomerSessionResult.Failure).error)
+    }
 
     @Test
     fun `when updateCustomerSession is called and succeeds, callback is invoked with Success`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
 
-            coEvery {
-                updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-            } answers {
-                UpdateCustomerSessionResult.Success(sessionId)
-            }
-
-            var result: CustomerSessionResult? = null
-            subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerSessionResult.Success)
-            assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
+        coEvery {
+            updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+        } answers {
+            UpdateCustomerSessionResult.Success(sessionId)
         }
+
+        var result: CustomerSessionResult? = null
+        subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerSessionResult.Success)
+        assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
+    }
 
     @Test
     fun `when updateCustomerSession is called and fails, callback is invoked with Failure`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
-            val error = Exception("Test error")
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
+        val error = Exception("Test error")
 
-            coEvery {
-                updateCustomerSessionApi.execute(
-                    customerSessionRequest,
-                    sessionId
-                )
-            } answers {
-                UpdateCustomerSessionResult.Error(error)
-            }
-
-            var result: CustomerSessionResult? = null
-            subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerSessionResult.Failure)
-            assertEquals(error, (result as CustomerSessionResult.Failure).error)
+        coEvery {
+            updateCustomerSessionApi.execute(
+                customerSessionRequest,
+                sessionId
+            )
+        } answers {
+            UpdateCustomerSessionResult.Error(error)
         }
+
+        var result: CustomerSessionResult? = null
+        subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerSessionResult.Failure)
+        assertEquals(error, (result as CustomerSessionResult.Failure).error)
+    }
 
     @Test
     fun `when generateCustomerRecommendations is called and succeeds, callback is invoked with Success`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
-            val recommendations = mockk<CustomerRecommendations>()
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
+        val recommendations = mockk<CustomerRecommendations>()
 
-            coEvery {
-                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
-            } answers {
-                GenerateCustomerRecommendationsResult.Success(recommendations)
-            }
-
-            var result: CustomerRecommendationsResult? = null
-            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerRecommendationsResult.Success)
-            assertEquals(recommendations, (result as CustomerRecommendationsResult.Success).customerRecommendations)
+        coEvery {
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+        } answers {
+            GenerateCustomerRecommendationsResult.Success(recommendations)
         }
+
+        var result: CustomerRecommendationsResult? = null
+        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerRecommendationsResult.Success)
+        assertEquals(recommendations, (result as CustomerRecommendationsResult.Success).customerRecommendations)
+    }
 
     @Test
     fun `when generateCustomerRecommendations is called and fails, callback is invoked with Failure`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
-            val error = Exception("Test error")
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
+        val error = Exception("Test error")
 
-            coEvery {
-                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
-            } answers {
-                GenerateCustomerRecommendationsResult.Error(error)
-            }
-
-            var result: CustomerRecommendationsResult? = null
-            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
-            advanceUntilIdle()
-
-            assert(result is CustomerRecommendationsResult.Failure)
-            assertEquals(error, (result as CustomerRecommendationsResult.Failure).error)
+        coEvery {
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+        } answers {
+            GenerateCustomerRecommendationsResult.Error(error)
         }
+
+        var result: CustomerRecommendationsResult? = null
+        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
+        advanceUntilIdle()
+
+        assert(result is CustomerRecommendationsResult.Failure)
+        assertEquals(error, (result as CustomerRecommendationsResult.Failure).error)
+    }
 
     @Test
     fun `createCustomerSession sends started and succeeded analytics events`() = runTest(testDispatcher) {
@@ -364,23 +364,23 @@ class ShopperInsightsClientV2UnitTest {
 
     @Test
     fun `generateCustomerRecommendations sends started and failed analytics events on error`() =
-        runTest(testDispatcher) {
-            val customerSessionRequest = mockk<CustomerSessionRequest>()
-            val sessionId = "test-session-id"
-            val error = Exception("Test error")
+    runTest(testDispatcher) {
+        val customerSessionRequest = mockk<CustomerSessionRequest>()
+        val sessionId = "test-session-id"
+        val error = Exception("Test error")
 
-            coEvery {
-                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
-            } answers {
-                GenerateCustomerRecommendationsResult.Error(error)
-            }
-
-            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) {}
-            advanceUntilIdle()
-
-            verifyOrder {
-                analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
-                analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_FAILED)
-            }
+        coEvery {
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+        } answers {
+            GenerateCustomerRecommendationsResult.Error(error)
         }
+
+        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) {}
+        advanceUntilIdle()
+
+        verifyOrder {
+            analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
+            analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_FAILED)
+        }
+    }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/ShopperInsightsClientV2UnitTest.kt
@@ -136,129 +136,129 @@ class ShopperInsightsClientV2UnitTest {
 
     @Test
     fun `when createCustomerSession is called and succeeds, callback is invoked with Success`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
 
-        coEvery {
-            createCustomerSessionApi.execute(customerSessionRequest)
-        } answers {
-            CreateCustomerSessionResult.Success(sessionId)
+            coEvery {
+                createCustomerSessionApi.execute(customerSessionRequest)
+            } answers {
+                CreateCustomerSessionResult.Success(sessionId)
+            }
+
+            var result: CustomerSessionResult? = null
+            subject.createCustomerSession(customerSessionRequest) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerSessionResult.Success)
+            assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
         }
-
-        var result: CustomerSessionResult? = null
-        subject.createCustomerSession(customerSessionRequest) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerSessionResult.Success)
-        assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
-    }
 
     @Test
     fun `when createCustomerSession is called and fails, callback is invoked with Failure`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val error = Exception("Test error")
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val error = Exception("Test error")
 
-        coEvery {
-            createCustomerSessionApi.execute(customerSessionRequest)
-        } answers {
-            CreateCustomerSessionResult.Error(error)
+            coEvery {
+                createCustomerSessionApi.execute(customerSessionRequest)
+            } answers {
+                CreateCustomerSessionResult.Error(error)
+            }
+
+            var result: CustomerSessionResult? = null
+            subject.createCustomerSession(customerSessionRequest) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerSessionResult.Failure)
+            assertEquals(error, (result as CustomerSessionResult.Failure).error)
         }
-
-        var result: CustomerSessionResult? = null
-        subject.createCustomerSession(customerSessionRequest) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerSessionResult.Failure)
-        assertEquals(error, (result as CustomerSessionResult.Failure).error)
-    }
 
     @Test
     fun `when updateCustomerSession is called and succeeds, callback is invoked with Success`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
 
-        coEvery {
-            updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-        } answers {
-            UpdateCustomerSessionResult.Success(sessionId)
+            coEvery {
+                updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+            } answers {
+                UpdateCustomerSessionResult.Success(sessionId)
+            }
+
+            var result: CustomerSessionResult? = null
+            subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerSessionResult.Success)
+            assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
         }
-
-        var result: CustomerSessionResult? = null
-        subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerSessionResult.Success)
-        assertEquals(sessionId, (result as CustomerSessionResult.Success).sessionId)
-    }
 
     @Test
     fun `when updateCustomerSession is called and fails, callback is invoked with Failure`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
-        val error = Exception("Test error")
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
+            val error = Exception("Test error")
 
-        coEvery {
-            updateCustomerSessionApi.execute(
-                customerSessionRequest,
-                sessionId
-            )
-        } answers {
-            UpdateCustomerSessionResult.Error(error)
+            coEvery {
+                updateCustomerSessionApi.execute(
+                    customerSessionRequest,
+                    sessionId
+                )
+            } answers {
+                UpdateCustomerSessionResult.Error(error)
+            }
+
+            var result: CustomerSessionResult? = null
+            subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerSessionResult.Failure)
+            assertEquals(error, (result as CustomerSessionResult.Failure).error)
         }
-
-        var result: CustomerSessionResult? = null
-        subject.updateCustomerSession(customerSessionRequest, sessionId) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerSessionResult.Failure)
-        assertEquals(error, (result as CustomerSessionResult.Failure).error)
-    }
 
     @Test
     fun `when generateCustomerRecommendations is called and succeeds, callback is invoked with Success`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
-        val recommendations = mockk<CustomerRecommendations>()
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
+            val recommendations = mockk<CustomerRecommendations>()
 
-        coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
-        } answers {
-            GenerateCustomerRecommendationsResult.Success(recommendations)
+            coEvery {
+                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+            } answers {
+                GenerateCustomerRecommendationsResult.Success(recommendations)
+            }
+
+            var result: CustomerRecommendationsResult? = null
+            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerRecommendationsResult.Success)
+            assertEquals(recommendations, (result as CustomerRecommendationsResult.Success).customerRecommendations)
         }
-
-        var result: CustomerRecommendationsResult? = null
-        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerRecommendationsResult.Success)
-        assertEquals(recommendations, (result as CustomerRecommendationsResult.Success).customerRecommendations)
-    }
 
     @Test
     fun `when generateCustomerRecommendations is called and fails, callback is invoked with Failure`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
-        val error = Exception("Test error")
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
+            val error = Exception("Test error")
 
-        coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
-        } answers {
-            GenerateCustomerRecommendationsResult.Error(error)
+            coEvery {
+                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+            } answers {
+                GenerateCustomerRecommendationsResult.Error(error)
+            }
+
+            var result: CustomerRecommendationsResult? = null
+            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
+            advanceUntilIdle()
+
+            assert(result is CustomerRecommendationsResult.Failure)
+            assertEquals(error, (result as CustomerRecommendationsResult.Failure).error)
         }
-
-        var result: CustomerRecommendationsResult? = null
-        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) { result = it }
-        advanceUntilIdle()
-
-        assert(result is CustomerRecommendationsResult.Failure)
-        assertEquals(error, (result as CustomerRecommendationsResult.Failure).error)
-    }
 
     @Test
     fun `createCustomerSession sends started and succeeded analytics events`() = runTest(testDispatcher) {
@@ -348,7 +348,7 @@ class ShopperInsightsClientV2UnitTest {
         val recommendations = mockk<CustomerRecommendations>()
 
         coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
+            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
         } answers {
             GenerateCustomerRecommendationsResult.Success(recommendations)
         }
@@ -364,23 +364,23 @@ class ShopperInsightsClientV2UnitTest {
 
     @Test
     fun `generateCustomerRecommendations sends started and failed analytics events on error`() =
-    runTest(testDispatcher) {
-        val customerSessionRequest = mockk<CustomerSessionRequest>()
-        val sessionId = "test-session-id"
-        val error = Exception("Test error")
+        runTest(testDispatcher) {
+            val customerSessionRequest = mockk<CustomerSessionRequest>()
+            val sessionId = "test-session-id"
+            val error = Exception("Test error")
 
-        coEvery {
-            generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId)
-        } answers {
-            GenerateCustomerRecommendationsResult.Error(error)
+            coEvery {
+                generateCustomerRecommendationsApi.execute(customerSessionRequest, sessionId, null)
+            } answers {
+                GenerateCustomerRecommendationsResult.Error(error)
+            }
+
+            subject.generateCustomerRecommendations(customerSessionRequest, sessionId) {}
+            advanceUntilIdle()
+
+            verifyOrder {
+                analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
+                analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_FAILED)
+            }
         }
-
-        subject.generateCustomerRecommendations(customerSessionRequest, sessionId) {}
-        advanceUntilIdle()
-
-        verifyOrder {
-            analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_STARTED)
-            analyticsClient.sendEvent(ShopperInsightsAnalytics.GET_CUSTOMER_RECOMMENDATIONS_FAILED)
-        }
-    }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
@@ -78,9 +78,9 @@ class CreateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-        runTest(testDispatcher) {
-            val sessionId = "test-session-id"
-            val responseBody = """
+    runTest(testDispatcher) {
+        val sessionId = "test-session-id"
+        val responseBody = """
             {
                 "data": {
                     "createCustomerSession": {
@@ -90,74 +90,74 @@ class CreateCustomerSessionApiUnitTest {
             }
         """.trimIndent()
 
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostSuccessfulResponse(responseBody)
-                .build()
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
 
-            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
-            val responseParser = mockk<ShopperInsightsResponseParser> {
-                every { parseSessionId(responseBody, "createCustomerSession") } returns sessionId
-            }
-
-            val createCustomerSessionApi = CreateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = customerSessionRequestBuilder,
-                responseParser = responseParser
-            )
-
-            val result = createCustomerSessionApi.execute(customerSessionRequest)
-            advanceUntilIdle()
-
-            assert(result is CreateCustomerSessionResult.Success)
-            assertEquals(sessionId, (result as CreateCustomerSessionResult.Success).sessionId)
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+        val responseParser = mockk<ShopperInsightsResponseParser> {
+            every { parseSessionId(responseBody, "createCustomerSession") } returns sessionId
         }
+
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
+
+        val result = createCustomerSessionApi.execute(customerSessionRequest)
+        advanceUntilIdle()
+
+        assert(result is CreateCustomerSessionResult.Success)
+        assertEquals(sessionId, (result as CreateCustomerSessionResult.Success).sessionId)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and an error is returned, callback with Error is invoked`() =
-        runTest(testDispatcher) {
-            val error = IOException("Network error")
+    runTest(testDispatcher) {
+        val error = IOException("Network error")
 
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostErrorResponse(error)
-                .build()
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostErrorResponse(error)
+            .build()
 
-            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
-            val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
 
-            val createCustomerSessionApi = CreateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = customerSessionRequestBuilder,
-                responseParser = responseParser
-            )
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
 
-            val result = createCustomerSessionApi.execute(customerSessionRequest)
-            advanceUntilIdle()
+        val result = createCustomerSessionApi.execute(customerSessionRequest)
+        advanceUntilIdle()
 
-            assert(result is CreateCustomerSessionResult.Error)
-            assertEquals(error, (result as CreateCustomerSessionResult.Error).error)
-        }
+        assert(result is CreateCustomerSessionResult.Error)
+        assertEquals(error, (result as CreateCustomerSessionResult.Error).error)
+    }
 
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-        runTest(testDispatcher) {
-            val exception = JSONException("Test exception")
-            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
-                every { createRequestObjects(any()) } throws exception
-            }
-            val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
-
-            val createCustomerSessionApi = CreateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = customerSessionRequestBuilder,
-                responseParser = responseParser
-            )
-
-            val result = createCustomerSessionApi.execute(customerSessionRequest)
-
-            assert(result is CreateCustomerSessionResult.Error)
-            assertEquals(exception, (result as CreateCustomerSessionResult.Error).error)
+    runTest(testDispatcher) {
+        val exception = JSONException("Test exception")
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(any()) } throws exception
         }
+        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = responseParser
+        )
+
+        val result = createCustomerSessionApi.execute(customerSessionRequest)
+
+        assert(result is CreateCustomerSessionResult.Error)
+        assertEquals(exception, (result as CreateCustomerSessionResult.Error).error)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressWarnings("LongMethod")
@@ -226,75 +226,75 @@ class CreateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
-        runTest(testDispatcher) {
-            val requestWithCampaigns = customerSessionRequest.copy(
-                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
-            )
+    runTest(testDispatcher) {
+        val requestWithCampaigns = customerSessionRequest.copy(
+            payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+        )
 
-            val responseBody = """
-            {
-                "data": {
-                    "createCustomerSession": {
-                        "sessionId": "test-session-id"
-                    }
+        val responseBody = """
+        {
+            "data": {
+                "createCustomerSession": {
+                    "sessionId": "test-session-id"
                 }
-            }
-            """.trimIndent()
-
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostSuccessfulResponse(responseBody)
-                .build()
-
-            val createCustomerSessionApi = CreateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                responseParser = mockk {
-                    every { parseSessionId(responseBody, "createCustomerSession") } returns "test-session-id"
-                }
-            )
-
-            createCustomerSessionApi.execute(requestWithCampaigns)
-            advanceUntilIdle()
-
-            val expectedRequestBody = JSONObject().apply {
-                put(
-                    "query",
-                    """
-                mutation CreateCustomerSession(${'$'}input: CreateCustomerSessionInput!) {
-                    createCustomerSession(input: ${'$'}input) {
-                        sessionId
-                    }
-                }
-                    """.trimIndent()
-                )
-                put(
-                    "variables",
-                    JSONObject().apply {
-                        put("input", JSONObject().apply {
-                            put("customer", JSONObject().apply {
-                                put("hashedEmail", "hashedEmail")
-                                put("hashedPhoneNumber", "hashedPhoneNumber")
-                                put("paypalAppInstalled", true)
-                                put("venmoAppInstalled", false)
-                            })
-                            put(
-                                "paypal_campaigns",
-                                JSONArray().apply {
-                                    put(
-                                        JSONObject().apply {
-                                            put("id", "PPL-MOCK-CAMPAIGN")
-                                        }
-                                    )
-                                }
-                            )
-                        })
-                    }
-                )
-            }
-
-            coVerify {
-                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
-                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
-                })
             }
         }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
+
+        val createCustomerSessionApi = CreateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            responseParser = mockk {
+                every { parseSessionId(responseBody, "createCustomerSession") } returns "test-session-id"
+            }
+        )
+
+        createCustomerSessionApi.execute(requestWithCampaigns)
+        advanceUntilIdle()
+
+        val expectedRequestBody = JSONObject().apply {
+            put(
+                "query",
+                """
+            mutation CreateCustomerSession(${'$'}input: CreateCustomerSessionInput!) {
+                createCustomerSession(input: ${'$'}input) {
+                    sessionId
+                }
+            }
+                """.trimIndent()
+            )
+            put(
+                "variables",
+                JSONObject().apply {
+                    put("input", JSONObject().apply {
+                        put("customer", JSONObject().apply {
+                            put("hashedEmail", "hashedEmail")
+                            put("hashedPhoneNumber", "hashedPhoneNumber")
+                            put("paypalAppInstalled", true)
+                            put("venmoAppInstalled", false)
+                        })
+                        put(
+                            "paypal_campaigns",
+                            JSONArray().apply {
+                                put(
+                                    JSONObject().apply {
+                                        put("id", "PPL-MOCK-CAMPAIGN")
+                                    }
+                                )
+                            }
+                        )
+                    })
+                }
+            )
+        }
+
+        coVerify {
+            braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+            })
+        }
+    }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CreateCustomerSessionApiUnitTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.CreateCustomerSessionApi.CreateCustomerSessionResult
 import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
@@ -77,9 +78,9 @@ class CreateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-    runTest(testDispatcher) {
-        val sessionId = "test-session-id"
-        val responseBody = """
+        runTest(testDispatcher) {
+            val sessionId = "test-session-id"
+            val responseBody = """
             {
                 "data": {
                     "createCustomerSession": {
@@ -89,74 +90,74 @@ class CreateCustomerSessionApiUnitTest {
             }
         """.trimIndent()
 
-        val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPostSuccessfulResponse(responseBody)
-            .build()
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
 
-        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
-        val responseParser = mockk<ShopperInsightsResponseParser> {
-            every { parseSessionId(responseBody, "createCustomerSession") } returns sessionId
+            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+            val responseParser = mockk<ShopperInsightsResponseParser> {
+                every { parseSessionId(responseBody, "createCustomerSession") } returns sessionId
+            }
+
+            val createCustomerSessionApi = CreateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = customerSessionRequestBuilder,
+                responseParser = responseParser
+            )
+
+            val result = createCustomerSessionApi.execute(customerSessionRequest)
+            advanceUntilIdle()
+
+            assert(result is CreateCustomerSessionResult.Success)
+            assertEquals(sessionId, (result as CreateCustomerSessionResult.Success).sessionId)
         }
-
-        val createCustomerSessionApi = CreateCustomerSessionApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = customerSessionRequestBuilder,
-            responseParser = responseParser
-        )
-
-        val result = createCustomerSessionApi.execute(customerSessionRequest)
-        advanceUntilIdle()
-
-        assert(result is CreateCustomerSessionResult.Success)
-        assertEquals(sessionId, (result as CreateCustomerSessionResult.Success).sessionId)
-    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and an error is returned, callback with Error is invoked`() =
-    runTest(testDispatcher) {
-        val error = IOException("Network error")
+        runTest(testDispatcher) {
+            val error = IOException("Network error")
 
-        val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPostErrorResponse(error)
-            .build()
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostErrorResponse(error)
+                .build()
 
-        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
-        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true)
+            val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
 
-        val createCustomerSessionApi = CreateCustomerSessionApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = customerSessionRequestBuilder,
-            responseParser = responseParser
-        )
+            val createCustomerSessionApi = CreateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = customerSessionRequestBuilder,
+                responseParser = responseParser
+            )
 
-        val result = createCustomerSessionApi.execute(customerSessionRequest)
-        advanceUntilIdle()
+            val result = createCustomerSessionApi.execute(customerSessionRequest)
+            advanceUntilIdle()
 
-        assert(result is CreateCustomerSessionResult.Error)
-        assertEquals(error, (result as CreateCustomerSessionResult.Error).error)
-    }
+            assert(result is CreateCustomerSessionResult.Error)
+            assertEquals(error, (result as CreateCustomerSessionResult.Error).error)
+        }
 
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-    runTest(testDispatcher) {
-        val exception = JSONException("Test exception")
-        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
-            every { createRequestObjects(any()) } throws exception
+        runTest(testDispatcher) {
+            val exception = JSONException("Test exception")
+            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+                every { createRequestObjects(any()) } throws exception
+            }
+            val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+
+            val createCustomerSessionApi = CreateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = customerSessionRequestBuilder,
+                responseParser = responseParser
+            )
+
+            val result = createCustomerSessionApi.execute(customerSessionRequest)
+
+            assert(result is CreateCustomerSessionResult.Error)
+            assertEquals(exception, (result as CreateCustomerSessionResult.Error).error)
         }
-        val responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
-
-        val createCustomerSessionApi = CreateCustomerSessionApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = customerSessionRequestBuilder,
-            responseParser = responseParser
-        )
-
-        val result = createCustomerSessionApi.execute(customerSessionRequest)
-
-        assert(result is CreateCustomerSessionResult.Error)
-        assertEquals(exception, (result as CreateCustomerSessionResult.Error).error)
-    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressWarnings("LongMethod")
@@ -221,4 +222,79 @@ class CreateCustomerSessionApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
+        runTest(testDispatcher) {
+            val requestWithCampaigns = customerSessionRequest.copy(
+                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+            )
+
+            val responseBody = """
+            {
+                "data": {
+                    "createCustomerSession": {
+                        "sessionId": "test-session-id"
+                    }
+                }
+            }
+            """.trimIndent()
+
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
+
+            val createCustomerSessionApi = CreateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                responseParser = mockk {
+                    every { parseSessionId(responseBody, "createCustomerSession") } returns "test-session-id"
+                }
+            )
+
+            createCustomerSessionApi.execute(requestWithCampaigns)
+            advanceUntilIdle()
+
+            val expectedRequestBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation CreateCustomerSession(${'$'}input: CreateCustomerSessionInput!) {
+                    createCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put("input", JSONObject().apply {
+                            put("customer", JSONObject().apply {
+                                put("hashedEmail", "hashedEmail")
+                                put("hashedPhoneNumber", "hashedPhoneNumber")
+                                put("paypalAppInstalled", true)
+                                put("venmoAppInstalled", false)
+                            })
+                            put(
+                                "paypal_campaigns",
+                                JSONArray().apply {
+                                    put(
+                                        JSONObject().apply {
+                                            put("id", "PPL-MOCK-CAMPAIGN")
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+                })
+            }
+        }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/CustomerSessionRequestBuilderUnitTest.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import org.json.JSONArray
 import org.json.JSONObject
@@ -76,5 +77,45 @@ class CustomerSessionRequestBuilderUnitTest {
 
         JSONAssert.assertEquals(expectedCustomer, result.customer, false)
         assertNull(result.purchaseUnits)
+    }
+
+    @Test
+    fun `createRequestObjects includes payPalCampaigns when provided`() {
+        val customerSessionRequest = CustomerSessionRequest(
+            hashedEmail = "hashedEmail",
+            hashedPhoneNumber = "hashedPhoneNumber",
+            payPalAppInstalled = true,
+            venmoAppInstalled = false,
+            purchaseUnits = null,
+            payPalCampaigns = listOf(
+                PayPalCampaign(id = "PPL-TT-10OFF"),
+                PayPalCampaign(id = "PPL-OTHER-MOCK")
+            )
+        )
+
+        val result = requestBuilder.createRequestObjects(customerSessionRequest)
+
+        val expectedCampaigns = JSONArray().apply {
+            put(JSONObject().put("id", "PPL-TT-10OFF"))
+            put(JSONObject().put("id", "PPL-OTHER-MOCK"))
+        }
+
+        JSONAssert.assertEquals(expectedCampaigns, result.payPalCampaigns, false)
+    }
+
+    @Test
+    fun `createRequestObjects omits payPalCampaigns when null or empty`() {
+        val withNull = CustomerSessionRequest(
+            hashedEmail = "e",
+            hashedPhoneNumber = "p",
+            payPalAppInstalled = false,
+            venmoAppInstalled = false,
+            purchaseUnits = null,
+            payPalCampaigns = null
+        )
+        assertNull(requestBuilder.createRequestObjects(withNull).payPalCampaigns)
+
+        val withEmpty = withNull.copy(payPalCampaigns = emptyList())
+        assertNull(requestBuilder.createRequestObjects(withEmpty).payPalCampaigns)
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -134,9 +134,9 @@ class GenerateCustomerRecommendationsApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-        runTest(testDispatcher) {
-            val sessionId = "test-session-id"
-            val responseBody = """
+    runTest(testDispatcher) {
+        val sessionId = "test-session-id"
+        val responseBody = """
             {
                 "data": {
                     "generateCustomerRecommendations": {
@@ -153,29 +153,29 @@ class GenerateCustomerRecommendationsApiUnitTest {
             }
         """.trimIndent()
 
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostSuccessfulResponse(responseBody)
-                .build()
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
 
-            val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = customerSessionRequestBuilder
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+        advanceUntilIdle()
+
+        val expectedResult = CustomerRecommendations(
+            sessionId = sessionId,
+            isInPayPalNetwork = true,
+            paymentRecommendations = listOf(
+                PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
             )
+        )
 
-            val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
-            advanceUntilIdle()
-
-            val expectedResult = CustomerRecommendations(
-                sessionId = sessionId,
-                isInPayPalNetwork = true,
-                paymentRecommendations = listOf(
-                    PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
-                )
-            )
-
-            assert(result is GenerateCustomerRecommendationsResult.Success)
-            assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
-        }
+        assert(result is GenerateCustomerRecommendationsResult.Success)
+        assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -200,23 +200,23 @@ class GenerateCustomerRecommendationsApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-        runTest(testDispatcher) {
-            val exception = JSONException("Test exception")
-            val braintreeClient = mockk<BraintreeClient> {
-                coEvery { sendGraphQLPOST(any()) } throws exception
-            }
-
-            val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = customerSessionRequestBuilder
-            )
-
-            val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
-            advanceUntilIdle()
-
-            assert(result is GenerateCustomerRecommendationsResult.Error)
-            assertEquals(exception, (result as GenerateCustomerRecommendationsResult.Error).error)
+    runTest(testDispatcher) {
+        val exception = JSONException("Test exception")
+        val braintreeClient = mockk<BraintreeClient> {
+            coEvery { sendGraphQLPOST(any()) } throws exception
         }
+
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+        advanceUntilIdle()
+
+        assert(result is GenerateCustomerRecommendationsResult.Error)
+        assertEquals(exception, (result as GenerateCustomerRecommendationsResult.Error).error)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -246,60 +246,60 @@ class GenerateCustomerRecommendationsApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called with sessionId and payPalCampaigns only, GraphQL variables include campaigns`() =
-        runTest(testDispatcher) {
-            val braintreeClient = mockk<BraintreeClient>(relaxed = true)
-            val realBuilder = CustomerSessionRequestBuilder()
-            val generateApi = GenerateCustomerRecommendationsApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = realBuilder
-            )
+    runTest(testDispatcher) {
+        val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+        val realBuilder = CustomerSessionRequestBuilder()
+        val generateApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = realBuilder
+        )
 
-            generateApi.execute(
-                customerSessionRequest = null,
-                sessionId = "test-session-id",
-                payPalCampaigns = listOf(PayPalCampaign(id = "RECOMMENDED_OFFER_1"))
-            )
-            advanceUntilIdle()
+        generateApi.execute(
+            customerSessionRequest = null,
+            sessionId = "test-session-id",
+            payPalCampaigns = listOf(PayPalCampaign(id = "RECOMMENDED_OFFER_1"))
+        )
+        advanceUntilIdle()
 
-            val expectedBody = JSONObject().apply {
-                put(
-                    "query",
-                    """
-                mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
-                    generateCustomerRecommendations(input: ${'$'}input) {
-                        sessionId
-                        isInPayPalNetwork
-                        paymentRecommendations {
-                            paymentOption
-                            recommendedPriority
-                        }
+        val expectedBody = JSONObject().apply {
+            put(
+                "query",
+                """
+            mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                generateCustomerRecommendations(input: ${'$'}input) {
+                    sessionId
+                    isInPayPalNetwork
+                    paymentRecommendations {
+                        paymentOption
+                        recommendedPriority
                     }
                 }
-                    """.trimIndent()
-                )
-                put(
-                    "variables",
-                    JSONObject().apply {
-                        put(
-                            "input",
-                            JSONObject().apply {
-                                put("sessionId", "test-session-id")
-                                put(
-                                    "paypal_campaigns",
-                                    JSONArray().apply {
-                                        put(JSONObject().put("id", "RECOMMENDED_OFFER_1"))
-                                    }
-                                )
-                            }
-                        )
-                    }
-                )
             }
-
-            coVerify {
-                braintreeClient.sendGraphQLPOST(withArg { actual ->
-                    JSONAssert.assertEquals(expectedBody, actual, false)
-                })
-            }
+                """.trimIndent()
+            )
+            put(
+                "variables",
+                JSONObject().apply {
+                    put(
+                        "input",
+                        JSONObject().apply {
+                            put("sessionId", "test-session-id")
+                            put(
+                                "paypal_campaigns",
+                                JSONArray().apply {
+                                    put(JSONObject().put("id", "RECOMMENDED_OFFER_1"))
+                                }
+                            )
+                        }
+                    )
+                }
+            )
         }
+
+        coVerify {
+            braintreeClient.sendGraphQLPOST(withArg { actual ->
+                JSONAssert.assertEquals(expectedBody, actual, false)
+            })
+        }
+    }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -4,6 +4,7 @@ import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.GenerateCustomerRecommendationsApi.GenerateCustomerRecommendationsResult
@@ -133,9 +134,9 @@ class GenerateCustomerRecommendationsApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-    runTest(testDispatcher) {
-        val sessionId = "test-session-id"
-        val responseBody = """
+        runTest(testDispatcher) {
+            val sessionId = "test-session-id"
+            val responseBody = """
             {
                 "data": {
                     "generateCustomerRecommendations": {
@@ -152,29 +153,29 @@ class GenerateCustomerRecommendationsApiUnitTest {
             }
         """.trimIndent()
 
-        val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPostSuccessfulResponse(responseBody)
-            .build()
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
 
-        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = customerSessionRequestBuilder
-        )
-
-        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
-        advanceUntilIdle()
-
-        val expectedResult = CustomerRecommendations(
-            sessionId = sessionId,
-            isInPayPalNetwork = true,
-            paymentRecommendations = listOf(
-                PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
+            val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = customerSessionRequestBuilder
             )
-        )
 
-        assert(result is GenerateCustomerRecommendationsResult.Success)
-        assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
-    }
+            val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+            advanceUntilIdle()
+
+            val expectedResult = CustomerRecommendations(
+                sessionId = sessionId,
+                isInPayPalNetwork = true,
+                paymentRecommendations = listOf(
+                    PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
+                )
+            )
+
+            assert(result is GenerateCustomerRecommendationsResult.Success)
+            assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
+        }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -199,23 +200,23 @@ class GenerateCustomerRecommendationsApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-    runTest(testDispatcher) {
-        val exception = JSONException("Test exception")
-        val braintreeClient = mockk<BraintreeClient> {
-            coEvery { sendGraphQLPOST(any()) } throws exception
+        runTest(testDispatcher) {
+            val exception = JSONException("Test exception")
+            val braintreeClient = mockk<BraintreeClient> {
+                coEvery { sendGraphQLPOST(any()) } throws exception
+            }
+
+            val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = customerSessionRequestBuilder
+            )
+
+            val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+            advanceUntilIdle()
+
+            assert(result is GenerateCustomerRecommendationsResult.Error)
+            assertEquals(exception, (result as GenerateCustomerRecommendationsResult.Error).error)
         }
-
-        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = customerSessionRequestBuilder
-        )
-
-        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
-        advanceUntilIdle()
-
-        assert(result is GenerateCustomerRecommendationsResult.Error)
-        assertEquals(exception, (result as GenerateCustomerRecommendationsResult.Error).error)
-    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -241,4 +242,64 @@ class GenerateCustomerRecommendationsApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with sessionId and payPalCampaigns only, GraphQL variables include campaigns`() =
+        runTest(testDispatcher) {
+            val braintreeClient = mockk<BraintreeClient>(relaxed = true)
+            val realBuilder = CustomerSessionRequestBuilder()
+            val generateApi = GenerateCustomerRecommendationsApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = realBuilder
+            )
+
+            generateApi.execute(
+                customerSessionRequest = null,
+                sessionId = "test-session-id",
+                payPalCampaigns = listOf(PayPalCampaign(id = "RECOMMENDED_OFFER_1"))
+            )
+            advanceUntilIdle()
+
+            val expectedBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation GenerateCustomerRecommendations(${'$'}input: GenerateCustomerRecommendationsInput!) {
+                    generateCustomerRecommendations(input: ${'$'}input) {
+                        sessionId
+                        isInPayPalNetwork
+                        paymentRecommendations {
+                            paymentOption
+                            recommendedPriority
+                        }
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put(
+                            "input",
+                            JSONObject().apply {
+                                put("sessionId", "test-session-id")
+                                put(
+                                    "paypal_campaigns",
+                                    JSONArray().apply {
+                                        put(JSONObject().put("id", "RECOMMENDED_OFFER_1"))
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actual ->
+                    JSONAssert.assertEquals(expectedBody, actual, false)
+                })
+            }
+        }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.shopperinsights.v2.internal
 import com.braintreepayments.api.core.BraintreeClient
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
+import com.braintreepayments.api.shopperinsights.v2.PayPalCampaign
 import com.braintreepayments.api.shopperinsights.v2.PurchaseUnit
 import com.braintreepayments.api.shopperinsights.v2.internal.UpdateCustomerSessionApi.UpdateCustomerSessionResult
 import com.braintreepayments.api.testutils.MockkBraintreeClientBuilder
@@ -63,8 +64,8 @@ class UpdateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-    runTest(testDispatcher) {
-        val responseBody = """
+        runTest(testDispatcher) {
+            val responseBody = """
             {
                 "data": {
                     "updateCustomerSession": {
@@ -74,26 +75,26 @@ class UpdateCustomerSessionApiUnitTest {
             }
         """.trimIndent()
 
-        val braintreeClient = MockkBraintreeClientBuilder()
-            .sendGraphQLPostSuccessfulResponse(responseBody)
-            .build()
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
 
-        val responseParser = mockk<ShopperInsightsResponseParser> {
-            every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+            val responseParser = mockk<ShopperInsightsResponseParser> {
+                every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+            }
+
+            val updateCustomerSessionApi = UpdateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
+                responseParser = responseParser
+            )
+
+            val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+            advanceUntilIdle()
+
+            assert(result is UpdateCustomerSessionResult.Success)
+            assertEquals(sessionId, (result as UpdateCustomerSessionResult.Success).sessionId)
         }
-
-        val updateCustomerSessionApi = UpdateCustomerSessionApi(
-            braintreeClient = braintreeClient,
-            customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
-            responseParser = responseParser
-        )
-
-        val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-        advanceUntilIdle()
-
-        assert(result is UpdateCustomerSessionResult.Success)
-        assertEquals(sessionId, (result as UpdateCustomerSessionResult.Success).sessionId)
-    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -119,23 +120,23 @@ class UpdateCustomerSessionApiUnitTest {
 
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-    runTest(testDispatcher) {
-        val exception = JSONException("Test exception")
-        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
-            every { createRequestObjects(any()) } throws exception
+        runTest(testDispatcher) {
+            val exception = JSONException("Test exception")
+            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+                every { createRequestObjects(any()) } throws exception
+            }
+
+            val updateCustomerSessionApi = UpdateCustomerSessionApi(
+                braintreeClient = mockk<BraintreeClient>(relaxed = true),
+                customerSessionRequestBuilder = customerSessionRequestBuilder,
+                responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+            )
+
+            val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+
+            assert(result is UpdateCustomerSessionResult.Error)
+            assertEquals(exception, (result as UpdateCustomerSessionResult.Error).error)
         }
-
-        val updateCustomerSessionApi = UpdateCustomerSessionApi(
-            braintreeClient = mockk<BraintreeClient>(relaxed = true),
-            customerSessionRequestBuilder = customerSessionRequestBuilder,
-            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
-        )
-
-        val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-
-        assert(result is UpdateCustomerSessionResult.Error)
-        assertEquals(exception, (result as UpdateCustomerSessionResult.Error).error)
-    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressWarnings("LongMethod")
@@ -203,4 +204,80 @@ class UpdateCustomerSessionApiUnitTest {
             })
         }
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
+        runTest(testDispatcher) {
+            val requestWithCampaigns = customerSessionRequest.copy(
+                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+            )
+
+            val responseBody = """
+            {
+                "data": {
+                    "updateCustomerSession": {
+                        "sessionId": "$sessionId"
+                    }
+                }
+            }
+            """.trimIndent()
+
+            val braintreeClient = MockkBraintreeClientBuilder()
+                .sendGraphQLPostSuccessfulResponse(responseBody)
+                .build()
+
+            val updateCustomerSessionApi = UpdateCustomerSessionApi(
+                braintreeClient = braintreeClient,
+                responseParser = mockk {
+                    every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+                }
+            )
+
+            updateCustomerSessionApi.execute(requestWithCampaigns, sessionId)
+            advanceUntilIdle()
+
+            val expectedRequestBody = JSONObject().apply {
+                put(
+                    "query",
+                    """
+                mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
+                    updateCustomerSession(input: ${'$'}input) {
+                        sessionId
+                    }
+                }
+                    """.trimIndent()
+                )
+                put(
+                    "variables",
+                    JSONObject().apply {
+                        put("input", JSONObject().apply {
+                            put("sessionId", sessionId)
+                            put("customer", JSONObject().apply {
+                                put("hashedEmail", "hashedEmail")
+                                put("hashedPhoneNumber", "hashedPhoneNumber")
+                                put("paypalAppInstalled", true)
+                                put("venmoAppInstalled", false)
+                            })
+                            put(
+                                "paypal_campaigns",
+                                JSONArray().apply {
+                                    put(
+                                        JSONObject().apply {
+                                            put("id", "PPL-MOCK-CAMPAIGN")
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                    }
+                )
+            }
+
+            coVerify {
+                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+                })
+            }
+        }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/UpdateCustomerSessionApiUnitTest.kt
@@ -64,8 +64,8 @@ class UpdateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called and a responseBody is returned, callback with Success is invoked`() =
-        runTest(testDispatcher) {
-            val responseBody = """
+    runTest(testDispatcher) {
+        val responseBody = """
             {
                 "data": {
                     "updateCustomerSession": {
@@ -75,26 +75,26 @@ class UpdateCustomerSessionApiUnitTest {
             }
         """.trimIndent()
 
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostSuccessfulResponse(responseBody)
-                .build()
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
 
-            val responseParser = mockk<ShopperInsightsResponseParser> {
-                every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
-            }
-
-            val updateCustomerSessionApi = UpdateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
-                responseParser = responseParser
-            )
-
-            val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-            advanceUntilIdle()
-
-            assert(result is UpdateCustomerSessionResult.Success)
-            assertEquals(sessionId, (result as UpdateCustomerSessionResult.Success).sessionId)
+        val responseParser = mockk<ShopperInsightsResponseParser> {
+            every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
         }
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder>(relaxed = true),
+            responseParser = responseParser
+        )
+
+        val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+        advanceUntilIdle()
+
+        assert(result is UpdateCustomerSessionResult.Success)
+        assertEquals(sessionId, (result as UpdateCustomerSessionResult.Success).sessionId)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -120,23 +120,23 @@ class UpdateCustomerSessionApiUnitTest {
 
     @Test
     fun `when execute is called and a JSONException is thrown, callback with Error is invoked`() =
-        runTest(testDispatcher) {
-            val exception = JSONException("Test exception")
-            val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
-                every { createRequestObjects(any()) } throws exception
-            }
-
-            val updateCustomerSessionApi = UpdateCustomerSessionApi(
-                braintreeClient = mockk<BraintreeClient>(relaxed = true),
-                customerSessionRequestBuilder = customerSessionRequestBuilder,
-                responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
-            )
-
-            val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
-
-            assert(result is UpdateCustomerSessionResult.Error)
-            assertEquals(exception, (result as UpdateCustomerSessionResult.Error).error)
+    runTest(testDispatcher) {
+        val exception = JSONException("Test exception")
+        val customerSessionRequestBuilder = mockk<CustomerSessionRequestBuilder> {
+            every { createRequestObjects(any()) } throws exception
         }
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = mockk<BraintreeClient>(relaxed = true),
+            customerSessionRequestBuilder = customerSessionRequestBuilder,
+            responseParser = mockk<ShopperInsightsResponseParser>(relaxed = true)
+        )
+
+        val result = updateCustomerSessionApi.execute(customerSessionRequest, sessionId)
+
+        assert(result is UpdateCustomerSessionResult.Error)
+        assertEquals(exception, (result as UpdateCustomerSessionResult.Error).error)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressWarnings("LongMethod")
@@ -208,76 +208,76 @@ class UpdateCustomerSessionApiUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when execute is called with payPalCampaigns, GraphQL variables include paypalCampaigns`() =
-        runTest(testDispatcher) {
-            val requestWithCampaigns = customerSessionRequest.copy(
-                payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
-            )
+    runTest(testDispatcher) {
+        val requestWithCampaigns = customerSessionRequest.copy(
+            payPalCampaigns = listOf(PayPalCampaign(id = "PPL-MOCK-CAMPAIGN"))
+        )
 
-            val responseBody = """
-            {
-                "data": {
-                    "updateCustomerSession": {
-                        "sessionId": "$sessionId"
-                    }
+        val responseBody = """
+        {
+            "data": {
+                "updateCustomerSession": {
+                    "sessionId": "$sessionId"
                 }
-            }
-            """.trimIndent()
-
-            val braintreeClient = MockkBraintreeClientBuilder()
-                .sendGraphQLPostSuccessfulResponse(responseBody)
-                .build()
-
-            val updateCustomerSessionApi = UpdateCustomerSessionApi(
-                braintreeClient = braintreeClient,
-                responseParser = mockk {
-                    every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
-                }
-            )
-
-            updateCustomerSessionApi.execute(requestWithCampaigns, sessionId)
-            advanceUntilIdle()
-
-            val expectedRequestBody = JSONObject().apply {
-                put(
-                    "query",
-                    """
-                mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
-                    updateCustomerSession(input: ${'$'}input) {
-                        sessionId
-                    }
-                }
-                    """.trimIndent()
-                )
-                put(
-                    "variables",
-                    JSONObject().apply {
-                        put("input", JSONObject().apply {
-                            put("sessionId", sessionId)
-                            put("customer", JSONObject().apply {
-                                put("hashedEmail", "hashedEmail")
-                                put("hashedPhoneNumber", "hashedPhoneNumber")
-                                put("paypalAppInstalled", true)
-                                put("venmoAppInstalled", false)
-                            })
-                            put(
-                                "paypal_campaigns",
-                                JSONArray().apply {
-                                    put(
-                                        JSONObject().apply {
-                                            put("id", "PPL-MOCK-CAMPAIGN")
-                                        }
-                                    )
-                                }
-                            )
-                        })
-                    }
-                )
-            }
-
-            coVerify {
-                braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
-                    JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
-                })
             }
         }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
+
+        val updateCustomerSessionApi = UpdateCustomerSessionApi(
+            braintreeClient = braintreeClient,
+            responseParser = mockk {
+                every { parseSessionId(responseBody, "updateCustomerSession") } returns sessionId
+            }
+        )
+
+        updateCustomerSessionApi.execute(requestWithCampaigns, sessionId)
+        advanceUntilIdle()
+
+        val expectedRequestBody = JSONObject().apply {
+            put(
+                "query",
+                """
+            mutation UpdateCustomerSession(${'$'}input: UpdateCustomerSessionInput!) {
+                updateCustomerSession(input: ${'$'}input) {
+                    sessionId
+                }
+            }
+                """.trimIndent()
+            )
+            put(
+                "variables",
+                JSONObject().apply {
+                    put("input", JSONObject().apply {
+                        put("sessionId", sessionId)
+                        put("customer", JSONObject().apply {
+                            put("hashedEmail", "hashedEmail")
+                            put("hashedPhoneNumber", "hashedPhoneNumber")
+                            put("paypalAppInstalled", true)
+                            put("venmoAppInstalled", false)
+                        })
+                        put(
+                            "paypal_campaigns",
+                            JSONArray().apply {
+                                put(
+                                    JSONObject().apply {
+                                        put("id", "PPL-MOCK-CAMPAIGN")
+                                    }
+                                )
+                            }
+                        )
+                    })
+                }
+            )
+        }
+
+        coVerify {
+            braintreeClient.sendGraphQLPOST(withArg { actualRequestBody ->
+                JSONAssert.assertEquals(expectedRequestBody, actualRequestBody, false)
+            })
+        }
+    }
 }


### PR DESCRIPTION
### Summary of changes

1. Add public PayPalCampaign (id) for Shopper Insights v2, aligned with iOS BTPayPalCampaign encoding ({ "id": "..." } per entry).
2. Extend CustomerSessionRequest with optional payPalCampaigns and wire it through CustomerSessionRequestBuilder.
3. Include paypal_campaigns in GraphQL variables for create session, update session, and generate customer recommendations APIs.
4. Extend ShopperInsightsClientV2 so generateCustomerRecommendations (and related overloads) accept optional payPalCampaigns, merging with the request when present.
5. Add/update unit tests asserting paypal_campaigns appears correctly in request JSON.

### Checklist

 - [x] Added a changelog entry
 - [x] Relevant test coverage
 - [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
- anandparmar2410-stack