### PR TITLE
Add additional instrumentation tests for Venmo and UIComponents

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -27,7 +27,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :Venmo:connectedCheck :UIComponents:connectedCheck --stacktrace
 
 
       - name: retry tests
@@ -38,5 +38,5 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :Venmo:connectedCheck :UIComponents:connectedCheck --stacktrace
 

--- a/UIComponents/build.gradle
+++ b/UIComponents/build.gradle
@@ -79,6 +79,11 @@ dependencies {
     testImplementation libs.kotlin.test
     testImplementation project(':TestUtils')
     debugImplementation libs.androidx.ui.tooling
+
+    androidTestImplementation project(':TestUtils')
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.junit
 }
 
 // region signing and publishing

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/PayPalButtonTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/PayPalButtonTest.kt
@@ -1,0 +1,74 @@
+package com.braintreepayments.api.uicomponents
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class PayPalButtonTest {
+
+    @Test
+    fun payPalButton_canBeInstantiated() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun payPalButton_isEnabledByDefault() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        assertTrue(button.isEnabled)
+    }
+
+    @Test
+    fun setButtonColor_toBlack_doesNotThrow() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(PayPalButtonColor.Black)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setButtonColor_toWhite_doesNotThrow() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(PayPalButtonColor.White)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setButtonColor_toSameColor_doesNotThrow() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(PayPalButtonColor.Blue)
+        button.setButtonColor(PayPalButtonColor.Blue)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setEnabled_false_disablesButton() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+
+        button.isEnabled = false
+
+        assertFalse(button.isEnabled)
+    }
+
+    @Test
+    fun setEnabled_trueAfterFalse_reenablesButton() {
+        val button = PayPalButton(ApplicationProvider.getApplicationContext())
+        button.isEnabled = false
+
+        button.isEnabled = true
+
+        assertTrue(button.isEnabled)
+    }
+}

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/VenmoButtonTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/VenmoButtonTest.kt
@@ -1,0 +1,74 @@
+package com.braintreepayments.api.uicomponents
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoButtonTest {
+
+    @Test
+    fun venmoButton_canBeInstantiated() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun venmoButton_isEnabledByDefault() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        assertTrue(button.isEnabled)
+    }
+
+    @Test
+    fun setButtonColor_toBlack_doesNotThrow() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(VenmoButtonColor.Black)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setButtonColor_toWhite_doesNotThrow() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(VenmoButtonColor.White)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setButtonColor_toSameColor_doesNotThrow() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        button.setButtonColor(VenmoButtonColor.Blue)
+        button.setButtonColor(VenmoButtonColor.Blue)
+
+        assertNotNull(button)
+    }
+
+    @Test
+    fun setEnabled_false_disablesButton() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+
+        button.isEnabled = false
+
+        assertFalse(button.isEnabled)
+    }
+
+    @Test
+    fun setEnabled_trueAfterFalse_reenablesButton() {
+        val button = VenmoButton(ApplicationProvider.getApplicationContext())
+        button.isEnabled = false
+
+        button.isEnabled = true
+
+        assertTrue(button.isEnabled)
+    }
+}

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -64,6 +64,11 @@ dependencies {
     testImplementation libs.test.parameter.injector
     testImplementation project(':TestUtils')
     testImplementation libs.coroutines.test
+
+    androidTestImplementation project(':TestUtils')
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.junit
 }
 
 // region signing and publishing

