### PR TITLE
test: add instrumentation test coverage to ThreeDSecure module

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -27,7 +27,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :ThreeDSecure:connectedCheck --stacktrace
 
 
       - name: retry tests
@@ -38,5 +38,5 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :ThreeDSecure:connectedCheck --stacktrace
 

--- a/ThreeDSecure/src/androidTest/AndroidManifest.xml
+++ b/ThreeDSecure/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureAdditionalInformationTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureAdditionalInformationTest.kt
@@ -1,0 +1,251 @@
+package com.braintreepayments.api.threedsecure
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import kotlinx.parcelize.parcelableCreator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureAdditionalInformationTest {
+
+    @Suppress("LongMethod")
+    @Test
+    fun parcels_withAllFieldsPopulated() {
+        val shippingAddress = ThreeDSecurePostalAddress(
+            givenName = "Joe",
+            surname = "Guy",
+            streetAddress = "555 Smith St.",
+            extendedAddress = "Unit 1",
+            line3 = "Building A",
+            locality = "Oakland",
+            region = "CA",
+            postalCode = "12345",
+            countryCodeAlpha2 = "US",
+            phoneNumber = "5551234567"
+        )
+
+        val original = ThreeDSecureAdditionalInformation(
+            shippingAddress = shippingAddress,
+            shippingMethodIndicator = "01",
+            productCode = "AIR",
+            deliveryTimeframe = "02",
+            deliveryEmail = "test@example.com",
+            reorderIndicator = "01",
+            preorderIndicator = "02",
+            preorderDate = "20250101",
+            giftCardAmount = "100",
+            giftCardCurrencyCode = "USD",
+            giftCardCount = "2",
+            accountAgeIndicator = "05",
+            accountCreateDate = "20200101",
+            accountChangeIndicator = "04",
+            accountChangeDate = "20240601",
+            accountPwdChangeIndicator = "03",
+            accountPwdChangeDate = "20240501",
+            shippingAddressUsageIndicator = "04",
+            shippingAddressUsageDate = "20230101",
+            transactionCountDay = "3",
+            transactionCountYear = "50",
+            addCardAttempts = "1",
+            accountPurchases = "20",
+            fraudActivity = "01",
+            shippingNameIndicator = "01",
+            paymentAccountIndicator = "05",
+            paymentAccountAge = "20190601",
+            addressMatch = "Y",
+            accountId = "user-123",
+            ipAddress = "192.168.1.1",
+            orderDescription = "Test order",
+            taxAmount = "1000",
+            userAgent = "Mozilla/5.0",
+            authenticationIndicator = "02",
+            installment = "3",
+            purchaseDate = "20250101120000",
+            recurringEnd = "20261231",
+            recurringFrequency = "28",
+            sdkMaxTimeout = "05",
+            workPhoneNumber = "5559876543"
+        )
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureAdditionalInformation>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(original.shippingAddress?.givenName, restored.shippingAddress?.givenName)
+        assertEquals(original.shippingAddress?.surname, restored.shippingAddress?.surname)
+        assertEquals(original.shippingAddress?.streetAddress, restored.shippingAddress?.streetAddress)
+        assertEquals(original.shippingAddress?.locality, restored.shippingAddress?.locality)
+        assertEquals(original.shippingAddress?.postalCode, restored.shippingAddress?.postalCode)
+        assertEquals(original.shippingMethodIndicator, restored.shippingMethodIndicator)
+        assertEquals(original.productCode, restored.productCode)
+        assertEquals(original.deliveryTimeframe, restored.deliveryTimeframe)
+        assertEquals(original.deliveryEmail, restored.deliveryEmail)
+        assertEquals(original.reorderIndicator, restored.reorderIndicator)
+        assertEquals(original.preorderIndicator, restored.preorderIndicator)
+        assertEquals(original.preorderDate, restored.preorderDate)
+        assertEquals(original.giftCardAmount, restored.giftCardAmount)
+        assertEquals(original.giftCardCurrencyCode, restored.giftCardCurrencyCode)
+        assertEquals(original.giftCardCount, restored.giftCardCount)
+        assertEquals(original.accountAgeIndicator, restored.accountAgeIndicator)
+        assertEquals(original.accountCreateDate, restored.accountCreateDate)
+        assertEquals(original.accountChangeIndicator, restored.accountChangeIndicator)
+        assertEquals(original.accountChangeDate, restored.accountChangeDate)
+        assertEquals(original.accountPwdChangeIndicator, restored.accountPwdChangeIndicator)
+        assertEquals(original.accountPwdChangeDate, restored.accountPwdChangeDate)
+        assertEquals(original.shippingAddressUsageIndicator, restored.shippingAddressUsageIndicator)
+        assertEquals(original.shippingAddressUsageDate, restored.shippingAddressUsageDate)
+        assertEquals(original.transactionCountDay, restored.transactionCountDay)
+        assertEquals(original.transactionCountYear, restored.transactionCountYear)
+        assertEquals(original.addCardAttempts, restored.addCardAttempts)
+        assertEquals(original.accountPurchases, restored.accountPurchases)
+        assertEquals(original.fraudActivity, restored.fraudActivity)
+        assertEquals(original.shippingNameIndicator, restored.shippingNameIndicator)
+        assertEquals(original.paymentAccountIndicator, restored.paymentAccountIndicator)
+        assertEquals(original.paymentAccountAge, restored.paymentAccountAge)
+        assertEquals(original.addressMatch, restored.addressMatch)
+        assertEquals(original.accountId, restored.accountId)
+        assertEquals(original.ipAddress, restored.ipAddress)
+        assertEquals(original.orderDescription, restored.orderDescription)
+        assertEquals(original.taxAmount, restored.taxAmount)
+        assertEquals(original.userAgent, restored.userAgent)
+        assertEquals(original.authenticationIndicator, restored.authenticationIndicator)
+        assertEquals(original.installment, restored.installment)
+        assertEquals(original.purchaseDate, restored.purchaseDate)
+        assertEquals(original.recurringEnd, restored.recurringEnd)
+        assertEquals(original.recurringFrequency, restored.recurringFrequency)
+        assertEquals(original.sdkMaxTimeout, restored.sdkMaxTimeout)
+        assertEquals(original.workPhoneNumber, restored.workPhoneNumber)
+    }
+
+    @Test
+    fun parcels_withDefaultValues() {
+        val original = ThreeDSecureAdditionalInformation()
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureAdditionalInformation>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertNull(restored.shippingAddress)
+        assertNull(restored.shippingMethodIndicator)
+        assertNull(restored.productCode)
+        assertNull(restored.deliveryTimeframe)
+        assertNull(restored.deliveryEmail)
+        assertNull(restored.accountId)
+        assertNull(restored.ipAddress)
+        assertNull(restored.workPhoneNumber)
+    }
+
+    @Test
+    fun parcels_withNestedShippingAddress() {
+        val shippingAddress = ThreeDSecurePostalAddress(
+            givenName = "Jane",
+            surname = "Doe",
+            streetAddress = "123 Main St",
+            extendedAddress = "Suite 200",
+            line3 = "Floor 3",
+            locality = "Chicago",
+            region = "IL",
+            postalCode = "60601",
+            countryCodeAlpha2 = "US",
+            phoneNumber = "3125551234"
+        )
+        val original = ThreeDSecureAdditionalInformation(shippingAddress = shippingAddress)
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureAdditionalInformation>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals("Jane", restored.shippingAddress?.givenName)
+        assertEquals("Doe", restored.shippingAddress?.surname)
+        assertEquals("123 Main St", restored.shippingAddress?.streetAddress)
+        assertEquals("Suite 200", restored.shippingAddress?.extendedAddress)
+        assertEquals("Floor 3", restored.shippingAddress?.line3)
+        assertEquals("Chicago", restored.shippingAddress?.locality)
+        assertEquals("IL", restored.shippingAddress?.region)
+        assertEquals("60601", restored.shippingAddress?.postalCode)
+        assertEquals("US", restored.shippingAddress?.countryCodeAlpha2)
+        assertEquals("3125551234", restored.shippingAddress?.phoneNumber)
+    }
+
+    @Test
+    fun toJson_withAllFieldsPopulated() {
+        val shippingAddress = ThreeDSecurePostalAddress(
+            givenName = "Joe",
+            surname = "Guy",
+            streetAddress = "555 Smith St.",
+            locality = "Oakland",
+            region = "CA",
+            postalCode = "12345",
+            countryCodeAlpha2 = "US",
+            phoneNumber = "5551234567"
+        )
+
+        val additionalInfo = ThreeDSecureAdditionalInformation(
+            shippingAddress = shippingAddress,
+            shippingMethodIndicator = "01",
+            productCode = "AIR",
+            deliveryTimeframe = "02",
+            deliveryEmail = "test@example.com",
+            reorderIndicator = "01",
+            preorderIndicator = "02",
+            preorderDate = "20250101",
+            giftCardAmount = "100",
+            giftCardCurrencyCode = "USD",
+            giftCardCount = "2",
+            accountAgeIndicator = "05",
+            accountCreateDate = "20200101",
+            ipAddress = "192.168.1.1",
+            orderDescription = "Test order",
+            taxAmount = "1000",
+            workPhoneNumber = "5559876543"
+        )
+
+        val json = additionalInfo.toJson()
+
+        assertEquals("Joe", json.getString("shipping_given_name"))
+        assertEquals("Guy", json.getString("shipping_surname"))
+        assertEquals("555 Smith St.", json.getString("shipping_line1"))
+        assertEquals("Oakland", json.getString("shipping_city"))
+        assertEquals("CA", json.getString("shipping_state"))
+        assertEquals("12345", json.getString("shipping_postal_code"))
+        assertEquals("US", json.getString("shipping_country_code"))
+        assertEquals("5551234567", json.getString("shipping_phone"))
+        assertEquals("01", json.getString("shipping_method_indicator"))
+        assertEquals("AIR", json.getString("product_code"))
+        assertEquals("02", json.getString("delivery_timeframe"))
+        assertEquals("test@example.com", json.getString("delivery_email"))
+        assertEquals("01", json.getString("reorder_indicator"))
+        assertEquals("02", json.getString("preorder_indicator"))
+        assertEquals("20250101", json.getString("preorder_date"))
+        assertEquals("100", json.getString("gift_card_amount"))
+        assertEquals("USD", json.getString("gift_card_currency_code"))
+        assertEquals("2", json.getString("gift_card_count"))
+        assertEquals("05", json.getString("account_age_indicator"))
+        assertEquals("20200101", json.getString("account_create_date"))
+        assertEquals("192.168.1.1", json.getString("ip_address"))
+        assertEquals("Test order", json.getString("order_description"))
+        assertEquals("1000", json.getString("tax_amount"))
+        assertEquals("5559876543", json.getString("work_phone_number"))
+    }
+
+    @Test
+    fun toJson_withEmptyFields() {
+        val additionalInfo = ThreeDSecureAdditionalInformation()
+
+        val json = additionalInfo.toJson()
+
+        assertEquals(0, json.length())
+    }
+}

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientTest.kt
@@ -1,0 +1,573 @@
+package com.braintreepayments.api.threedsecure
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.card.Card
+import com.braintreepayments.api.card.CardClient
+import com.braintreepayments.api.card.CardResult
+import com.braintreepayments.api.core.Authorization
+import com.braintreepayments.api.core.BraintreeException
+import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.testutils.CardNumber
+import com.braintreepayments.api.testutils.ExpirationDateHelper
+import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.SharedPreferencesHelper
+import com.braintreepayments.api.testutils.TestClientTokenBuilder
+import com.cardinalcommerce.cardinalmobilesdk.cm.models.CardinalError
+import com.cardinalcommerce.cardinalmobilesdk.models.CardinalActionCode
+import com.cardinalcommerce.cardinalmobilesdk.models.ValidateResponse
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureClientTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test(timeout = 10000)
+    fun createPaymentAuthRequest_withNullAmount_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val request = ThreeDSecureRequest(nonce = "fake-nonce", amount = null)
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            val failure = result as ThreeDSecurePaymentAuthRequest.Failure
+            assertTrue(failure.error.message.orEmpty().contains("nonce and amount cannot be null"))
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun createPaymentAuthRequest_withNullNonce_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val request = ThreeDSecureRequest(nonce = null, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("nonce and amount cannot be null")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun createPaymentAuthRequest_whenThreeDSecureDisabled_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITHOUT_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val request = ThreeDSecureRequest(nonce = "fake-nonce", amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("Three D Secure is not enabled")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun createPaymentAuthRequest_whenMissingCardinalJwt_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val request = ThreeDSecureRequest(nonce = "fake-nonce", amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("Merchant is not configured for 3DS 2.0")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withInvalidJson_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse("not valid json") { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withNoPaymentMethodOrLookup_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse(
+            Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR
+        ) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("lookup and threeDSecureNonce are null")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withNonceButNoLookup_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse(
+            Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE
+        ) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("lookup and threeDSecureNonce are null")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withV1Response_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse(
+            Fixtures.THREE_D_SECURE_V1_LOOKUP_RESPONSE
+        ) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.Failure)
+            assertTrue(
+                (result as ThreeDSecurePaymentAuthRequest.Failure)
+                    .error.message.orEmpty().contains("3D Secure v1 is deprecated")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withV2AcsUrl_returnsReadyToLaunch() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse(
+            Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE
+        ) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.ReadyToLaunch)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun initializeChallengeWithLookupResponse_withNoAcsUrl_returnsLaunchNotRequiredWithNonceDetails() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val countDownLatch = CountDownLatch(1)
+
+        sut.initializeChallengeWithLookupResponse(
+            Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE_NO_ACS_URL
+        ) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+            val nonce = (result as ThreeDSecurePaymentAuthRequest.LaunchNotRequired).nonce
+            assertEquals("Visa", nonce.cardType)
+            assertEquals("11", nonce.lastTwo)
+            assertEquals("1111", nonce.lastFour)
+            assertTrue(nonce.threeDSecureInfo.liabilityShifted)
+            assertTrue(nonce.threeDSecureInfo.liabilityShiftPossible)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun tokenize_withError_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val paymentAuthResult = ThreeDSecurePaymentAuthResult(
+            error = BraintreeException("3DS challenge failed")
+        )
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.tokenize(paymentAuthResult) { result ->
+            assertTrue(result is ThreeDSecureResult.Failure)
+            val failure = result as ThreeDSecureResult.Failure
+            assertEquals("3DS challenge failed", failure.error.message)
+            assertNull(failure.nonce)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun tokenize_whenCanceled_returnsCancel() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val paymentAuthResult = ThreeDSecurePaymentAuthResult(
+            validateResponse = ValidateResponse(false, CardinalActionCode.CANCEL, CardinalError(0, "User canceled"))
+        )
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.tokenize(paymentAuthResult) { result ->
+            assertTrue(result is ThreeDSecureResult.Cancel)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun tokenize_whenErrorOrTimeout_returnsFailureWithNullNonce() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val paymentAuthResult = ThreeDSecurePaymentAuthResult(
+            validateResponse = ValidateResponse(false, CardinalActionCode.TIMEOUT, CardinalError(0, "Timeout occurred"))
+        )
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.tokenize(paymentAuthResult) { result ->
+            assertTrue(result is ThreeDSecureResult.Failure)
+            assertNull((result as ThreeDSecureResult.Failure).nonce)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun tokenize_whenSuccess_withNullParams_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val paymentAuthResult = ThreeDSecurePaymentAuthResult(
+            validateResponse = ValidateResponse(true, CardinalActionCode.SUCCESS, CardinalError(0)),
+            threeDSecureParams = null,
+            jwt = null
+        )
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.tokenize(paymentAuthResult) { result ->
+            assertTrue(result is ThreeDSecureResult.Failure)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun tokenize_withNullValidateResponse_returnsInvalidActionCodeFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val paymentAuthResult = ThreeDSecurePaymentAuthResult(
+            validateResponse = null,
+            threeDSecureParams = null,
+            jwt = null
+        )
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.tokenize(paymentAuthResult) { result ->
+            assertTrue(result is ThreeDSecureResult.Failure)
+            assertEquals("invalid action code", (result as ThreeDSecureResult.Failure).error.message)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun prepareLookup_whenMissingCardinalJwt_returnsFailure() {
+        overrideConfigCache(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
+
+        val sut = ThreeDSecureClient(context, Fixtures.TOKENIZATION_KEY)
+        val request = ThreeDSecureRequest(nonce = "fake-nonce", amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.prepareLookup(context, request) { result ->
+            assertTrue(result is ThreeDSecurePrepareLookupResult.Failure)
+            assertTrue(
+                (result as ThreeDSecurePrepareLookupResult.Failure)
+                    .error.message.orEmpty().contains("Merchant is not configured for 3DS 2.0")
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun prepareLookup_withRealSandbox_returnsSuccessWithClientData() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_VERIFICATON_NOT_REQUIRED)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "25.00", email = "test@example.com")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.prepareLookup(context, request) { result ->
+            assertTrue(
+                "Expected Success but got Failure: " +
+                    "${(result as? ThreeDSecurePrepareLookupResult.Failure)?.error?.message}",
+                result is ThreeDSecurePrepareLookupResult.Success
+            )
+            val success = result as ThreeDSecurePrepareLookupResult.Success
+
+            val clientDataJson = JSONObject(success.clientData)
+            assertTrue(clientDataJson.has("authorizationFingerprint"))
+            assertTrue(clientDataJson.has("braintreeLibraryVersion"))
+            assertEquals(cardNonce, clientDataJson.getString("nonce"))
+            assertTrue(clientDataJson.getString("dfReferenceId").isNotEmpty())
+            assertEquals("2", clientDataJson.getJSONObject("clientMetadata").getString("requestedThreeDSecureVersion"))
+
+            assertEquals(cardNonce, success.request.nonce)
+            assertEquals("25.00", success.request.amount)
+            assertEquals("test@example.com", success.request.email)
+
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withVerificationNotRequiredCard_returnsLaunchNotRequired() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_VERIFICATON_NOT_REQUIRED)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+            assertNotNull((result as ThreeDSecurePaymentAuthRequest.LaunchNotRequired).nonce)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withVerificationCard_completesLookupSuccessfully() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_VERIFICATON)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertFalse(
+                "Expected non-failure but got: ${(result as? ThreeDSecurePaymentAuthRequest.Failure)?.error?.message}",
+                result is ThreeDSecurePaymentAuthRequest.Failure
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withLookupErrorCard_completesWithoutCrash() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_LOOKUP_ERROR)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertNotNull(result)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withAuthFailedCard_returnsLaunchNotRequiredWithNoLiabilityShift() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_AUTHENTICATION_FAILED)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+            assertFalse(
+                (result as ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+                    .nonce.threeDSecureInfo.liabilityShifted
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withAuthenticationUnavailableCard_returnsLaunchNotRequired() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_AUTHENTICATION_UNAVAILABLE)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withVerificationNotRequired_nonceHasThreeDSecureInfo() {
+        assumeTrue("Cardinal SDK not compatible with Android 15+", Build.VERSION.SDK_INT < 35)
+
+        val authorization = TestClientTokenBuilder().build()
+        val cardNonce = tokenizeCard(authorization, CardNumber.THREE_D_SECURE_VERIFICATON_NOT_REQUIRED)
+
+        val sut = ThreeDSecureClient(context, authorization)
+        val request = ThreeDSecureRequest(nonce = cardNonce, amount = "10.00")
+
+        val countDownLatch = CountDownLatch(1)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is ThreeDSecurePaymentAuthRequest.LaunchNotRequired)
+            val nonce = (result as ThreeDSecurePaymentAuthRequest.LaunchNotRequired).nonce
+            assertNotNull(nonce.threeDSecureInfo)
+            assertTrue(nonce.threeDSecureInfo.wasVerified)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    private fun overrideConfigCache(configJson: String) {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(configJson)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+    }
+
+    private fun tokenizeCard(authorization: String, cardNumber: String): String {
+        val cardClient = CardClient(context, authorization)
+
+        val card = Card()
+        card.number = cardNumber
+        card.expirationMonth = "01"
+        card.expirationYear = ExpirationDateHelper.validExpirationYear()
+        card.cvv = "123"
+
+        val countDownLatch = CountDownLatch(1)
+        var nonce = ""
+
+        cardClient.tokenize(card) { result ->
+            assertTrue(
+                "Card tokenization failed: ${(result as? CardResult.Failure)?.error?.message}",
+                result is CardResult.Success
+            )
+            nonce = (result as CardResult.Success).nonce.string
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+        return nonce
+    }
+}

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureLookupTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureLookupTest.kt
@@ -1,0 +1,76 @@
+package com.braintreepayments.api.threedsecure
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.testutils.Fixtures
+import kotlinx.parcelize.parcelableCreator
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureLookupTest {
+
+    @Test
+    fun fromJson_parsesAllFields() {
+        val lookupJson = JSONObject(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)
+            .getJSONObject("lookup").toString()
+
+        val lookup = ThreeDSecureLookup.fromJson(lookupJson)
+
+        assertEquals("https://acs-url/", lookup.acsUrl)
+        assertEquals("merchant-descriptor", lookup.md)
+        assertEquals("https://term-url/", lookup.termUrl)
+        assertEquals("pareq", lookup.pareq)
+        assertEquals("2.1.0", lookup.threeDSecureVersion)
+        assertEquals("some-transaction-id", lookup.transactionId)
+        assertTrue(lookup.requiresUserAuthentication())
+    }
+
+    @Test
+    fun fromJson_withNullPareq_returnsEmptyString() {
+        val lookupJson = JSONObject(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE_NULL_PAREQ)
+            .getJSONObject("lookup").toString()
+
+        assertEquals("", ThreeDSecureLookup.fromJson(lookupJson).pareq)
+    }
+
+    @Test
+    fun fromJson_withMissingPareq_returnsEmptyString() {
+        val lookupJson = JSONObject(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE_MISSING_PAREQ)
+            .getJSONObject("lookup").toString()
+
+        assertEquals("", ThreeDSecureLookup.fromJson(lookupJson).pareq)
+    }
+
+    @Test
+    fun fromJson_withNoAcsUrl_requiresUserAuthenticationReturnsFalse() {
+        val lookupJson = JSONObject(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE_NO_ACS_URL)
+            .getJSONObject("lookup").toString()
+
+        val lookup = ThreeDSecureLookup.fromJson(lookupJson)
+
+        assertNull(lookup.acsUrl)
+        assertFalse(lookup.requiresUserAuthentication())
+    }
+
+    @Test
+    fun parcels_correctly() {
+        val lookupJson = JSONObject(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)
+            .getJSONObject("lookup").toString()
+        val original = ThreeDSecureLookup.fromJson(lookupJson)
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureLookup>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(original, restored)
+    }
+}

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureNonceTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureNonceTest.kt
@@ -1,0 +1,68 @@
+package com.braintreepayments.api.threedsecure
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.testutils.Fixtures
+import kotlinx.parcelize.parcelableCreator
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureNonceTest {
+
+    @Test
+    fun fromJSON_parsesRESTResponse() {
+        val json = JSONObject(Fixtures.PAYMENT_METHODS_RESPONSE_VISA_CREDIT_CARD)
+        val nonce = ThreeDSecureNonce.fromJSON(json)
+
+        assertEquals("Visa", nonce.cardType)
+        assertEquals("11", nonce.lastTwo)
+        assertEquals("1111", nonce.lastFour)
+        assertEquals("123456-12345-12345-a-adfa", nonce.string)
+        assertFalse(nonce.isDefault)
+
+        val info = nonce.threeDSecureInfo
+        assertEquals("fake-cavv", info.cavv)
+        assertEquals("07", info.eciFlag)
+        assertEquals("Y", info.enrolled)
+        assertTrue(info.liabilityShiftPossible)
+        assertFalse(info.liabilityShifted)
+        assertTrue(info.wasVerified)
+        assertEquals("Y", info.authenticationTransactionStatus)
+        assertEquals("N", info.lookupTransactionStatus)
+    }
+
+    @Test
+    fun fromJSON_parsesGraphQLResponse() {
+        val nonce = ThreeDSecureNonce.fromJSON(JSONObject(Fixtures.GRAPHQL_RESPONSE_CREDIT_CARD))
+
+        assertEquals("Visa", nonce.cardType)
+        assertEquals("1111", nonce.lastFour)
+        assertNotNull(nonce.threeDSecureInfo)
+    }
+
+    @Test
+    fun parcels_correctly() {
+        val json = JSONObject(Fixtures.PAYMENT_METHODS_RESPONSE_VISA_CREDIT_CARD)
+        val original = ThreeDSecureNonce.fromJSON(json)
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureNonce>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(original.string, restored.string)
+        assertEquals(original.cardType, restored.cardType)
+        assertEquals(original.lastTwo, restored.lastTwo)
+        assertEquals(original.lastFour, restored.lastFour)
+        assertEquals(original.bin, restored.bin)
+        assertEquals(original.threeDSecureInfo, restored.threeDSecureInfo)
+    }
+}

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequestTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureRequestTest.kt
@@ -1,0 +1,119 @@
+package com.braintreepayments.api.threedsecure
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import kotlinx.parcelize.parcelableCreator
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureRequestTest {
+
+    @Test
+    fun parcels_withAllFieldsPopulated() {
+        val original = ThreeDSecureRequest(
+            nonce = "fake-nonce",
+            amount = "10.00",
+            mobilePhoneNumber = "5551234567",
+            email = "test@example.com",
+            shippingMethod = ThreeDSecureShippingMethod.GROUND,
+            billingAddress = ThreeDSecurePostalAddress(
+                givenName = "Joe", surname = "Guy",
+                streetAddress = "555 Smith St.", locality = "Oakland",
+                region = "CA", postalCode = "12345", countryCodeAlpha2 = "US"
+            ),
+            accountType = ThreeDSecureAccountType.CREDIT,
+            additionalInformation = ThreeDSecureAdditionalInformation(
+                shippingMethodIndicator = "01", productCode = "AIR"
+            ),
+            challengeRequested = true,
+            dataOnlyRequested = true,
+            exemptionRequested = true,
+            requestedExemptionType = ThreeDSecureRequestedExemptionType.LOW_VALUE,
+            cardAddChallengeRequested = true,
+            uiType = ThreeDSecureUiType.NATIVE,
+            renderTypes = listOf(
+                ThreeDSecureRenderType.OTP, ThreeDSecureRenderType.SINGLE_SELECT,
+                ThreeDSecureRenderType.MULTI_SELECT, ThreeDSecureRenderType.OOB
+            ),
+            customFields = mapOf("field1" to "value1", "field2" to "value2"),
+            requestorAppUrl = "https://example.com/app"
+        )
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureRequest>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun parcels_withDefaultValues() {
+        val original = ThreeDSecureRequest(nonce = "a-nonce", amount = "1.00")
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureRequest>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun build_producesCorrectJson() {
+        val request = ThreeDSecureRequest(
+            amount = "10.00",
+            mobilePhoneNumber = "5551234567",
+            email = "test@example.com",
+            shippingMethod = ThreeDSecureShippingMethod.GROUND,
+            billingAddress = ThreeDSecurePostalAddress(
+                givenName = "Joe", surname = "Guy",
+                streetAddress = "555 Smith St.", locality = "Oakland"
+            ),
+            accountType = ThreeDSecureAccountType.CREDIT,
+            challengeRequested = true,
+            exemptionRequested = true,
+            requestedExemptionType = ThreeDSecureRequestedExemptionType.LOW_VALUE,
+            cardAddChallengeRequested = true,
+            customFields = mapOf("field1" to "value1")
+        )
+
+        val json = JSONObject(request.build("fake-df-ref"))
+
+        assertEquals("10.00", json.getString("amount"))
+        assertTrue(json.getBoolean("challenge_requested"))
+        assertTrue(json.getBoolean("exemption_requested"))
+        assertEquals("low_value", json.getString("requested_exemption_type"))
+        assertEquals("credit", json.getString("account_type"))
+        assertTrue(json.getBoolean("card_add"))
+        assertEquals("fake-df-ref", json.getString("df_reference_id"))
+        assertEquals("value1", json.getJSONObject("custom_fields").getString("field1"))
+
+        val info = json.getJSONObject("additional_info")
+        assertEquals("5551234567", info.getString("mobile_phone_number"))
+        assertEquals("test@example.com", info.getString("email"))
+        assertEquals("04", info.getString("shipping_method"))
+        assertEquals("Joe", info.getString("billing_given_name"))
+        assertEquals("Oakland", info.getString("billing_city"))
+    }
+
+    @Test
+    fun build_withDefaultValues_producesMinimalJson() {
+        val json = JSONObject(ThreeDSecureRequest(amount = "1.00").build(null))
+
+        assertEquals("1.00", json.getString("amount"))
+        assertFalse(json.has("account_type"))
+        assertFalse(json.has("card_add"))
+        assertFalse(json.has("custom_fields"))
+        assertFalse(json.has("df_reference_id"))
+    }
+}

--- a/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureV2UiCustomizationTest.kt
+++ b/ThreeDSecure/src/androidTest/java/com/braintreepayments/api/threedsecure/ThreeDSecureV2UiCustomizationTest.kt
@@ -1,0 +1,160 @@
+package com.braintreepayments.api.threedsecure
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import kotlinx.parcelize.parcelableCreator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ThreeDSecureV2UiCustomizationTest {
+
+    @Test
+    fun parcels_withAllNestedCustomizations() {
+        val original = ThreeDSecureV2UiCustomization(
+            buttonCustomization = ThreeDSecureV2ButtonCustomization(
+                textFontName = "Roboto",
+                textColor = "#000000",
+                textFontSize = 16,
+                backgroundColor = "#D3D3D3",
+                cornerRadius = 8
+            ),
+            buttonType = ThreeDSecureV2ButtonType.BUTTON_TYPE_VERIFY,
+            labelCustomization = ThreeDSecureV2LabelCustomization(
+                textFontName = "Roboto",
+                textColor = "#333333",
+                textFontSize = 14,
+                headingTextColor = "#0082CB",
+                headingTextFontName = "Roboto-Bold",
+                headingTextFontSize = 18
+            ),
+            textBoxCustomization = ThreeDSecureV2TextBoxCustomization(
+                textFontName = "Roboto",
+                textColor = "#111111",
+                textFontSize = 14,
+                borderWidth = 2,
+                borderColor = "#0082CB",
+                cornerRadius = 4
+            ),
+            toolbarCustomization = ThreeDSecureV2ToolbarCustomization(
+                textFontName = "Roboto",
+                textColor = "#222222",
+                textFontSize = 18,
+                backgroundColor = "#FF5A5F",
+                headerText = "Braintree 3DS Checkout",
+                buttonText = "Close"
+            )
+        )
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureV2UiCustomization>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals("#D3D3D3", restored.buttonCustomization?.backgroundColor)
+        assertEquals("#000000", restored.buttonCustomization?.textColor)
+        assertEquals("Roboto", restored.buttonCustomization?.textFontName)
+        assertEquals(16, restored.buttonCustomization?.textFontSize)
+        assertEquals(8, restored.buttonCustomization?.cornerRadius)
+        assertEquals(ThreeDSecureV2ButtonType.BUTTON_TYPE_VERIFY, restored.buttonType)
+
+        assertEquals("#0082CB", restored.labelCustomization?.headingTextColor)
+        assertEquals("Roboto-Bold", restored.labelCustomization?.headingTextFontName)
+        assertEquals(18, restored.labelCustomization?.headingTextFontSize)
+
+        assertEquals(2, restored.textBoxCustomization?.borderWidth)
+        assertEquals("#0082CB", restored.textBoxCustomization?.borderColor)
+        assertEquals(4, restored.textBoxCustomization?.cornerRadius)
+
+        assertEquals("Braintree 3DS Checkout", restored.toolbarCustomization?.headerText)
+        assertEquals("Close", restored.toolbarCustomization?.buttonText)
+        assertEquals("#FF5A5F", restored.toolbarCustomization?.backgroundColor)
+    }
+
+    @Test
+    fun parcels_withDefaultValues() {
+        val original = ThreeDSecureV2UiCustomization()
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+
+        val restored = parcelableCreator<ThreeDSecureV2UiCustomization>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertNull(restored.buttonCustomization)
+        assertNull(restored.buttonType)
+        assertNull(restored.labelCustomization)
+        assertNull(restored.textBoxCustomization)
+        assertNull(restored.toolbarCustomization)
+    }
+
+    @Test
+    fun cardinalUiCustomization_bridgesAllProperties() {
+        val uiCustomization = ThreeDSecureV2UiCustomization(
+            buttonCustomization = ThreeDSecureV2ButtonCustomization(
+                textFontName = "Arial",
+                textColor = "#FF0000",
+                textFontSize = 20,
+                backgroundColor = "#00FF00",
+                cornerRadius = 12
+            ),
+            buttonType = ThreeDSecureV2ButtonType.BUTTON_TYPE_VERIFY,
+            labelCustomization = ThreeDSecureV2LabelCustomization(
+                headingTextColor = "#0082CB",
+                headingTextFontName = "Arial-Bold",
+                headingTextFontSize = 22,
+                textFontSize = 14
+            ),
+            textBoxCustomization = ThreeDSecureV2TextBoxCustomization(
+                borderColor = "#0082CB",
+                borderWidth = 3,
+                cornerRadius = 6
+            ),
+            toolbarCustomization = ThreeDSecureV2ToolbarCustomization(
+                headerText = "Checkout",
+                buttonText = "Done",
+                backgroundColor = "#FFFFFF"
+            )
+        )
+
+        val cardinal = uiCustomization.cardinalUiCustomization
+        assertNotNull(cardinal)
+
+        val btn = checkNotNull(uiCustomization.buttonCustomization).cardinalButtonCustomization
+        assertEquals("Arial", btn.textFontName)
+        assertEquals("#FF0000", btn.textColor)
+        assertEquals(20, btn.textFontSize)
+        assertEquals("#00FF00", btn.backgroundColor)
+        assertEquals(12, btn.cornerRadius)
+
+        val lbl = checkNotNull(uiCustomization.labelCustomization).cardinalLabelCustomization
+        assertEquals("#0082CB", lbl.headingTextColor)
+        assertEquals(22, lbl.headingTextFontSize)
+
+        val txt = checkNotNull(uiCustomization.textBoxCustomization).cardinalTextBoxCustomization
+        assertEquals("#0082CB", txt.borderColor)
+        assertEquals(3, txt.borderWidth)
+
+        val toolbar = checkNotNull(uiCustomization.toolbarCustomization).cardinalToolbarCustomization
+        assertEquals("Checkout", toolbar.headerText)
+        assertEquals("Done", toolbar.buttonText)
+    }
+
+    @Test
+    fun cardinalUiCustomization_withNullsAndButtonWithoutType_doesNotCrash() {
+        val empty = ThreeDSecureV2UiCustomization()
+        assertNotNull(empty.cardinalUiCustomization)
+
+        val buttonNoType = ThreeDSecureV2UiCustomization(
+            buttonCustomization = ThreeDSecureV2ButtonCustomization(backgroundColor = "#D3D3D3"),
+            buttonType = null
+        )
+        assertNotNull(buttonNoType.cardinalUiCustomization)
+    }
+}

--- a/ThreeDSecure/src/androidTest/res/xml/network_security_config.xml
+++ b/ThreeDSecure/src/androidTest/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">braintree-demo-merchant-63b7a2204f6e.herokuapp.com</domain>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
### Summary of changes
- Add instrumentation tests forThreeDSecureAdditionalInformation, ThreeDSecureClient,ThreeDSecureLookup, ThreeDSecureNonce, ThreeDSecureRequest, ThreeDSecureV2UiCustomization
- Add AndroidManifest and network_security_config to test end-to-end flows (followed existing setup from Card module)
- Add :ThreeDSecure:connectedCheck to CI instrumentation test workflow (run + retry steps)
- Achieved test coverage is 70%

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Test generation and brainstorming

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 

