### PR TITLE
fix(paypal): fix malformed return_url in AppLink mode and add bidirectional intent resilience

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/MerchantRepository.kt
@@ -18,6 +18,9 @@ class MerchantRepository {
 
     var deepLinkFallbackUrlScheme: String? = null
 
+    val resolvedDeepLinkFallbackUrlScheme: String
+        get() = deepLinkFallbackUrlScheme ?: returnUrlScheme
+
     companion object {
 
         /**

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/usecase/GetReturnLinkUseCase.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/usecase/GetReturnLinkUseCase.kt
@@ -30,7 +30,10 @@ class GetReturnLinkUseCase(
 ) {
 
     sealed class ReturnLinkResult {
-        data class AppLink(val appLinkReturnUri: Uri) : ReturnLinkResult()
+        data class AppLink(
+            val appLinkReturnUri: Uri,
+            val deepLinkFallbackUrlScheme: String
+        ) : ReturnLinkResult()
 
         data class DeepLink(val deepLinkFallbackUrlScheme: String) : ReturnLinkResult()
 
@@ -40,8 +43,12 @@ class GetReturnLinkUseCase(
     operator fun invoke(@CheckoutUri uri: Uri = "https://www.paypal.com/checkout".toUri()): ReturnLinkResult {
         return when (getReturnLinkTypeUseCase(uri)) {
             GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK -> {
-                merchantRepository.appLinkReturnUri?.let { ReturnLinkResult.AppLink(it) }
-                    ?: ReturnLinkResult.Failure(BraintreeException("App Link Return Uri is null"))
+                merchantRepository.appLinkReturnUri?.let {
+                    ReturnLinkResult.AppLink(
+                        appLinkReturnUri = it,
+                        deepLinkFallbackUrlScheme = merchantRepository.resolvedDeepLinkFallbackUrlScheme
+                    )
+                } ?: ReturnLinkResult.Failure(BraintreeException("App Link Return Uri is null"))
             }
 
             GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK -> {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/usecase/GetReturnLinkUseCaseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/usecase/GetReturnLinkUseCaseUnitTest.kt
@@ -27,6 +27,7 @@ class GetReturnLinkUseCaseUnitTest {
     fun setUp() {
         every { merchantRepository.appLinkReturnUri } returns appLinkReturnUri
         every { merchantRepository.deepLinkFallbackUrlScheme } returns deepLinkFallbackUrlScheme
+        every { merchantRepository.resolvedDeepLinkFallbackUrlScheme } returns deepLinkFallbackUrlScheme
 
         sut = GetReturnLinkUseCase(
             merchantRepository,
@@ -42,7 +43,13 @@ class GetReturnLinkUseCaseUnitTest {
 
         val result = sut()
 
-        assertEquals(GetReturnLinkUseCase.ReturnLinkResult.AppLink(appLinkReturnUri), result)
+        assertEquals(
+            GetReturnLinkUseCase.ReturnLinkResult.AppLink(
+                appLinkReturnUri = appLinkReturnUri,
+                deepLinkFallbackUrlScheme = deepLinkFallbackUrlScheme
+            ),
+            result
+        )
     }
 
     @Test
@@ -52,6 +59,25 @@ class GetReturnLinkUseCaseUnitTest {
         val result = sut()
 
         assertEquals(GetReturnLinkUseCase.ReturnLinkResult.DeepLink(deepLinkFallbackUrlScheme), result)
+    }
+
+    @Test
+    fun `when app link available and deepLinkFallbackUrlScheme is null, falls back to returnUrlScheme`() {
+        every { getReturnLinkTypeUseCase() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK
+        every { merchantRepository.deepLinkFallbackUrlScheme } returns null
+        val returnUrlScheme = "com.braintreepayments.demo.fallback"
+        every { merchantRepository.returnUrlScheme } returns returnUrlScheme
+        every { merchantRepository.resolvedDeepLinkFallbackUrlScheme } returns returnUrlScheme
+
+        val result = sut()
+
+        assertEquals(
+            GetReturnLinkUseCase.ReturnLinkResult.AppLink(
+                appLinkReturnUri = appLinkReturnUri,
+                deepLinkFallbackUrlScheme = returnUrlScheme
+            ),
+            result
+        )
     }
 
     @Test

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -232,6 +232,7 @@ class PayPalClient internal constructor(
                     is GetReturnLinkUseCase.ReturnLinkResult.AppLink -> {
                         appLinkUri(returnLinkResult.appLinkReturnUri)
                         successAppLinkUri(paymentAuthRequest.successUrl?.toUri())
+                        returnUrlScheme(returnLinkResult.deepLinkFallbackUrlScheme)
                     }
 
                     is GetReturnLinkUseCase.ReturnLinkResult.DeepLink -> {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -232,7 +232,9 @@ class PayPalClient internal constructor(
                     is GetReturnLinkUseCase.ReturnLinkResult.AppLink -> {
                         appLinkUri(returnLinkResult.appLinkReturnUri)
                         successAppLinkUri(paymentAuthRequest.successUrl?.toUri())
-                        returnUrlScheme(returnLinkResult.deepLinkFallbackUrlScheme)
+                        merchantRepository.deepLinkFallbackUrlScheme?.let {
+                            returnUrlScheme(it)
+                        }
                     }
 
                     is GetReturnLinkUseCase.ReturnLinkResult.DeepLink -> {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -237,6 +237,7 @@ class PayPalClient internal constructor(
 
                     is GetReturnLinkUseCase.ReturnLinkResult.DeepLink -> {
                         returnUrlScheme(returnLinkResult.deepLinkFallbackUrlScheme)
+                        merchantRepository.appLinkReturnUri?.let { appLinkUri(it) }
                     }
 
                     is GetReturnLinkUseCase.ReturnLinkResult.Failure -> throw returnLinkResult.exception

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalInternalClient.kt
@@ -51,7 +51,7 @@ internal class PayPalInternalClient(
         val returnLinkResult = getReturnLinkUseCase()
         val navigationLink: String = when (returnLinkResult) {
             is GetReturnLinkUseCase.ReturnLinkResult.AppLink ->
-                returnLinkResult.appLinkReturnUri.toString()
+                returnLinkResult.deepLinkFallbackUrlScheme
 
             is GetReturnLinkUseCase.ReturnLinkResult.DeepLink ->
                 returnLinkResult.deepLinkFallbackUrlScheme
@@ -125,15 +125,10 @@ internal class PayPalInternalClient(
             dataCollector.getClientMetadataId(context, dataCollectorRequest, configuration)
         }
 
-        val returnLink: String = when (val returnLinkResult = getReturnLinkUseCase(parsedRedirectUri)) {
-            is GetReturnLinkUseCase.ReturnLinkResult.AppLink ->
-                returnLinkResult.appLinkReturnUri.toString()
-
-            is GetReturnLinkUseCase.ReturnLinkResult.DeepLink ->
-                returnLinkResult.deepLinkFallbackUrlScheme
-
-            is GetReturnLinkUseCase.ReturnLinkResult.Failure ->
-                throw returnLinkResult.exception
+        val returnLink: String = when (val result = getReturnLinkUseCase(parsedRedirectUri)) {
+            is GetReturnLinkUseCase.ReturnLinkResult.AppLink -> result.deepLinkFallbackUrlScheme
+            is GetReturnLinkUseCase.ReturnLinkResult.DeepLink -> result.deepLinkFallbackUrlScheme
+            is GetReturnLinkUseCase.ReturnLinkResult.Failure -> throw result.exception
         }
 
         val paymentAuthRequest = PayPalPaymentAuthRequestParams(

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -342,7 +342,8 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_deepLinkBranch_setsAppLinkUriWhenAppLinkReturnUriIsConfigured() = runTest(testDispatcher) {
+    fun createPaymentAuthRequest_deepLinkBranch_setsAppLinkUriWhenAppLinkReturnUriIsConfigured() =
+        runTest(testDispatcher) {
         every { getReturnLinkUseCase.invoke(any()) } returns DeepLink("myapp")
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://merchant.com/braintree")
 
@@ -379,7 +380,8 @@ class PayPalClientUnitTest {
 
         val request = slot.captured
         assertTrue(request is PayPalPaymentAuthRequest.ReadyToLaunch)
-        val browserSwitchOptions = (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams.browserSwitchOptions!!
+        val browserSwitchOptions =
+            (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams.browserSwitchOptions!!
         assertEquals(
             "myapp",
             browserSwitchOptions.returnUrlScheme

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -73,6 +73,7 @@ class PayPalClientUnitTest {
     @Throws(JSONException::class)
     fun beforeEach() {
         every { merchantRepository.returnUrlScheme } returns "com.braintreepayments.demo"
+        every { merchantRepository.deepLinkFallbackUrlScheme } returns "com.braintreepayments.demo"
         every { getReturnLinkUseCase.invoke() } returns AppLink(
             appLinkReturnUri = Uri.parse("www.example.com"),
             deepLinkFallbackUrlScheme = "com.braintreepayments.demo"

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -341,6 +341,55 @@ class PayPalClientUnitTest {
     }
 
     @Test
+    fun createPaymentAuthRequest_deepLinkBranch_setsAppLinkUriWhenAppLinkReturnUriIsConfigured() = runTest(testDispatcher) {
+        every { getReturnLinkUseCase.invoke(any()) } returns DeepLink("myapp")
+        every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://merchant.com/braintree")
+
+        val payPalVaultRequest = PayPalVaultRequest(true)
+        payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
+
+        val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+            payPalVaultRequest,
+            null,
+            "https://example.com/approval/url",
+            "sample-client-metadata-id",
+            null,
+            "https://example.com/success/url"
+        )
+
+        val payPalInternalClient =
+            MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest)
+                .build()
+
+        val braintreeClient = MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig)
+            .build()
+
+        val sut = testPaypalClient(
+            braintreeClient,
+            payPalInternalClient,
+            testDispatcher,
+            this
+        )
+        sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback)
+        advanceUntilIdle()
+
+        val slot = slot<PayPalPaymentAuthRequest>()
+        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(capture(slot)) }
+
+        val request = slot.captured
+        assertTrue(request is PayPalPaymentAuthRequest.ReadyToLaunch)
+        val browserSwitchOptions = (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams.browserSwitchOptions!!
+        assertEquals(
+            "myapp",
+            browserSwitchOptions.returnUrlScheme
+        )
+        assertEquals(
+            Uri.parse("https://merchant.com/braintree"),
+            browserSwitchOptions.appLinkUri
+        )
+    }
+
+    @Test
     fun createPaymentAuthRequest_returnsAnErrorWhen_getReturnLinkUseCase_returnsAFailure() = runTest(testDispatcher) {
         val exception = BraintreeException()
         every { getReturnLinkUseCase.invoke(any()) } returns ReturnLinkResult.Failure(exception)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -73,7 +73,10 @@ class PayPalClientUnitTest {
     @Throws(JSONException::class)
     fun beforeEach() {
         every { merchantRepository.returnUrlScheme } returns "com.braintreepayments.demo"
-        every { getReturnLinkUseCase.invoke() } returns AppLink(Uri.parse("www.example.com"))
+        every { getReturnLinkUseCase.invoke() } returns AppLink(
+            appLinkReturnUri = Uri.parse("www.example.com"),
+            deepLinkFallbackUrlScheme = "com.braintreepayments.demo"
+        )
         every { getReturnLinkTypeUseCase.invoke() } returns ReturnLinkTypeResult.APP_LINK
     }
 
@@ -246,7 +249,10 @@ class PayPalClientUnitTest {
 
     @Test
     fun createPaymentAuthRequest_setsAppLinkReturnUrl() = runTest(testDispatcher) {
-        every { getReturnLinkUseCase.invoke(any()) } returns AppLink("www.example.com".toUri())
+        every { getReturnLinkUseCase.invoke(any()) } returns AppLink(
+            appLinkReturnUri = "www.example.com".toUri(),
+            deepLinkFallbackUrlScheme = "com.braintreepayments.demo"
+        )
         val payPalVaultRequest = PayPalVaultRequest(true)
         payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
 
@@ -285,6 +291,10 @@ class PayPalClientUnitTest {
         assertEquals(
             merchantRepository.appLinkReturnUri,
             (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams.browserSwitchOptions!!.appLinkUri
+        )
+        assertEquals(
+            "com.braintreepayments.demo",
+            (request as PayPalPaymentAuthRequest.ReadyToLaunch).requestParams.browserSwitchOptions!!.returnUrlScheme
         )
     }
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
@@ -86,7 +86,8 @@ class PayPalInternalClientUnitTest {
         deviceInspector = mockk(relaxed = true)
 
         every { getReturnLinkUseCase.invoke(any()) } returns ReturnLinkResult.AppLink(
-            Uri.parse("https://example.com")
+            appLinkReturnUri = Uri.parse("https://example.com"),
+            deepLinkFallbackUrlScheme = "com.example.deeplink"
         )
     }
 
@@ -160,8 +161,8 @@ class PayPalInternalClientUnitTest {
                 "currency_iso_code": "USD",
                 "intent": "authorize",
                 "authorization_fingerprint": "client-token-bearer",
-                "return_url": "https://example.com://onetouch/v1/success",
-                "cancel_url": "https://example.com://onetouch/v1/cancel",
+                "return_url": "com.example.deeplink://onetouch/v1/success",
+                "cancel_url": "com.example.deeplink://onetouch/v1/cancel",
                 "offer_pay_later": true,
                 "offer_paypal_credit": true,
                 "request_billing_agreement": true,
@@ -255,7 +256,7 @@ class PayPalInternalClientUnitTest {
         assertFalse(params.isVaultRequest)
         assertEquals(PayPalPaymentIntent.AUTHORIZE, params.intent)
         assertEquals("sample-merchant-account-id", params.merchantAccountId)
-        assertEquals("https://example.com://onetouch/v1/success", params.successUrl)
+        assertEquals("com.example.deeplink://onetouch/v1/success", params.successUrl)
         assertEquals("fake-token", params.contextId)
         assertEquals("sample-client-metadata-id", params.clientMetadataId)
         assertEquals(expectedUrl, params.approvalUrl)
@@ -271,7 +272,7 @@ class PayPalInternalClientUnitTest {
     private fun assertPayPalVaultParams(params: PayPalPaymentAuthRequestParams, expectedUrl: String) {
         assertTrue(params.isVaultRequest)
         assertEquals("sample-merchant-account-id", params.merchantAccountId)
-        assertEquals("https://example.com://onetouch/v1/success", params.successUrl)
+        assertEquals("com.example.deeplink://onetouch/v1/success", params.successUrl)
         assertEquals("fake-ba-token", params.contextId)
         assertEquals("sample-client-metadata-id", params.clientMetadataId)
         assertEquals(expectedUrl, params.approvalUrl)
@@ -295,8 +296,8 @@ class PayPalInternalClientUnitTest {
 
         val expected = JSONObject()
             .put("authorization_fingerprint", "client-token-bearer")
-            .put("return_url", "https://example.com://onetouch/v1/success")
-            .put("cancel_url", "https://example.com://onetouch/v1/cancel")
+            .put("return_url", "com.example.deeplink://onetouch/v1/success")
+            .put("cancel_url", "com.example.deeplink://onetouch/v1/cancel")
             .put("offer_paypal_credit", true)
             .put("description", "Billing Agreement Description")
             .put(
@@ -736,7 +737,10 @@ class PayPalInternalClientUnitTest {
     @Test
     fun sendRequest_propagatesHttpErrors() = runTest(testDispatcher) {
         val httpError = IOException("http error")
-        every { getReturnLinkUseCase.invoke() } returns ReturnLinkResult.AppLink(Uri.parse("https://example.com"))
+        every { getReturnLinkUseCase.invoke() } returns ReturnLinkResult.AppLink(
+            appLinkReturnUri = Uri.parse("https://example.com"),
+            deepLinkFallbackUrlScheme = "com.example.deeplink"
+        )
         every { merchantRepository.authorization } returns clientToken
         val sut = createSutWithMocks(error = httpError)
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects {
     }
 }
 
-version '5.26.1-SNAPSHOT'
+version '5.26.2-SNAPSHOT'
 group 'com.braintreepayments'
 ext {
     compileSdkVersion = 36


### PR DESCRIPTION
## Problem

In AppLink mode, `PayPalInternalClient` constructed the OneTouch return URL by using the full HTTPS App Link URI as a scheme prefix:

```
https://example.com/paypal-app-switch://onetouch/v1/success  ← malformed
```

This URL has no registered intent handler on Android, so `BrowserSwitchClient` returns `NoResult` instead of `Success`. The billing agreement stays in `PENDING` state.

A secondary issue: `BrowserSwitchOptions` was missing `returnUrlScheme` in the AppLink branch and `appLinkUri` in the DeepLink branch, meaning a mismatch between the intent type chosen at request time and the intent type delivered at return time would always fail both `matchesDeepLinkUrlScheme()` and `matchesAppLinkUri()`.

## Changes

**`GetReturnLinkUseCase`** — extend `ReturnLinkResult.AppLink` to carry `deepLinkFallbackUrlScheme` alongside `appLinkReturnUri`. Add `resolvedDeepLinkFallbackUrlScheme` to `MerchantRepository` as a non-null accessor that falls back to `returnUrlScheme` when the merchant has not explicitly set one.

**`PayPalInternalClient`** — use `deepLinkFallbackUrlScheme` (a valid custom scheme) instead of `appLinkReturnUri.toString()` for the `return_url` and `cancel_url` in AppLink mode. `merchant_app_return_url` continues to use the HTTPS App Link URI.

**`PayPalClient`** — bidirectional resilience in `buildBrowserSwitchOptions()`:
- AppLink branch: add `returnUrlScheme` (only when `deepLinkFallbackUrlScheme` is explicitly configured by the merchant — skipped for App Link–only integrations that have no deep link scheme in their manifest)
- DeepLink branch: add `appLinkUri` when `appLinkReturnUri` is available

## Test coverage

- `GetReturnLinkUseCaseUnitTest`: assert both fields on `AppLink` result, including the fallback-to-`returnUrlScheme` case
- `PayPalInternalClientUnitTest`: assert `return_url` uses the custom scheme and `merchant_app_return_url` uses the HTTPS URI
- `PayPalClientUnitTest`: assert both `returnUrlScheme` + `appLinkUri` are set in AppLink mode; assert both are set in DeepLink mode when `appLinkReturnUri` is configured

## Pre-PR checklist
- [x] `./gradlew --continue clean testRelease` — all modules pass
- [x] `./gradlew clean lint` — no issues
- [x] `./gradlew detekt --auto-correct` — no issues