### PR TITLE
test: add instrumentation tests for PayPalMessaging module

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -27,7 +27,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck :PayPalMessaging:connectedCheck --stacktrace
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
@@ -37,4 +37,4 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :Demo:connectedCheck :PayPalMessaging:connectedCheck --stacktrace

--- a/PayPalMessaging/build.gradle
+++ b/PayPalMessaging/build.gradle
@@ -65,6 +65,11 @@ dependencies {
     testImplementation libs.test.parameter.injector
     testImplementation project(':TestUtils')
     testImplementation libs.coroutines.test
+
+    androidTestImplementation project(':TestUtils')
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.junit
 }
 
 // region signing and publishing

--- a/PayPalMessaging/src/androidTest/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingViewTest.kt
+++ b/PayPalMessaging/src/androidTest/java/com/braintreepayments/api/paypalmessaging/PayPalMessagingViewTest.kt
@@ -1,0 +1,177 @@
+package com.braintreepayments.api.paypalmessaging
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
+import com.braintreepayments.api.core.Authorization
+import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.SharedPreferencesHelper
+import com.paypal.messages.PayPalMessageView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+
+@OptIn(ExperimentalBetaApi::class)
+@RunWith(AndroidJUnit4ClassRunner::class)
+class PayPalMessagingViewTest {
+
+    @Before
+    fun setUp() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
+        SharedPreferencesHelper.overrideConfigurationCache(
+            ApplicationProvider.getApplicationContext(),
+            authorization,
+            configuration
+        )
+    }
+
+    @Test(timeout = 10000)
+    fun start_whenConfigHasNoPayPalClientId_callsOnFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration =
+            Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_NO_CLIENT_ID)
+        SharedPreferencesHelper.overrideConfigurationCache(
+            ApplicationProvider.getApplicationContext(),
+            authorization,
+            configuration
+        )
+
+        val countDownLatch = CountDownLatch(1)
+        val sut = PayPalMessagingView(
+            ApplicationProvider.getApplicationContext(),
+            Fixtures.TOKENIZATION_KEY
+        )
+
+        var capturedError: Exception? = null
+        sut.setListener(object : PayPalMessagingListener {
+            override fun onPayPalMessagingClick() = Unit
+            override fun onPayPalMessagingApply() = Unit
+            override fun onPayPalMessagingLoading() = Unit
+            override fun onPayPalMessagingSuccess() = Unit
+            override fun onPayPalMessagingFailure(error: Exception) {
+                capturedError = error
+                countDownLatch.countDown()
+            }
+        })
+
+        sut.start()
+        countDownLatch.await()
+
+        assertNotNull(capturedError)
+        assertEquals(
+            "Could not find PayPal client ID in Braintree configuration.",
+            capturedError?.message
+        )
+    }
+
+    @Test(timeout = 10000)
+    fun start_whenConfigFetchFails_callsOnFailure() {
+        val countDownLatch = CountDownLatch(1)
+        val sut = PayPalMessagingView(
+            ApplicationProvider.getApplicationContext(),
+            "sandbox_invalid_key_xxxxxxxx"
+        )
+
+        var capturedError: Exception? = null
+        sut.setListener(object : PayPalMessagingListener {
+            override fun onPayPalMessagingClick() = Unit
+            override fun onPayPalMessagingApply() = Unit
+            override fun onPayPalMessagingLoading() = Unit
+            override fun onPayPalMessagingSuccess() = Unit
+            override fun onPayPalMessagingFailure(error: Exception) {
+                capturedError = error
+                countDownLatch.countDown()
+            }
+        })
+
+        sut.start()
+        countDownLatch.await()
+
+        assertNotNull(capturedError)
+    }
+
+    @Test(timeout = 10000)
+    fun start_whenConfigHasPayPalClientId_addsPayPalMessageView() {
+        val countDownLatch = CountDownLatch(1)
+        val sut = PayPalMessagingView(
+            ApplicationProvider.getApplicationContext(),
+            Fixtures.TOKENIZATION_KEY
+        )
+
+        sut.setListener(object : PayPalMessagingListener {
+            override fun onPayPalMessagingClick() = Unit
+            override fun onPayPalMessagingApply() = Unit
+            override fun onPayPalMessagingLoading() {
+                countDownLatch.countDown()
+            }
+            override fun onPayPalMessagingSuccess() {
+                countDownLatch.countDown()
+            }
+            override fun onPayPalMessagingFailure(error: Exception) {
+                countDownLatch.countDown()
+            }
+        })
+
+        sut.start()
+        countDownLatch.await()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertEquals(1, sut.childCount)
+        assertTrue(sut.getChildAt(0) is PayPalMessageView)
+    }
+
+    @Test(timeout = 15000)
+    fun start_calledTwice_doesNotDuplicateChildViews() {
+        val firstLatch = CountDownLatch(1)
+        val sut = PayPalMessagingView(
+            ApplicationProvider.getApplicationContext(),
+            Fixtures.TOKENIZATION_KEY
+        )
+
+        sut.setListener(object : PayPalMessagingListener {
+            override fun onPayPalMessagingClick() = Unit
+            override fun onPayPalMessagingApply() = Unit
+            override fun onPayPalMessagingLoading() {
+                firstLatch.countDown()
+            }
+            override fun onPayPalMessagingSuccess() {
+                firstLatch.countDown()
+            }
+            override fun onPayPalMessagingFailure(error: Exception) {
+                firstLatch.countDown()
+            }
+        })
+
+        sut.start()
+        firstLatch.await()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val secondLatch = CountDownLatch(1)
+        sut.setListener(object : PayPalMessagingListener {
+            override fun onPayPalMessagingClick() = Unit
+            override fun onPayPalMessagingApply() = Unit
+            override fun onPayPalMessagingLoading() {
+                secondLatch.countDown()
+            }
+            override fun onPayPalMessagingSuccess() {
+                secondLatch.countDown()
+            }
+            override fun onPayPalMessagingFailure(error: Exception) {
+                secondLatch.countDown()
+            }
+        })
+
+        sut.start()
+        secondLatch.await()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertEquals(1, sut.childCount)
+    }
+}


### PR DESCRIPTION
### Summary of changes
- Add instrumentation tests for the PayPal module covering PayPalMessagingView
- Add :PayPalMessaging:connectedCheck to CI instrumentation test workflow (run + retry steps)
- Achieved test coverage is 70%

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Test Generation and brainstorming

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 

