### PR TITLE
feat: Add CardBrand enum and LuhnValidator for CardFields feature

### DIFF
--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardBrand.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardBrand.kt
@@ -1,0 +1,119 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+@Suppress("MagicNumber")
+internal enum class CardBrand(
+    /** Strict prefix patterns checked first across all brands before relaxed patterns. */
+    val prefixPatterns: List<Regex>,
+    /**
+     * Relaxed prefix patterns only used if no strict match is found across all brands.
+     * Only Maestro uses relaxed matching — mirrors the card-form's/drop-in's two-pass detection.
+     */
+    val relaxedPrefixPatterns: List<Regex> = emptyList(),
+    val validLengths: Set<Int>,
+    val cvvLength: Int,
+    val formatGaps: IntArray = intArrayOf(4, 8, 12)
+) {
+    VISA(
+        prefixPatterns = listOf("^4\\d*".toRegex()),
+        validLengths = setOf(16),
+        cvvLength = 3
+    ),
+
+    MASTERCARD(
+        prefixPatterns = listOf("^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*".toRegex()),
+        validLengths = setOf(16),
+        cvvLength = 3
+    ),
+
+    DISCOVER(
+        prefixPatterns = listOf("^(6011|65|64[4-9]|622)\\d*".toRegex()),
+        validLengths = setOf(16, 17, 18, 19),
+        cvvLength = 3
+    ),
+
+    AMEX(
+        prefixPatterns = listOf("^3[47]\\d*".toRegex()),
+        validLengths = setOf(15),
+        cvvLength = 4,
+        formatGaps = intArrayOf(4, 10)
+    ),
+
+    DINERS_CLUB(
+        prefixPatterns = listOf("^(36|38|30[0-5])\\d*".toRegex()),
+        validLengths = setOf(14),
+        cvvLength = 3,
+        formatGaps = intArrayOf(4, 10)
+    ),
+
+    JCB(
+        prefixPatterns = listOf("^35\\d*".toRegex()),
+        validLengths = setOf(16),
+        cvvLength = 3
+    ),
+
+    MAESTRO(
+        prefixPatterns = listOf(
+            "^(5018|5020|5038|5[6-9]|6020|6304|6703|6759|676[1-3])\\d*".toRegex()
+        ),
+        relaxedPrefixPatterns = listOf("^6\\d*".toRegex()),
+        validLengths = setOf(12, 13, 14, 15, 16, 17, 18, 19),
+        cvvLength = 3
+    ),
+
+    UNIONPAY(
+        prefixPatterns = listOf("^62\\d*".toRegex()),
+        validLengths = setOf(16, 17, 18, 19),
+        cvvLength = 3
+    ),
+
+    HIPER(
+        prefixPatterns = listOf("^637(095|568|599|609|612)\\d*".toRegex()),
+        validLengths = setOf(16),
+        cvvLength = 3
+    ),
+
+    HIPERCARD(
+        prefixPatterns = listOf("^606282\\d*".toRegex()),
+        validLengths = setOf(16),
+        cvvLength = 3
+    ),
+
+    UNKNOWN(
+        prefixPatterns = emptyList(),
+        validLengths = setOf(12, 13, 14, 15, 16, 17, 18, 19),
+        cvvLength = 3
+    );
+
+    val minLength: Int get() = validLengths.min()
+
+    val maxLength: Int get() = validLengths.max()
+
+    companion object {
+        /**
+         * Detects which card brands could match the given card number.
+         *
+         * Returns a list because early digits can be ambiguous.
+         * The caller will show a generic icon when the list has multiple matches
+         * and switch to a brand-specific icon once it narrows to one.
+         *
+         * When the input is empty, returns an empty list.
+         *
+         * @param cardNumber Raw input string (spaces are filtered out internally).
+         * @return List of matching brands, or an empty list if input is empty or digits are present
+         * but no brand matches (caller should treat this as [UNKNOWN]).
+         */
+        fun detect(cardNumber: String): List<CardBrand> {
+            val digits = cardNumber.filter { it.isDigit() }
+            if (digits.isEmpty()) return emptyList()
+
+            val strictMatches = entries.filter { brand ->
+                brand.prefixPatterns.any { it.containsMatchIn(digits) }
+            }
+            if (strictMatches.isNotEmpty()) return strictMatches
+
+            return entries.filter { brand ->
+                brand.relaxedPrefixPatterns.any { it.containsMatchIn(digits) }
+            }
+        }
+    }
+}

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/LuhnValidator.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/LuhnValidator.kt
@@ -1,0 +1,29 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+@Suppress("MagicNumber")
+internal object LuhnValidator {
+
+    /**
+     * Performs the Luhn check on the given card number.
+     *
+     * @param cardNumber a String consisting of numeric digits (only).
+     * @return `true` if the sequence passes the checksum.
+     * @throws IllegalArgumentException if [cardNumber] contains a non-digit character.
+     * @see <a href="https://en.wikipedia.org/wiki/Luhn_algorithm">Luhn Algorithm (Wikipedia)</a>
+     */
+    fun isLuhnValid(cardNumber: String): Boolean {
+        val reversed = cardNumber.reversed()
+        var oddSum = 0
+        var evenSum = 0
+        for (i in reversed.indices) {
+            val digit = reversed[i].digitToIntOrNull()
+                ?: throw IllegalArgumentException("Not a digit: '${reversed[i]}'")
+            if (i % 2 == 0) {
+                oddSum += digit
+            } else {
+                evenSum += digit / 5 + (2 * digit) % 10
+            }
+        }
+        return (oddSum + evenSum) % 10 == 0
+    }
+}

