### PR TITLE
test: Add instrumentation test coverage to SEPADirectDebit

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -27,7 +27,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :SEPADirectDebit:connectedCheck :Demo:connectedCheck --stacktrace
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
@@ -37,4 +37,4 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :SEPADirectDebit:connectedCheck :Demo:connectedCheck --stacktrace

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.kt
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.kt
@@ -29,7 +29,9 @@ class SEPADirectDebitClientTest {
 
     companion object {
         private const val SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn"
-        private const val SANDBOX_IBAN = "FR7630006000019876543210173" //generated using the same algorithm as the demo app
+
+        // generated using the same algorithm as the demo app
+        private const val SANDBOX_IBAN = "FR7630006000019876543210173"
     }
 
     @Before
@@ -435,5 +437,4 @@ class SEPADirectDebitClientTest {
             locale = "en-US"
         )
     }
-
 }

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.kt
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientTest.kt
@@ -1,0 +1,439 @@
+package com.braintreepayments.api.sepadirectdebit
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.core.Authorization
+import com.braintreepayments.api.core.BraintreeRequestCodes
+import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.core.PostalAddress
+import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.SharedPreferencesHelper
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class SEPADirectDebitClientTest {
+
+    private lateinit var context: Context
+
+    companion object {
+        private const val SANDBOX_TOKENIZATION_KEY = "sandbox_tmxhyf7d_dcpspy2brwdjr3qn"
+        private const val SANDBOX_IBAN = "FR7630006000019876543210173" //generated using the same algorithm as the demo app
+    }
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withValidRequest_returnsReadyToLaunchWithBrowserSwitchParams() {
+        val returnUrlScheme = "com.braintreepayments.test.sepa"
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, returnUrlScheme)
+        val request = buildValidSandboxRequest()
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val authResult = requireNotNull(result)
+        assertTrue(
+            "Expected ReadyToLaunch but got ${authResult::class.simpleName}",
+            authResult is SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        )
+
+        val readyToLaunch = authResult as SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        assertNotNull(readyToLaunch.requestParams)
+        assertNotNull(readyToLaunch.requestParams.browserSwitchOptions)
+
+        val options = readyToLaunch.requestParams.browserSwitchOptions
+        assertNotNull(options.url)
+        assertEquals(BraintreeRequestCodes.SEPA_DEBIT.code, options.requestCode)
+        assertEquals(returnUrlScheme, options.returnUrlScheme)
+
+        val metadata = requireNotNull(options.metadata)
+        assertTrue(metadata.optString("ibanLastFour").isNotEmpty())
+        assertTrue(metadata.optString("customerId").isNotEmpty())
+        assertTrue(metadata.optString("bankReferenceToken").isNotEmpty())
+        assertTrue(metadata.optString("mandateType").isNotEmpty())
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun endToEnd_successBrowserSwitch_returnsNonceWithDetails() {
+        val returnUrlScheme = "com.braintreepayments.test.sepa"
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, returnUrlScheme)
+        val request = buildValidSandboxRequest(mandateType = SEPADirectDebitMandateType.RECURRENT)
+
+        val createLatch = CountDownLatch(1)
+        var authRequest: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { result ->
+            authRequest = result
+            createLatch.countDown()
+        }
+        createLatch.await()
+
+        val createResult = requireNotNull(authRequest)
+        assertTrue(
+            "Expected ReadyToLaunch but got ${createResult::class.simpleName}",
+            createResult is SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        )
+        val readyToLaunch = createResult as SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        val options = readyToLaunch.requestParams.browserSwitchOptions
+        val metadata = requireNotNull(options.metadata)
+
+        val paymentAuthResult = simulateBrowserSwitchReturn(
+            returnUrlScheme = returnUrlScheme,
+            approvalUrl = options.url.toString(),
+            metadata = metadata,
+            returnPath = "sepa/success?success=true"
+        )
+
+        assertTrue(
+            "Expected Success but got ${paymentAuthResult::class.simpleName}",
+            paymentAuthResult is SEPADirectDebitPaymentAuthResult.Success
+        )
+
+        val tokenizeLatch = CountDownLatch(1)
+        var tokenizeResult: SEPADirectDebitResult? = null
+        sut.tokenize(paymentAuthResult as SEPADirectDebitPaymentAuthResult.Success) { result ->
+            tokenizeResult = result
+            tokenizeLatch.countDown()
+        }
+        tokenizeLatch.await()
+
+        val tokenResult = requireNotNull(tokenizeResult)
+        assertTrue(
+            "Expected Success but got ${tokenResult::class.simpleName}",
+            tokenResult is SEPADirectDebitResult.Success
+        )
+        val success = tokenResult as SEPADirectDebitResult.Success
+        assertNotNull(success.nonce)
+        assertTrue(success.nonce.string.isNotEmpty())
+        assertNotNull(success.nonce.ibanLastFour)
+        assertNotNull(success.nonce.customerId)
+        assertNotNull(success.nonce.mandateType)
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun endToEnd_cancelBrowserSwitch_returnsCancelResult() {
+        val returnUrlScheme = "com.braintreepayments.test.sepa"
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, returnUrlScheme)
+        val request = buildValidSandboxRequest()
+
+        val createLatch = CountDownLatch(1)
+        var authRequest: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { result ->
+            authRequest = result
+            createLatch.countDown()
+        }
+        createLatch.await()
+
+        val createResult = requireNotNull(authRequest)
+        assertTrue(
+            "Expected ReadyToLaunch but got ${createResult::class.simpleName}",
+            createResult is SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        )
+        val readyToLaunch = createResult as SEPADirectDebitPaymentAuthRequest.ReadyToLaunch
+        val options = readyToLaunch.requestParams.browserSwitchOptions
+        val metadata = requireNotNull(options.metadata)
+
+        val paymentAuthResult = simulateBrowserSwitchReturn(
+            returnUrlScheme = returnUrlScheme,
+            approvalUrl = options.url.toString(),
+            metadata = metadata,
+            returnPath = "sepa/cancel"
+        )
+
+        assertTrue(paymentAuthResult is SEPADirectDebitPaymentAuthResult.Success)
+
+        val tokenizeLatch = CountDownLatch(1)
+        var tokenizeResult: SEPADirectDebitResult? = null
+        sut.tokenize(paymentAuthResult as SEPADirectDebitPaymentAuthResult.Success) { result ->
+            tokenizeResult = result
+            tokenizeLatch.countDown()
+        }
+        tokenizeLatch.await()
+
+        val cancelResult = requireNotNull(tokenizeResult)
+        assertTrue(
+            "Expected Cancel but got ${cancelResult::class.simpleName}",
+            cancelResult is SEPADirectDebitResult.Cancel
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withMissingIban_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+
+        val request = SEPADirectDebitRequest(
+            accountHolderName = "John Doe",
+            iban = null,
+            customerId = "a-customer-id",
+            mandateType = SEPADirectDebitMandateType.ONE_OFF,
+            merchantAccountId = "EUR-sepa-direct-debit"
+        )
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withMissingAccountHolderName_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+
+        val request = SEPADirectDebitRequest(
+            accountHolderName = null,
+            iban = SANDBOX_IBAN,
+            customerId = "a-customer-id",
+            mandateType = SEPADirectDebitMandateType.ONE_OFF,
+            merchantAccountId = "EUR-sepa-direct-debit"
+        )
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withMissingCustomerId_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+
+        val request = SEPADirectDebitRequest(
+            accountHolderName = "John Doe",
+            iban = SANDBOX_IBAN,
+            customerId = null,
+            mandateType = SEPADirectDebitMandateType.ONE_OFF,
+            merchantAccountId = "EUR-sepa-direct-debit"
+        )
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withMissingBillingAddress_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+
+        val request = SEPADirectDebitRequest(
+            accountHolderName = "John Doe",
+            iban = SANDBOX_IBAN,
+            customerId = UUID.randomUUID().toString().substring(0, 20),
+            mandateType = SEPADirectDebitMandateType.ONE_OFF,
+            billingAddress = null,
+            merchantAccountId = "EUR-sepa-direct-debit"
+        )
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withEmptyRequest_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+        val request = SEPADirectDebitRequest()
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withInvalidAuthorization_returnsFailure() {
+        val sut = SEPADirectDebitClient(context, "invalid_authorization_key", null)
+        val request = buildValidSandboxRequest()
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withDisabledPayPal_returnsFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_DISABLED_PAYPAL)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+
+        val sut = SEPADirectDebitClient(context, Fixtures.TOKENIZATION_KEY, null)
+        val request = buildValidSandboxRequest()
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        val failureResult = requireNotNull(result)
+        assertTrue(
+            "Expected Failure but got ${failureResult::class.simpleName}",
+            failureResult is SEPADirectDebitPaymentAuthRequest.Failure
+        )
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_failureResult_containsNonNullError() {
+        val sut = SEPADirectDebitClient(context, SANDBOX_TOKENIZATION_KEY, null)
+        val request = SEPADirectDebitRequest()
+
+        val latch = CountDownLatch(1)
+        var result: SEPADirectDebitPaymentAuthRequest? = null
+        sut.createPaymentAuthRequest(request) { paymentAuthRequest ->
+            result = paymentAuthRequest
+            latch.countDown()
+        }
+
+        latch.await()
+
+        assertTrue(result is SEPADirectDebitPaymentAuthRequest.Failure)
+        val failure = result as SEPADirectDebitPaymentAuthRequest.Failure
+        assertNotNull(failure.error)
+        assertNotNull(failure.error.message)
+    }
+
+    private fun simulateBrowserSwitchReturn(
+        returnUrlScheme: String,
+        approvalUrl: String,
+        metadata: JSONObject,
+        returnPath: String
+    ): SEPADirectDebitPaymentAuthResult {
+        val pendingRequestJson = JSONObject()
+            .put("requestCode", BraintreeRequestCodes.SEPA_DEBIT.code)
+            .put("url", approvalUrl)
+            .put("returnUrlScheme", returnUrlScheme)
+            .put("metadata", metadata)
+
+        val pendingRequestString = Base64.encodeToString(
+            pendingRequestJson.toString().toByteArray(Charsets.UTF_8),
+            Base64.DEFAULT
+        )
+
+        val intent = Intent().apply {
+            data = Uri.parse("$returnUrlScheme://$returnPath")
+        }
+
+        val launcher = SEPADirectDebitLauncher()
+        val pendingRequest = SEPADirectDebitPendingRequest.Started(pendingRequestString)
+        return launcher.handleReturnToApp(pendingRequest, intent)
+    }
+
+    private fun buildValidSandboxRequest(
+        mandateType: SEPADirectDebitMandateType = SEPADirectDebitMandateType.ONE_OFF
+    ): SEPADirectDebitRequest {
+        val billingAddress = PostalAddress()
+        billingAddress.streetAddress = "Kantstraße 70"
+        billingAddress.extendedAddress = "#170"
+        billingAddress.locality = "Freistaat Sachsen"
+        billingAddress.region = "Annaberg-buchholz"
+        billingAddress.postalCode = "09456"
+        billingAddress.countryCodeAlpha2 = "FR"
+
+        return SEPADirectDebitRequest(
+            accountHolderName = "John Doe",
+            iban = SANDBOX_IBAN,
+            customerId = UUID.randomUUID().toString().substring(0, 20),
+            mandateType = mandateType,
+            billingAddress = billingAddress,
+            merchantAccountId = "EUR-sepa-direct-debit",
+            locale = "en-US"
+        )
+    }
+
+}

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherTest.kt
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitLauncherTest.kt
@@ -1,0 +1,84 @@
+package com.braintreepayments.api.sepadirectdebit
+
+import android.content.Intent
+import android.net.Uri
+import android.util.Base64
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.core.BraintreeRequestCodes
+import org.json.JSONObject
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class SEPADirectDebitLauncherTest {
+
+    private val returnUrlScheme = "com.braintreepayments.test"
+
+    @Test
+    fun handleReturnToApp_withSuccessDeepLink_returnsSuccess() {
+        val launcher = SEPADirectDebitLauncher()
+        val pendingRequest = buildPendingRequest()
+
+        val intent = Intent().apply {
+            data = Uri.parse("$returnUrlScheme://sepa/success?success=true")
+        }
+
+        val result = launcher.handleReturnToApp(pendingRequest, intent)
+        assertTrue(
+            "Expected Success but got ${result::class.simpleName}",
+            result is SEPADirectDebitPaymentAuthResult.Success
+        )
+    }
+
+    @Test
+    fun handleReturnToApp_withCancelDeepLink_returnsSuccess() {
+        val launcher = SEPADirectDebitLauncher()
+        val pendingRequest = buildPendingRequest()
+
+        val intent = Intent().apply {
+            data = Uri.parse("$returnUrlScheme://sepa/cancel")
+        }
+
+        val result = launcher.handleReturnToApp(pendingRequest, intent)
+        assertTrue(
+            "Expected Success but got ${result::class.simpleName}",
+            result is SEPADirectDebitPaymentAuthResult.Success
+        )
+    }
+
+    @Test
+    fun handleReturnToApp_withNonMatchingIntent_returnsNoResult() {
+        val launcher = SEPADirectDebitLauncher()
+        val pendingRequest = buildPendingRequest()
+
+        val intent = Intent()
+
+        val result = launcher.handleReturnToApp(pendingRequest, intent)
+        assertTrue(
+            "Expected NoResult but got ${result::class.simpleName}",
+            result is SEPADirectDebitPaymentAuthResult.NoResult
+        )
+    }
+
+    private fun buildPendingRequest(): SEPADirectDebitPendingRequest.Started {
+        val metadata = JSONObject()
+            .put("ibanLastFour", "6610")
+            .put("customerId", "a-customer-id")
+            .put("bankReferenceToken", "QkEtWDZDQkpCUU5TWENDVw")
+            .put("mandateType", "RECURRENT")
+
+        val pendingRequestJson = JSONObject()
+            .put("requestCode", BraintreeRequestCodes.SEPA_DEBIT.code)
+            .put("url", "https://api.test19.stage.paypal.com/directdebit/mandate/authorize")
+            .put("returnUrlScheme", returnUrlScheme)
+            .put("metadata", metadata)
+
+        val pendingRequestString = Base64.encodeToString(
+            pendingRequestJson.toString().toByteArray(Charsets.UTF_8),
+            Base64.DEFAULT
+        )
+
+        return SEPADirectDebitPendingRequest.Started(pendingRequestString)
+    }
+}

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonceTest.kt
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitNonceTest.kt
@@ -1,0 +1,92 @@
+package com.braintreepayments.api.sepadirectdebit
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.testutils.Fixtures
+import kotlinx.parcelize.parcelableCreator
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class SEPADirectDebitNonceTest {
+
+    @Test
+    fun parcels_withAllFieldsPopulated() {
+        val nonce = SEPADirectDebitNonce(
+            string = "fake-nonce-123",
+            isDefault = true,
+            ibanLastFour = "1234",
+            customerId = "customer-abc",
+            mandateType = SEPADirectDebitMandateType.RECURRENT
+        )
+
+        val parcel = Parcel.obtain()
+        nonce.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val parceled = parcelableCreator<SEPADirectDebitNonce>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals("fake-nonce-123", parceled.string)
+        assertEquals(true, parceled.isDefault)
+        assertEquals("1234", parceled.ibanLastFour)
+        assertEquals("customer-abc", parceled.customerId)
+        assertEquals(SEPADirectDebitMandateType.RECURRENT, parceled.mandateType)
+    }
+
+    @Test
+    fun parcels_withNullOptionalFields() {
+        val nonce = SEPADirectDebitNonce(
+            string = "fake-nonce-456",
+            isDefault = false,
+            ibanLastFour = null,
+            customerId = null,
+            mandateType = null
+        )
+
+        val parcel = Parcel.obtain()
+        nonce.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val parceled = parcelableCreator<SEPADirectDebitNonce>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals("fake-nonce-456", parceled.string)
+        assertFalse(parceled.isDefault)
+        assertNull(parceled.ibanLastFour)
+        assertNull(parceled.customerId)
+        assertNull(parceled.mandateType)
+    }
+
+    @Test
+    fun fromJSON_parsesTokenizeResponse() {
+        val json = JSONObject(Fixtures.SEPA_DEBIT_TOKENIZE_RESPONSE)
+        val nonce = SEPADirectDebitNonce.fromJSON(json)
+
+        assertEquals("1194c322-9763-08b7-4777-0b9b5e5cc3e4", nonce.string)
+        assertFalse(nonce.isDefault)
+        assertEquals("1234", nonce.ibanLastFour)
+        assertEquals("a-customer-id", nonce.customerId)
+        assertEquals(SEPADirectDebitMandateType.ONE_OFF, nonce.mandateType)
+    }
+
+    @Test
+    fun fromJSON_withMissingDetails_hasNullOptionalFields() {
+        val json = JSONObject("""
+            {
+                "nonce": "test-nonce-789"
+            }
+        """)
+        val nonce = SEPADirectDebitNonce.fromJSON(json)
+
+        assertEquals("test-nonce-789", nonce.string)
+        assertFalse(nonce.isDefault)
+        assertNull(nonce.ibanLastFour)
+        assertNull(nonce.customerId)
+        assertNull(nonce.mandateType)
+    }
+}

--- a/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequestTest.kt
+++ b/SEPADirectDebit/src/androidTest/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitRequestTest.kt
@@ -1,0 +1,59 @@
+package com.braintreepayments.api.sepadirectdebit
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.core.PostalAddress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class SEPADirectDebitRequestTest {
+
+    @Test
+    fun defaultValues_areCorrect() {
+        val request = SEPADirectDebitRequest()
+
+        assertNull(request.accountHolderName)
+        assertNull(request.iban)
+        assertNull(request.customerId)
+        assertEquals(SEPADirectDebitMandateType.ONE_OFF, request.mandateType)
+        assertNull(request.billingAddress)
+        assertNull(request.merchantAccountId)
+        assertNull(request.locale)
+    }
+
+    @Test
+    fun allFields_canBeSet() {
+        val billingAddress = PostalAddress()
+        billingAddress.streetAddress = "Kantstraße 70"
+        billingAddress.extendedAddress = "Apt 1"
+        billingAddress.locality = "Freistaat Sachsen"
+        billingAddress.region = "Sachsen"
+        billingAddress.postalCode = "01069"
+        billingAddress.countryCodeAlpha2 = "DE"
+
+        val request = SEPADirectDebitRequest(
+            accountHolderName = "John Doe",
+            iban = "DE89370400440532013000",
+            customerId = "customer-123",
+            mandateType = SEPADirectDebitMandateType.RECURRENT,
+            billingAddress = billingAddress,
+            merchantAccountId = "EUR-sepa-direct-debit",
+            locale = "en-US"
+        )
+
+        assertEquals("John Doe", request.accountHolderName)
+        assertEquals("DE89370400440532013000", request.iban)
+        assertEquals("customer-123", request.customerId)
+        assertEquals(SEPADirectDebitMandateType.RECURRENT, request.mandateType)
+        assertEquals("Kantstraße 70", request.billingAddress?.streetAddress)
+        assertEquals("Apt 1", request.billingAddress?.extendedAddress)
+        assertEquals("Freistaat Sachsen", request.billingAddress?.locality)
+        assertEquals("Sachsen", request.billingAddress?.region)
+        assertEquals("01069", request.billingAddress?.postalCode)
+        assertEquals("DE", request.billingAddress?.countryCodeAlpha2)
+        assertEquals("EUR-sepa-direct-debit", request.merchantAccountId)
+        assertEquals("en-US", request.locale)
+    }
+}


### PR DESCRIPTION
### Summary of changes
- Add instrumentation tests for SEPADirectDebitNonce, SEPADirectDebitClient, SEPADirectDebitLauncher, SEPADirectDebitRequest
- Add :SEPADirectDebit:connectedCheck to CI instrumentation test workflow (run + retry steps)
- Achieved test coverage is 77%

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Test generation and brainstorming

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 