--- a/Venmo/src/androidTest/AndroidManifest.xml
+++ b/Venmo/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoAccountNonceTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoAccountNonceTest.kt
@@ -1,0 +1,104 @@
+package com.braintreepayments.api.venmo
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.testutils.Fixtures
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoAccountNonceTest {
+
+    @Test
+    fun fromJSON_withVenmoAccountResponse_parsesNonceAndUsername() {
+        val json = JSONObject(Fixtures.PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("fake-venmo-nonce", nonce.string)
+        assertTrue(nonce.isDefault)
+        assertEquals("venmojoe", nonce.username)
+    }
+
+    @Test
+    fun fromJSON_withVenmoAccountResponse_hasNullPayerInfo() {
+        val json = JSONObject(Fixtures.PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertNull(nonce.email)
+        assertNull(nonce.externalId)
+        assertNull(nonce.firstName)
+        assertNull(nonce.lastName)
+        assertNull(nonce.phoneNumber)
+        assertNull(nonce.billingAddress)
+        assertNull(nonce.shippingAddress)
+    }
+
+    @Test
+    fun fromJSON_withPaymentMethodContext_parsesNonceAndUsername() {
+        val json = JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_JSON)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("sample-payment-method-id", nonce.string)
+        assertFalse(nonce.isDefault)
+        assertEquals("@sampleuser", nonce.username)
+    }
+
+    @Test
+    fun fromJSON_withPaymentMethodContext_parsesPayerInfo() {
+        val json = JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_JSON)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("venmo-email", nonce.email)
+        assertEquals("venmo-external-id", nonce.externalId)
+        assertEquals("venmo-first-name", nonce.firstName)
+        assertEquals("venmo-last-name", nonce.lastName)
+        assertEquals("venmo-phone-number", nonce.phoneNumber)
+    }
+
+    @Test
+    fun fromJSON_withPaymentMethodContextWithAddresses_parsesAddresses() {
+        val json = JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_JSON_WITH_ADDRESSES)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertNotNull(nonce.billingAddress)
+        assertNotNull(nonce.shippingAddress)
+    }
+
+    @Test
+    fun fromJSON_withNullPayerInfo_returnsNullPayerFields() {
+        val json = JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_WITH_NULL_PAYER_INFO_JSON)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("sample-payment-method-id", nonce.string)
+        assertEquals("@sampleuser", nonce.username)
+        assertNull(nonce.email)
+        assertNull(nonce.externalId)
+        assertNull(nonce.firstName)
+        assertNull(nonce.lastName)
+        assertNull(nonce.phoneNumber)
+        assertNull(nonce.billingAddress)
+        assertNull(nonce.shippingAddress)
+    }
+
+    @Test
+    fun fromJSON_withPlainVenmoObject_parsesCorrectly() {
+        val json = JSONObject(Fixtures.PAYMENT_METHOD_VENMO_PLAIN_OBJECT)
+
+        val nonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("fake-venmo-nonce", nonce.string)
+        assertEquals("happy-venmo-joe", nonce.username)
+        assertFalse(nonce.isDefault)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoAccountTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoAccountTest.kt
@@ -1,0 +1,37 @@
+package com.braintreepayments.api.venmo
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoAccountTest {
+
+    @Test
+    fun buildJSON_includesNonceInVenmoAccountObject() {
+        val account = VenmoAccount("fake-venmo-nonce")
+
+        val json = account.buildJSON()
+
+        val venmoAccountJson = json.getJSONObject("venmoAccount")
+        assertEquals("fake-venmo-nonce", venmoAccountJson.getString("nonce"))
+    }
+
+    @Test
+    fun buildJSON_includesMetadataObject() {
+        val account = VenmoAccount("fake-venmo-nonce")
+
+        val json = account.buildJSON()
+
+        assertNotNull(json.getJSONObject("_meta"))
+    }
+
+    @Test
+    fun apiPath_returnsVenmoAccountsPath() {
+        val account = VenmoAccount("fake-venmo-nonce")
+
+        assertEquals("venmo_accounts", account.apiPath)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoClientTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoClientTest.kt
@@ -161,7 +161,8 @@ class VenmoClientTest {
     @Throws(InterruptedException::class)
     fun tokenize_whenSuccessUrlUsesAmpersandSeparator_returnsSuccess() {
         val sut = createVenmoClient()
-        val returnPath = "x-callback-url/vzero/auth/venmo/success&payment_method_nonce=fake-venmo-nonce&username=venmojoe"
+        val returnPath = "x-callback-url/vzero/auth/venmo/success" +
+            "&payment_method_nonce=fake-venmo-nonce&username=venmojoe"
         val paymentAuthResult = simulateVenmoReturn(returnPath)
         assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
 

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoClientTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoClientTest.kt
@@ -1,0 +1,294 @@
+package com.braintreepayments.api.venmo
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.core.Authorization
+import com.braintreepayments.api.core.BraintreeRequestCodes
+import com.braintreepayments.api.core.Configuration
+import com.braintreepayments.api.testutils.Fixtures
+import com.braintreepayments.api.testutils.SharedPreferencesHelper
+import org.json.JSONObject
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoClientTest {
+
+    private lateinit var context: Context
+    private lateinit var countDownLatch: CountDownLatch
+
+    private val appLinkReturnUrl = Uri.parse("https://example.com/braintree")
+    private val returnUrlScheme = "com.braintreepayments.api.venmo.test"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        countDownLatch = CountDownLatch(1)
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_whenVenmoDisabled_returnsFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+
+        val sut = VenmoClient(
+            context = context,
+            authorization = Fixtures.TOKENIZATION_KEY,
+            appLinkReturnUrl = appLinkReturnUrl
+        )
+
+        val request = VenmoRequest(paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is VenmoPaymentAuthRequest.Failure)
+            val failure = result as VenmoPaymentAuthRequest.Failure
+            assertTrue(failure.error.message?.contains("Venmo is not enabled") == true)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_withInvalidAuthorization_returnsFailure() {
+        val sut = VenmoClient(
+            context = context,
+            authorization = "sandbox_invalid_key_xxxxxxxx",
+            appLinkReturnUrl = appLinkReturnUrl
+        )
+
+        val request = VenmoRequest(paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is VenmoPaymentAuthRequest.Failure)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_whenCollectingShippingAddress_andECDDisabled_returnsFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+
+        val sut = VenmoClient(
+            context = context,
+            authorization = Fixtures.TOKENIZATION_KEY,
+            appLinkReturnUrl = appLinkReturnUrl
+        )
+
+        val request = VenmoRequest(
+            paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE,
+            collectCustomerShippingAddress = true
+        )
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is VenmoPaymentAuthRequest.Failure)
+            val failure = result as VenmoPaymentAuthRequest.Failure
+            assertTrue(failure.error.message?.contains("ECD is disabled") == true)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_whenCollectingBillingAddress_andECDDisabled_returnsFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+
+        val sut = VenmoClient(
+            context = context,
+            authorization = Fixtures.TOKENIZATION_KEY,
+            appLinkReturnUrl = appLinkReturnUrl
+        )
+
+        val request = VenmoRequest(
+            paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE,
+            collectCustomerBillingAddress = true
+        )
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is VenmoPaymentAuthRequest.Failure)
+            val failure = result as VenmoPaymentAuthRequest.Failure
+            assertTrue(failure.error.message?.contains("ECD is disabled") == true)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 30000)
+    @Throws(InterruptedException::class)
+    fun createPaymentAuthRequest_whenVenmoEnabled_andNetworkFails_returnsFailure() {
+        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
+        val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
+        SharedPreferencesHelper.overrideConfigurationCache(context, authorization, configuration)
+
+        val sut = VenmoClient(
+            context = context,
+            authorization = Fixtures.TOKENIZATION_KEY,
+            appLinkReturnUrl = appLinkReturnUrl
+        )
+
+        val request = VenmoRequest(paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE)
+
+        sut.createPaymentAuthRequest(context, request) { result ->
+            assertTrue(result is VenmoPaymentAuthRequest.Failure)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun tokenize_whenSuccessUrlUsesAmpersandSeparator_returnsSuccess() {
+        val sut = createVenmoClient()
+        val returnPath = "x-callback-url/vzero/auth/venmo/success&payment_method_nonce=fake-venmo-nonce&username=venmojoe"
+        val paymentAuthResult = simulateVenmoReturn(returnPath)
+        assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
+
+        var tokenizeResult: VenmoResult? = null
+        sut.tokenize(paymentAuthResult as VenmoPaymentAuthResult.Success) { result ->
+            tokenizeResult = result
+            countDownLatch.countDown()
+        }
+        countDownLatch.await()
+
+        assertTrue(tokenizeResult is VenmoResult.Success)
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun tokenize_whenCancelUrlReceived_returnsCancelResult() {
+        val sut = createVenmoClient()
+        val paymentAuthResult = simulateVenmoReturn("x-callback-url/vzero/auth/venmo/cancel")
+        assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
+
+        sut.tokenize(paymentAuthResult as VenmoPaymentAuthResult.Success) { result ->
+            assertTrue(result is VenmoResult.Cancel)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun tokenize_whenErrorUrlReceived_returnsFailure() {
+        val sut = createVenmoClient()
+        val paymentAuthResult = simulateVenmoReturn("x-callback-url/vzero/auth/venmo/error")
+        assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
+
+        sut.tokenize(paymentAuthResult as VenmoPaymentAuthResult.Success) { result ->
+            assertTrue(result is VenmoResult.Failure)
+            assertNotNull((result as VenmoResult.Failure).error)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun tokenize_withPaymentMethodNonceAndUsername_returnsSuccess() {
+        val sut = createVenmoClient()
+        val returnPath = "x-callback-url/vzero/auth/venmo/success" +
+                "?payment_method_nonce=fake-venmo-nonce&username=venmojoe"
+        val paymentAuthResult = simulateVenmoReturn(returnPath)
+        assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
+
+        var tokenizeResult: VenmoResult? = null
+        sut.tokenize(paymentAuthResult as VenmoPaymentAuthResult.Success) { result ->
+            tokenizeResult = result
+            countDownLatch.countDown()
+        }
+        countDownLatch.await()
+
+        assertTrue(tokenizeResult is VenmoResult.Success)
+        val success = tokenizeResult as VenmoResult.Success
+        assertNotNull(success.nonce)
+        assertTrue(success.nonce.username == "venmojoe")
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun tokenize_whenSuccessUrlWithNeitherNonceNorContextId_returnsFailure() {
+        val sut = createVenmoClient()
+        val paymentAuthResult = simulateVenmoReturn("x-callback-url/vzero/auth/venmo/success")
+        assertTrue(paymentAuthResult is VenmoPaymentAuthResult.Success)
+
+        sut.tokenize(paymentAuthResult as VenmoPaymentAuthResult.Success) { result ->
+            assertTrue(result is VenmoResult.Failure)
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    @Throws(InterruptedException::class)
+    fun handleReturnToApp_whenUrlSchemeDoesNotMatch_returnsNoResult() {
+        val pendingRequestString = buildPendingRequestString()
+        val intent = Intent().apply {
+            data = Uri.parse("different-scheme://x-callback-url/venmo/return")
+        }
+
+        val result = VenmoLauncher().handleReturnToApp(
+            VenmoPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(result is VenmoPaymentAuthResult.NoResult)
+    }
+
+    private fun createVenmoClient(): VenmoClient {
+        return VenmoClient(
+            context = context,
+            authorization = Fixtures.TOKENIZATION_KEY,
+            appLinkReturnUrl = appLinkReturnUrl,
+            deepLinkFallbackUrlScheme = returnUrlScheme
+        )
+    }
+
+    private fun simulateVenmoReturn(returnPath: String): VenmoPaymentAuthResult {
+        val pendingRequestString = buildPendingRequestString()
+        val intent = Intent().apply {
+            data = Uri.parse("$returnUrlScheme://$returnPath")
+        }
+        return VenmoLauncher().handleReturnToApp(
+            VenmoPendingRequest.Started(pendingRequestString),
+            intent
+        )
+    }
+
+    private fun buildPendingRequestString(): String {
+        val approvalUrl = "https://venmo.com/go/checkout?resource_id=fake-resource-id"
+        val pendingRequestJson = JSONObject()
+            .put("requestCode", BraintreeRequestCodes.VENMO.code)
+            .put("url", approvalUrl)
+            .put("returnUrlScheme", returnUrlScheme)
+            .put("metadata", JSONObject())
+        return Base64.encodeToString(
+            pendingRequestJson.toString().toByteArray(Charsets.UTF_8),
+            Base64.DEFAULT
+        )
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLauncherTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLauncherTest.kt
@@ -4,6 +4,7 @@ import android.util.Base64
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.braintreepayments.api.BrowserSwitchException
 import com.braintreepayments.api.core.BraintreeRequestCodes
+import org.junit.Assert.assertNotNull
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +22,7 @@ class VenmoLauncherTest {
         try {
             launcher.restorePendingRequest(pendingRequestString)
         } catch (e: BrowserSwitchException) {
-            // BrowserSwitchException is acceptable — the method was still exercised
+            assertNotNull(e)
         }
     }
 

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLauncherTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLauncherTest.kt
@@ -1,0 +1,40 @@
+package com.braintreepayments.api.venmo
+
+import android.util.Base64
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.BrowserSwitchException
+import com.braintreepayments.api.core.BraintreeRequestCodes
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoLauncherTest {
+
+    private val returnUrlScheme = "com.braintreepayments.api.venmo.test"
+
+    @Test
+    fun restorePendingRequest_withValidPendingRequestString_doesNotCrash() {
+        val launcher = VenmoLauncher()
+        val pendingRequestString = buildPendingRequestString()
+
+        try {
+            launcher.restorePendingRequest(pendingRequestString)
+        } catch (e: BrowserSwitchException) {
+            // BrowserSwitchException is acceptable — the method was still exercised
+        }
+    }
+
+    private fun buildPendingRequestString(): String {
+        val approvalUrl = "https://venmo.com/go/checkout?resource_id=fake-resource-id"
+        val pendingRequestJson = JSONObject()
+            .put("requestCode", BraintreeRequestCodes.VENMO.code)
+            .put("url", approvalUrl)
+            .put("returnUrlScheme", returnUrlScheme)
+            .put("metadata", JSONObject())
+        return Base64.encodeToString(
+            pendingRequestJson.toString().toByteArray(Charsets.UTF_8),
+            Base64.DEFAULT
+        )
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLineItemTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoLineItemTest.kt
@@ -1,0 +1,91 @@
+package com.braintreepayments.api.venmo
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoLineItemTest {
+
+    @Test
+    fun toJson_includesRequiredFields() {
+        val item = VenmoLineItem(
+            kind = VenmoLineItemKind.DEBIT,
+            name = "Widget",
+            quantity = 2,
+            unitAmount = "10.00"
+        )
+
+        val json = item.toJson()
+
+        assertEquals("DEBIT", json.getString("type"))
+        assertEquals("Widget", json.getString("name"))
+        assertEquals(2, json.getInt("quantity"))
+        assertEquals("10.00", json.getString("unitAmount"))
+    }
+
+    @Test
+    fun toJson_withAllOptionalFields_includesAllFields() {
+        val item = VenmoLineItem(
+            kind = VenmoLineItemKind.CREDIT,
+            name = "Gadget",
+            quantity = 1,
+            unitAmount = "25.00",
+            description = "A gadget",
+            productCode = "SKU-123",
+            unitTaxAmount = "2.00",
+            url = "https://example.com/gadget"
+        )
+
+        val json = item.toJson()
+
+        assertEquals("CREDIT", json.getString("type"))
+        assertEquals("Gadget", json.getString("name"))
+        assertEquals(1, json.getInt("quantity"))
+        assertEquals("25.00", json.getString("unitAmount"))
+        assertEquals("A gadget", json.getString("description"))
+        assertEquals("SKU-123", json.getString("productCode"))
+        assertEquals("2.00", json.getString("unitTaxAmount"))
+        assertEquals("https://example.com/gadget", json.getString("url"))
+    }
+
+    @Test
+    fun toJson_withNullOptionalFields_omitsNullFields() {
+        val item = VenmoLineItem(
+            kind = VenmoLineItemKind.DEBIT,
+            name = "Item",
+            quantity = 1,
+            unitAmount = "5.00"
+        )
+
+        val json = item.toJson()
+
+        assertFalse(json.has("description"))
+        assertFalse(json.has("productCode"))
+        assertFalse(json.has("unitTaxAmount"))
+        assertFalse(json.has("url"))
+    }
+
+    @Test
+    fun constructor_setsPropertiesCorrectly() {
+        val item = VenmoLineItem(
+            kind = VenmoLineItemKind.DEBIT,
+            name = "Test Item",
+            quantity = 3,
+            unitAmount = "15.00",
+            description = "Test description"
+        )
+
+        assertEquals(VenmoLineItemKind.DEBIT, item.kind)
+        assertEquals("Test Item", item.name)
+        assertEquals(3, item.quantity)
+        assertEquals("15.00", item.unitAmount)
+        assertEquals("Test description", item.description)
+        assertNull(item.productCode)
+        assertNull(item.unitTaxAmount)
+        assertNull(item.url)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoPaymentAuthRequestParamsTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoPaymentAuthRequestParamsTest.kt
@@ -1,0 +1,19 @@
+package com.braintreepayments.api.venmo
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.BrowserSwitchOptions
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoPaymentAuthRequestParamsTest {
+
+    @Test
+    fun constructor_storesBrowserSwitchOptions() {
+        val options = BrowserSwitchOptions()
+        val params = VenmoPaymentAuthRequestParams(options)
+
+        assertNotNull(params.browserSwitchOptions)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoRequestTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoRequestTest.kt
@@ -1,0 +1,95 @@
+package com.braintreepayments.api.venmo
+
+import android.os.Parcel
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import kotlinx.parcelize.parcelableCreator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoRequestTest {
+
+    @Test
+    fun parcelize_withAllFieldsPopulated_restoresAllFields() {
+        val lineItem = VenmoLineItem(
+            kind = VenmoLineItemKind.DEBIT,
+            name = "Widget",
+            quantity = 2,
+            unitAmount = "10.00",
+            description = "A widget",
+            productCode = "SKU-001",
+            unitTaxAmount = "1.00",
+            url = "https://example.com/widget"
+        )
+        val original = VenmoRequest(
+            paymentMethodUsage = VenmoPaymentMethodUsage.MULTI_USE,
+            lineItems = arrayListOf(lineItem),
+            shouldVault = true,
+            profileId = "profile-123",
+            displayName = "My Store",
+            collectCustomerShippingAddress = true,
+            collectCustomerBillingAddress = true,
+            totalAmount = "100.00",
+            subTotalAmount = "90.00",
+            discountAmount = "5.00",
+            taxAmount = "8.00",
+            shippingAmount = "2.00",
+            isFinalAmount = true,
+            riskCorrelationId = "risk-abc"
+        )
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restored = parcelableCreator<VenmoRequest>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(VenmoPaymentMethodUsage.MULTI_USE, restored.paymentMethodUsage)
+        assertTrue(restored.shouldVault)
+        assertEquals("profile-123", restored.profileId)
+        assertEquals("My Store", restored.displayName)
+        assertTrue(restored.collectCustomerShippingAddress)
+        assertTrue(restored.collectCustomerBillingAddress)
+        assertEquals("100.00", restored.totalAmount)
+        assertEquals("90.00", restored.subTotalAmount)
+        assertEquals("5.00", restored.discountAmount)
+        assertEquals("8.00", restored.taxAmount)
+        assertEquals("2.00", restored.shippingAmount)
+        assertTrue(restored.isFinalAmount)
+        assertEquals("risk-abc", restored.riskCorrelationId)
+        assertNotNull(restored.lineItems)
+        assertEquals(1, restored.lineItems!!.size)
+        assertEquals("Widget", restored.lineItems!![0].name)
+    }
+
+    @Test
+    fun parcelize_withDefaultValues_restoresDefaults() {
+        val original = VenmoRequest(paymentMethodUsage = VenmoPaymentMethodUsage.SINGLE_USE)
+
+        val parcel = Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restored = parcelableCreator<VenmoRequest>().createFromParcel(parcel)
+        parcel.recycle()
+
+        assertEquals(VenmoPaymentMethodUsage.SINGLE_USE, restored.paymentMethodUsage)
+        assertFalse(restored.shouldVault)
+        assertNull(restored.profileId)
+        assertNull(restored.displayName)
+        assertFalse(restored.collectCustomerShippingAddress)
+        assertFalse(restored.collectCustomerBillingAddress)
+        assertNull(restored.totalAmount)
+        assertNull(restored.subTotalAmount)
+        assertNull(restored.discountAmount)
+        assertNull(restored.taxAmount)
+        assertNull(restored.shippingAmount)
+        assertFalse(restored.isFinalAmount)
+        assertNull(restored.riskCorrelationId)
+        assertNull(restored.lineItems)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoSealedClassesTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoSealedClassesTest.kt
@@ -1,0 +1,37 @@
+package com.braintreepayments.api.venmo
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.braintreepayments.api.BrowserSwitchOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoSealedClassesTest {
+
+    @Test
+    fun venmoPendingRequestFailure_storesError() {
+        val error = Exception("pending request failed")
+        val failure = VenmoPendingRequest.Failure(error)
+
+        assertEquals("pending request failed", failure.error.message)
+    }
+
+    @Test
+    fun venmoPaymentAuthResultFailure_storesError() {
+        val error = Exception("auth result failed")
+        val failure = VenmoPaymentAuthResult.Failure(error)
+
+        assertEquals("auth result failed", failure.error.message)
+    }
+
+    @Test
+    fun venmoPaymentAuthRequestReadyToLaunch_storesParams() {
+        val options = BrowserSwitchOptions()
+        val params = VenmoPaymentAuthRequestParams(options)
+        val readyToLaunch = VenmoPaymentAuthRequest.ReadyToLaunch(params)
+
+        assertNotNull(readyToLaunch.requestParams)
+    }
+}

--- a/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoSharedPrefsWriterTest.kt
+++ b/Venmo/src/androidTest/java/com/braintreepayments/api/venmo/VenmoSharedPrefsWriterTest.kt
@@ -1,0 +1,43 @@
+package com.braintreepayments.api.venmo
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class VenmoSharedPrefsWriterTest {
+
+    private lateinit var context: Context
+    private lateinit var sut: VenmoSharedPrefsWriter
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        sut = VenmoSharedPrefsWriter()
+    }
+
+    @Test
+    fun getVenmoVaultOption_defaultsToFalse() {
+        assertFalse(sut.getVenmoVaultOption(context))
+    }
+
+    @Test
+    fun persistVenmoVaultOption_true_getVenmoVaultOption_returnsTrue() {
+        sut.persistVenmoVaultOption(context, true)
+
+        assertTrue(sut.getVenmoVaultOption(context))
+    }
+
+    @Test
+    fun persistVenmoVaultOption_false_getVenmoVaultOption_returnsFalse() {
+        sut.persistVenmoVaultOption(context, true)
+        sut.persistVenmoVaultOption(context, false)
+
+        assertFalse(sut.getVenmoVaultOption(context))
+    }
+}

--- a/Venmo/src/androidTest/res/xml/network_security_config.xml
+++ b/Venmo/src/androidTest/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">braintree-demo-merchant-63b7a2204f6e.herokuapp.com</domain>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
### Summary of changes
- Increase instrumentation test coverage for Venmo and UIComponents. Venmo achieved 72% coverage. UIComponents 45% through instrumentation tests however, UI tests within Demo touch 2 files that instrumentation tests cannot (VenmoButton and PayPalButton), largely increasing coverage.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used Claude to follow pattern of previous PRs to increase instrumentation coverage.

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 