--- a/UIComponents/src/main/res/values/strings_card_fields.xml
+++ b/UIComponents/src/main/res/values/strings_card_fields.xml
@@ -10,9 +10,6 @@
     <string name="card_icon_jcb">JCB</string>
     <string name="card_icon_unionpay">UnionPay</string>
     <string name="card_icon_maestro">Maestro</string>
-    <string name="card_icon_elo">Elo</string>
-    <string name="card_icon_mir">Mir</string>
     <string name="card_icon_hiper">Hiper</string>
     <string name="card_icon_hipercard">Hipercard</string>
-    <string name="card_icon_verve">Verve</string>
 </resources>

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardBrandUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardBrandUnitTest.kt
@@ -1,0 +1,272 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CardBrandUnitTest {
+
+    // region Brand detection - single brand matches
+
+    @Test
+    fun `detect returns VISA for prefix 4`() {
+        assertEquals(listOf(CardBrand.VISA), CardBrand.detect("4"))
+    }
+
+    @Test
+    fun `detect returns VISA for full card number`() {
+        assertEquals(listOf(CardBrand.VISA), CardBrand.detect("4111111111111111"))
+    }
+
+    @Test
+    fun `detect returns MASTERCARD for prefix 51`() {
+        assertEquals(listOf(CardBrand.MASTERCARD), CardBrand.detect("51"))
+    }
+
+    @Test
+    fun `detect returns MASTERCARD for prefix 55`() {
+        assertEquals(listOf(CardBrand.MASTERCARD), CardBrand.detect("55"))
+    }
+
+    @Test
+    fun `detect returns MASTERCARD for prefix 2221`() {
+        assertEquals(listOf(CardBrand.MASTERCARD), CardBrand.detect("2221"))
+    }
+
+    @Test
+    fun `detect returns MASTERCARD for prefix 2720`() {
+        assertEquals(listOf(CardBrand.MASTERCARD), CardBrand.detect("2720"))
+    }
+
+    @Test
+    fun `detect returns AMEX for prefix 34`() {
+        assertEquals(listOf(CardBrand.AMEX), CardBrand.detect("34"))
+    }
+
+    @Test
+    fun `detect returns AMEX for prefix 37`() {
+        assertEquals(listOf(CardBrand.AMEX), CardBrand.detect("37"))
+    }
+
+    @Test
+    fun `detect returns DISCOVER for prefix 6011`() {
+        assertEquals(listOf(CardBrand.DISCOVER), CardBrand.detect("6011"))
+    }
+
+    @Test
+    fun `detect returns DISCOVER for prefix 65`() {
+        val result = CardBrand.detect("65")
+        assertTrue(result.contains(CardBrand.DISCOVER))
+    }
+
+    @Test
+    fun `detect returns DISCOVER for prefix 644`() {
+        assertEquals(listOf(CardBrand.DISCOVER), CardBrand.detect("644"))
+    }
+
+    @Test
+    fun `detect returns JCB for prefix 3528`() {
+        assertEquals(listOf(CardBrand.JCB), CardBrand.detect("3528"))
+    }
+
+    @Test
+    fun `detect returns DINERS_CLUB for prefix 36`() {
+        assertEquals(listOf(CardBrand.DINERS_CLUB), CardBrand.detect("36"))
+    }
+
+    @Test
+    fun `detect returns DINERS_CLUB for prefix 305`() {
+        assertEquals(listOf(CardBrand.DINERS_CLUB), CardBrand.detect("305"))
+    }
+
+    @Test
+    fun `detect returns DINERS_CLUB for prefix 38`() {
+        assertEquals(listOf(CardBrand.DINERS_CLUB), CardBrand.detect("38"))
+    }
+
+    @Test
+    fun `detect returns MAESTRO for prefix 5018`() {
+        assertEquals(listOf(CardBrand.MAESTRO), CardBrand.detect("5018"))
+    }
+
+    @Test
+    fun `detect returns MAESTRO for prefix 6759`() {
+        assertEquals(listOf(CardBrand.MAESTRO), CardBrand.detect("6759"))
+    }
+
+    @Test
+    fun `detect returns MAESTRO for prefix 6761`() {
+        assertEquals(listOf(CardBrand.MAESTRO), CardBrand.detect("6761"))
+    }
+
+    @Test
+    fun `detect returns UNIONPAY for prefix 621`() {
+        assertEquals(listOf(CardBrand.UNIONPAY), CardBrand.detect("621"))
+    }
+
+    @Test
+    fun `detect returns HIPER for prefix 637095`() {
+        assertEquals(listOf(CardBrand.HIPER), CardBrand.detect("637095"))
+    }
+
+    @Test
+    fun `detect returns HIPER for prefix 637568`() {
+        assertEquals(listOf(CardBrand.HIPER), CardBrand.detect("637568"))
+    }
+
+    @Test
+    fun `detect returns HIPERCARD for prefix 606282`() {
+        assertEquals(listOf(CardBrand.HIPERCARD), CardBrand.detect("606282"))
+    }
+
+    // endregion
+
+    // region Brand detection - ambiguous prefixes
+
+    @Test
+    fun `detect returns DISCOVER and UNIONPAY for prefix 622`() {
+        val result = CardBrand.detect("622")
+        assertTrue(result.contains(CardBrand.DISCOVER))
+        assertTrue(result.contains(CardBrand.UNIONPAY))
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `detect returns only JCB for prefix 35`() {
+        val result = CardBrand.detect("35")
+        assertEquals(listOf(CardBrand.JCB), result)
+    }
+
+    // endregion
+
+    // region Brand detection - relaxed matching
+
+    @Test
+    fun `detect falls back to relaxed patterns when no strict match`() {
+        val result = CardBrand.detect("60")
+        assertEquals(listOf(CardBrand.MAESTRO), result)
+    }
+
+    @Test
+    fun `detect prefers strict match over relaxed match`() {
+        val result = CardBrand.detect("62")
+        assertEquals(listOf(CardBrand.UNIONPAY), result)
+    }
+
+    // endregion
+
+    // region Brand detection - no match
+
+    @Test
+    fun `detect returns empty list for prefix 0`() {
+        assertTrue(CardBrand.detect("0").isEmpty())
+    }
+
+    @Test
+    fun `detect returns empty list for prefix 9`() {
+        assertTrue(CardBrand.detect("9").isEmpty())
+    }
+
+    @Test
+    fun `detect returns empty list for prefix 123`() {
+        assertTrue(CardBrand.detect("123").isEmpty())
+    }
+
+    @Test
+    fun `detect returns empty list for single digit with no match`() {
+        assertTrue(CardBrand.detect("1").isEmpty())
+    }
+
+    // endregion
+
+    // region Brand detection - empty and special input
+
+    @Test
+    fun `detect returns empty list for empty string`() {
+        assertTrue(CardBrand.detect("").isEmpty())
+    }
+
+    @Test
+    fun `detect strips non-digit characters before matching`() {
+        assertEquals(listOf(CardBrand.VISA), CardBrand.detect("4 111"))
+    }
+
+    @Test
+    fun `detect returns empty list for non-digit-only input`() {
+        assertTrue(CardBrand.detect("abc").isEmpty())
+    }
+
+    // endregion
+
+    // region Brand detection - UNKNOWN never returned
+
+    @Test
+    fun `detect never returns UNKNOWN`() {
+        val inputs = listOf("", "0", "4", "34", "51", "6011", "9999999999")
+        inputs.forEach { input ->
+            val result = CardBrand.detect(input)
+            assertTrue(
+                "UNKNOWN should not be in results for input '$input'",
+                !result.contains(CardBrand.UNKNOWN)
+            )
+        }
+    }
+
+    // endregion
+
+    // region Property verification
+
+    @Test
+    fun `VISA has correct properties`() {
+        assertEquals(setOf(16), CardBrand.VISA.validLengths)
+        assertEquals(16, CardBrand.VISA.minLength)
+        assertEquals(16, CardBrand.VISA.maxLength)
+        assertEquals(3, CardBrand.VISA.cvvLength)
+        assertTrue(intArrayOf(4, 8, 12).contentEquals(CardBrand.VISA.formatGaps))
+    }
+
+    @Test
+    fun `AMEX has correct properties`() {
+        assertEquals(setOf(15), CardBrand.AMEX.validLengths)
+        assertEquals(4, CardBrand.AMEX.cvvLength)
+        assertTrue(intArrayOf(4, 10).contentEquals(CardBrand.AMEX.formatGaps))
+    }
+
+    @Test
+    fun `DINERS_CLUB has correct properties`() {
+        assertEquals(setOf(14), CardBrand.DINERS_CLUB.validLengths)
+        assertEquals(3, CardBrand.DINERS_CLUB.cvvLength)
+        assertTrue(intArrayOf(4, 10).contentEquals(CardBrand.DINERS_CLUB.formatGaps))
+    }
+
+    @Test
+    fun `DISCOVER has variable length`() {
+        assertEquals(setOf(16, 17, 18, 19), CardBrand.DISCOVER.validLengths)
+        assertEquals(16, CardBrand.DISCOVER.minLength)
+        assertEquals(19, CardBrand.DISCOVER.maxLength)
+    }
+
+    @Test
+    fun `MAESTRO has variable length`() {
+        assertEquals(setOf(12, 13, 14, 15, 16, 17, 18, 19), CardBrand.MAESTRO.validLengths)
+        assertEquals(12, CardBrand.MAESTRO.minLength)
+        assertEquals(19, CardBrand.MAESTRO.maxLength)
+    }
+
+    @Test
+    fun `UNKNOWN has empty prefix patterns`() {
+        assertTrue(CardBrand.UNKNOWN.prefixPatterns.isEmpty())
+    }
+
+    @Test
+    fun `all brands have minLength less than or equal to maxLength`() {
+        CardBrand.entries.forEach { brand ->
+            assertTrue(
+                "${brand.name} minLength (${brand.minLength}) should be <= maxLength (${brand.maxLength})",
+                brand.minLength <= brand.maxLength
+            )
+        }
+    }
+
+    // endregion
+}

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/LuhnValidatorUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/LuhnValidatorUnitTest.kt
@@ -1,0 +1,78 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LuhnValidatorUnitTest {
+
+    @Test
+    fun `isLuhnValid returns true for valid Visa number`() {
+        assertTrue(LuhnValidator.isLuhnValid("4111111111111111"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for valid Amex number`() {
+        assertTrue(LuhnValidator.isLuhnValid("378282246310005"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for valid Mastercard number`() {
+        assertTrue(LuhnValidator.isLuhnValid("5555555555554444"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for valid Discover number`() {
+        assertTrue(LuhnValidator.isLuhnValid("6011111111111117"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for valid Diners Club number`() {
+        assertTrue(LuhnValidator.isLuhnValid("30569309025904"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for valid JCB number`() {
+        assertTrue(LuhnValidator.isLuhnValid("3530111333300000"))
+    }
+
+    @Test
+    fun `isLuhnValid returns false for invalid Visa number`() {
+        assertFalse(LuhnValidator.isLuhnValid("4111111111111112"))
+    }
+
+    @Test
+    fun `isLuhnValid returns false for number with single digit changed`() {
+        assertFalse(LuhnValidator.isLuhnValid("4111111111111110"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for single digit zero`() {
+        assertTrue(LuhnValidator.isLuhnValid("0"))
+    }
+
+    @Test
+    fun `isLuhnValid returns true for empty string`() {
+        assertTrue(LuhnValidator.isLuhnValid(""))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `isLuhnValid throws for non-digit character`() {
+        LuhnValidator.isLuhnValid("4111111111111a11")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `isLuhnValid throws for spaces in input`() {
+        LuhnValidator.isLuhnValid("4111 1111 1111 1111")
+    }
+
+    @Test
+    fun `isLuhnValid returns true for second valid Visa number`() {
+        assertTrue(LuhnValidator.isLuhnValid("4005519200000004"))
+    }
+
+    @Test
+    fun `isLuhnValid returns false for invalid Amex number`() {
+        assertFalse(LuhnValidator.isLuhnValid("371111111111111"))
+    }
+}


### PR DESCRIPTION
### Summary of changes
- Add `CardBrand` enum with regex-based brand detection 
- Add `LuhnValidator` for card number checksum
- Create unit tests for new classes and methods

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Test generation

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 

