### PR TITLE
Add GitHub Action to Auto Add/Remove Labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -29,9 +29,9 @@
 Internal to PayPal contributors should fill out this section. All others can delete.
 
 PR should follow these steps before codeowners review will begin:
-1. PR should be opened in a draft state with the `tech lead review required`, and `inner source` label
+1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
 2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
-3. Once the above steps are completed, the PR can be moved to ready to review with the `tech lead review required` label removed
+3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
 4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review
 
 ### Inner Source Checklist

--- a/.github/workflows/inner-source-labels.yml
+++ b/.github/workflows/inner-source-labels.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   add-inner-source-labels:
@@ -16,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acknowledge command
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -45,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acknowledge command
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/inner-source-labels.yml
+++ b/.github/workflows/inner-source-labels.yml
@@ -1,0 +1,72 @@
+name: Inner Source Labels
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  add-inner-source-labels:
+    # Only fires on PR comments (not plain issues) containing the slash command
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/inner source')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Add inner source labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['inner source', 'tech lead review required']
+            });
+
+  remove-tech-lead-label:
+    # Only fires on PR comments containing the slash command
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/ready')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Remove tech lead review required label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'tech lead review required'
+              });
+            } catch (e) {
+              // 404 means the label wasn't on the PR — that's fine
+              if (e.status !== 404) throw e;
+            }


### PR DESCRIPTION
### Summary of changes
- Add GitHub Action to auto add/remove labels for inner source PRs when the comment `/inner source` or `/ready` are added to the PR as a comment. See in action here: https://github.com/braintree/braintree_ios/pull/1812

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to retrieve and push up the diff from the iOS PR

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- ~[ ] Added a changelog entry~
- ~[ ] Tested and confirmed payment flows affected by this change are functioning as expected~

### Authors
- @jaxdesmarais 
