### PR TITLE
feat: add card end-to-end flow to CardFields

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/CardFieldsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/CardFieldsFragment.kt
@@ -5,11 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.Toast
-import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.NavHostFragment
+import com.braintreepayments.api.card.Card
 import com.braintreepayments.api.uicomponents.cardfields.CardFields
+import com.braintreepayments.api.uicomponents.cardfields.CardFieldsResult
 
-class CardFieldsFragment : Fragment() {
+class CardFieldsFragment : BaseFragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,16 +21,39 @@ class CardFieldsFragment : Fragment() {
 
         val cardFields = view.findViewById<CardFields>(R.id.card_fields)
         val payButton = view.findViewById<Button>(R.id.pay_button)
+        cardFields.initialize(authStringArg)
+        // optional customer data
+        cardFields.setPaymentRequest(
+            Card(
+                cardholderName = "John Doe",
+                postalCode = "12345"
+            )
+        )
+
+        cardFields.setCardFieldsResultCallback { result ->
+            when (result) {
+                is CardFieldsResult.Success -> {
+                    // handle nonce
+                    super.onPaymentMethodNonceCreated(result.nonce)
+                    val action = CardFieldsFragmentDirections
+                        .actionCardFieldsFragmentToDisplayNonceFragment(result.nonce)
+                    NavHostFragment.findNavController(this).navigate(action)
+                }
+                is CardFieldsResult.Failure -> {
+                    // display error
+                    handleError(result.error)
+                }
+            }
+        }
 
         // Card fields will tell the merchant if the card is valid, and they can enable the button
         cardFields.setOnValidationChangedListener { isFormValid ->
             payButton.isEnabled = isFormValid
         }
 
-        // placeholder for tokenization
+        // submit card info for processing
         payButton.setOnClickListener {
-            Toast.makeText(requireContext(), R.string.card_fields_valid_toast, Toast.LENGTH_SHORT)
-                .show()
+            cardFields.submit()
         }
 
         return view

--- a/Demo/src/main/java/com/braintreepayments/demo/MainFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainFragment.kt
@@ -221,8 +221,11 @@ class MainFragment : BaseFragment() {
     }
 
     private fun launchCardFields() {
-        val action = MainFragmentDirections.actionMainFragmentToCardFieldsFragment()
-        findNavController().navigate(action)
+       fetchAuthorizationAndHandleError { authString ->
+           val action = MainFragmentDirections.actionMainFragmentToCardFieldsFragment()
+           action.setAuthString(authString)
+           findNavController().navigate(action)
+       }
     }
 
     private fun launchPaymentButtons() {

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -274,5 +274,15 @@
     <fragment
         android:id="@+id/cardFieldsFragment"
         android:name="com.braintreepayments.demo.CardFieldsFragment"
-        tools:layout="@layout/fragment_card_fields" />
+        tools:layout="@layout/fragment_card_fields">
+        <argument
+            android:name="authString"
+            android:defaultValue=""
+            app:argType="string" />
+        <action
+            android:id="@+id/action_cardFieldsFragment_to_displayNonceFragment"
+            app:destination="@id/displayNonceFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+    </fragment>
 </navigation>

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFields.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFields.kt
@@ -6,6 +6,10 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import com.braintreepayments.api.card.Card
+import com.braintreepayments.api.card.CardClient
+import com.braintreepayments.api.card.CardResult
+import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.uicomponents.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -13,11 +17,13 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 class CardFields internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-    private val viewModel: CardFieldsViewModel = CardFieldsViewModel()
+    private val viewModel: CardFieldsViewModel = CardFieldsViewModel(),
+    private var cardClient: CardClient? = null
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
     @JvmOverloads
@@ -32,6 +38,8 @@ class CardFields internal constructor(
     private val cvvView: CvvTextInputView
     private var observerScope: CoroutineScope? = null
     private var validationChangedListener: OnValidationChangedListener? = null
+    private var request: Card? = null
+    private var resultCallback: CardFieldsResultCallback? = null
 
     init {
         LayoutInflater.from(context).inflate(R.layout.card_fields_view, this, true)
@@ -75,6 +83,76 @@ class CardFields internal constructor(
         super.onDetachedFromWindow()
         observerScope?.cancel()
         observerScope = null
+    }
+
+    /**
+     * Initializes the card tokenization flow. Must be called before [submit].
+     * @param authorization a tokenization key or client token.
+     */
+    fun initialize(authorization: String) {
+        cardClient = CardClient(context, authorization)
+    }
+
+    /**
+     * Optionally accepts a [Card] with additional data to be included in the tokenization request, such as
+     * cardholder name or billing address. The card number, expiration, and CVV provided by the user will
+     * override any values set on the [Card] object.
+     */
+    fun setPaymentRequest(card: Card?) {
+        request = card
+    }
+
+    /**
+     * Register a callback to receive the [CardFieldsResult] from [submit]
+     */
+    fun setCardFieldsResultCallback(callback: CardFieldsResultCallback?) {
+        resultCallback = callback
+    }
+
+    /**
+     * Tokenizes the card details entered by the user, along with any additional data provided in
+     * [setPaymentRequest]. The result is returned via the [CardFieldsResultCallback] registered in
+     * [setCardFieldsResultCallback].
+     *
+     * If called before [initialize], delivers a [CardFieldsResult.Failure].
+     */
+    fun submit() {
+        val client = cardClient
+        if (client == null) {
+            resultCallback?.onCardFieldsResult(
+                CardFieldsResult.Failure(
+                    BraintreeException(
+                        "CardFields must be initialized by calling initialize() before submit()")
+                )
+            )
+            return
+        }
+        client.tokenize(buildCard()) { cardResult ->
+            val result = when (cardResult) {
+                is CardResult.Success -> {
+                    CardFieldsResult.Success(cardResult.nonce)
+                }
+                is CardResult.Failure -> {
+                    CardFieldsResult.Failure(cardResult.error)
+                }
+            }
+            resultCallback?.onCardFieldsResult(result)
+        }
+    }
+
+    /**
+     * Builds a [Card] from the user input merged with any additional data from [setPaymentRequest].
+     * [copy] returns a new instance with the typed fields updated, so the merchant's [request] fields
+     * remain unchanged.
+     */
+    private fun buildCard(): Card {
+        val rawExpiration = expirationView.getRawExpiration()
+        return (request ?: Card()).copy(
+            number = cardNumberView.getRawCardNumber(),
+            expirationMonth = rawExpiration.take(2),
+            expirationYear = rawExpiration.drop(2),
+            cvv = cvvView.getRawCvv()
+        )
     }
 
     /**

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResult.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResult.kt
@@ -1,0 +1,19 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+import com.braintreepayments.api.card.CardNonce
+
+/**
+ * Result of a call to [CardFields.submit]
+ */
+sealed class CardFieldsResult {
+
+    /**
+     * The card tokenization completed successfully. This [nonce] should be sent to your server.
+     */
+    class Success internal constructor(val nonce: CardNonce) : CardFieldsResult()
+
+    /**
+     * There was an [error] during card tokenization.
+     */
+    class Failure internal constructor(val error: Exception) : CardFieldsResult()
+}

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResultCallback.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResultCallback.kt
@@ -1,0 +1,14 @@
+package com.braintreepayments.api.uicomponents.cardfields
+
+import com.braintreepayments.api.card.CardNonce
+
+/**
+ * Callback for receiving result of [CardFields.submit].
+ */
+fun interface CardFieldsResultCallback {
+
+    /**
+     * @param cardFieldsResult a [cardFieldsResult] containing a [CardNonce] or [Exception]
+     */
+    fun onCardFieldsResult(cardFieldsResult: CardFieldsResult)
+}

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResultCallback.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsResultCallback.kt
@@ -8,7 +8,7 @@ import com.braintreepayments.api.card.CardNonce
 fun interface CardFieldsResultCallback {
 
     /**
-     * @param cardFieldsResult a [cardFieldsResult] containing a [CardNonce] or [Exception]
+     * @param cardFieldsResult a [CardFieldsResult] containing a [CardNonce] or [Exception]
      */
     fun onCardFieldsResult(cardFieldsResult: CardFieldsResult)
 }

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsUnitTest.kt
@@ -5,10 +5,19 @@ import android.text.InputFilter
 import android.view.View
 import android.widget.EditText
 import android.widget.TextView
+import com.braintreepayments.api.card.Card
+import com.braintreepayments.api.card.CardClient
+import com.braintreepayments.api.card.CardNonce
+import com.braintreepayments.api.card.CardResult
+import com.braintreepayments.api.card.CardTokenizeCallback
+import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.uicomponents.R
 import com.braintreepayments.api.uicomponents.util.CoroutineTestRule
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +25,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -33,6 +43,7 @@ class CardFieldsUnitTest {
 
     private lateinit var activity: Activity
     private lateinit var viewModel: CardFieldsViewModel
+    private val cardClient: CardClient = mockk(relaxed = true)
 
     // Controllable backing flows so each test can drive the ViewModel's outputs directly.
     private val cardNumberValidation = MutableStateFlow<ValidationResult>(ValidationResult.Validating)
@@ -54,6 +65,9 @@ class CardFieldsUnitTest {
     }
 
     private fun createCardFields() = CardFields(activity, viewModel = viewModel)
+
+    private fun createCardFieldsWithClient() =
+        CardFields(activity, viewModel = viewModel, cardClient = cardClient)
 
     private fun CardFields.attach() = activity.setContentView(this)
 
@@ -335,6 +349,130 @@ class CardFieldsUnitTest {
 
             assertEquals(View.GONE, errorLabel.visibility)
         }
+
+    // endregion
+
+    // region Tokenization
+
+    @Test
+    fun `submit before initialize delivers a Failure to the callback`() {
+        // No injected client and initialize() never called, so cardClient is null.
+        val cardFields = createCardFields()
+        var result: CardFieldsResult? = null
+        cardFields.setCardFieldsResultCallback { result = it }
+
+        cardFields.submit()
+
+        assertTrue(result is CardFieldsResult.Failure)
+        assertTrue((result as CardFieldsResult.Failure).error is BraintreeException)
+    }
+
+    @Test
+    fun `submit before initialize does not tokenize`() {
+        // No client is injected (null cardClient), so submit() hits the pre-init guard and
+        // skips tokenization entirely — cardClient.tokenize is never reached.
+        val cardFields = createCardFields()
+        cardFields.setCardFieldsResultCallback { }
+
+        cardFields.submit()
+
+        verify(exactly = 0) { cardClient.tokenize(any(), any()) }
+    }
+
+    @Test
+    fun `submit maps a CardResult Success to a CardFieldsResult Success`() {
+        val nonce = mockk<CardNonce>()
+        val successResult = mockk<CardResult.Success>()
+        every { successResult.nonce } returns nonce
+        every { cardClient.tokenize(any(), any()) } answers {
+            secondArg<CardTokenizeCallback>().onCardResult(successResult)
+        }
+        val cardFields = createCardFieldsWithClient()
+        var result: CardFieldsResult? = null
+        cardFields.setCardFieldsResultCallback { result = it }
+
+        cardFields.submit()
+
+        assertTrue(result is CardFieldsResult.Success)
+        assertEquals(nonce, (result as CardFieldsResult.Success).nonce)
+    }
+
+    @Test
+    fun `submit maps a CardResult Failure to a CardFieldsResult Failure`() {
+        val error = BraintreeException("tokenization failed")
+        val failureResult = mockk<CardResult.Failure>()
+        every { failureResult.error } returns error
+        every { cardClient.tokenize(any(), any()) } answers {
+            secondArg<CardTokenizeCallback>().onCardResult(failureResult)
+        }
+        val cardFields = createCardFieldsWithClient()
+        var result: CardFieldsResult? = null
+        cardFields.setCardFieldsResultCallback { result = it }
+
+        cardFields.submit()
+
+        assertTrue(result is CardFieldsResult.Failure)
+        assertEquals(error, (result as CardFieldsResult.Failure).error)
+    }
+
+    @Test
+    fun `submit tokenizes the user-entered card fields`() {
+        val cardSlot = slot<Card>()
+        every { cardClient.tokenize(capture(cardSlot), any()) } just Runs
+        val cardFields = createCardFieldsWithClient()
+        cardFields.cardNumberView().setText("4111111111111111")
+        cardFields.expirationView().setText("12/26")
+        cardFields.cvvView().setText("123")
+
+        cardFields.submit()
+
+        val captured = cardSlot.captured
+        assertEquals("4111111111111111", captured.number)
+        assertEquals("12", captured.expirationMonth)
+        assertEquals("26", captured.expirationYear)
+        assertEquals("123", captured.cvv)
+    }
+
+    @Test
+    fun `submit merges UI fields over the payment request, with all fields correctly preserved`() {
+        val cardSlot = slot<Card>()
+        every { cardClient.tokenize(capture(cardSlot), any()) } just Runs
+        val cardFields = createCardFieldsWithClient()
+        cardFields.cardNumberView().setText("4111111111111111")
+        cardFields.expirationView().setText("12/26")
+        cardFields.cvvView().setText("123")
+        // The merchant card carries metadata AND a number the user did not type.
+        cardFields.setPaymentRequest(
+            Card(cardholderName = "Jane Doe", postalCode = "94107", number = "0000")
+        )
+
+        cardFields.submit()
+
+        val captured = cardSlot.captured
+        // UI-entered number overrides the merchant-supplied "0000".
+        assertEquals("4111111111111111", captured.number)
+        // Merchant-only metadata is preserved by copy().
+        assertEquals("Jane Doe", captured.cardholderName)
+        assertEquals("94107", captured.postalCode)
+    }
+
+    @Test
+    fun `submit without a payment request still tokenizes the UI fields`() {
+        val cardSlot = slot<Card>()
+        every { cardClient.tokenize(capture(cardSlot), any()) } just Runs
+        val cardFields = createCardFieldsWithClient()
+        cardFields.cardNumberView().setText("4111111111111111")
+        cardFields.expirationView().setText("12/26")
+        cardFields.cvvView().setText("123")
+
+        cardFields.submit()
+
+        val captured = cardSlot.captured
+        assertEquals("4111111111111111", captured.number)
+        // No payment request was set, so metadata fields fall back to the empty Card() defaults.
+        assertNull(captured.cardholderName)
+        assertNull(captured.postalCode)
+    }
 
     // endregion
 


### PR DESCRIPTION
### Summary of changes
- Add card tokenization flow to CardFields
- Create `initialize()` method that creates CardClient
- Create `setPaymentRequest()` optional method that merchants can invoke if they need to pass more Card data (Name, address, etc)
- Create `submit()` as an method that will start the tokenization of the card once the Card data is valid
- Add `CardFieldsResult` and `CardFieldsResultCallback`
- Add a flow to demo

https://github.com/user-attachments/assets/a6394069-4fb2-44ee-942b-6deb96726aa3



### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Test Generation, code debugging

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 
