### PR TITLE
test: add CI instrumentation test retry logic

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -25,4 +25,6 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace
+          script: |
+            ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace || \
+            ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -19,12 +19,22 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: run tests
+        id: run_tests
+        uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_7_pro
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace
+
+      - name: retry tests
+        if: steps.run_tests.outcome == 'failure'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: |
-            ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace || \
-            ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,7 +28,7 @@ class BraintreeHttpClientTest {
             fail("Must throw an exception")
         } catch (e: IOException) {
             // Make sure exception is due to authorization not SSL handshake
-            assertTrue(e.message?.contains("code=403") == true)
+            assertFalse(e.message?.contains("code=403") == true)
         }
     }
 

--- a/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
+++ b/BraintreeCore/src/androidTest/java/com/braintreepayments/api/core/BraintreeHttpClientTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +27,7 @@ class BraintreeHttpClientTest {
             fail("Must throw an exception")
         } catch (e: IOException) {
             // Make sure exception is due to authorization not SSL handshake
-            assertFalse(e.message?.contains("code=403") == true)
+            assertTrue(e.message?.contains("code=403") == true)
         }
     }
 


### PR DESCRIPTION
### Summary of changes
- Add an additional step to the instrumentation test action to retry on failure to help prevent failed builds due to test flake

DTMOBILE-2186 

### AI Usage

**Which AI Agent Was Used?**
- [x] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Use claude code to gather ideas on different options to accomplish test retry

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
- @saralvasquez 

