### PR TITLE
Fix cvv length issue

### DIFF
--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
@@ -284,6 +284,37 @@ class CardFieldsTest {
         }
     }
 
+    @Test
+    fun cardFields_showsCvvError_whenSwitchingFromAmexToVisa() {
+        launchActivity().use { scenario ->
+            // Enter an Amex card with a valid 4-digit CVV
+            scenario.onActivity { activity ->
+                activity.cardFields.cardNumberEditText().setText("378282246310005")
+                activity.cardFields.cvvEditText().also { cvv ->
+                    cvv.requestFocus()
+                    cvv.setText("1234")
+                }
+            }
+            waitForMain()
+            // Switch to Visa — brand changes, 4-digit CVV is now too long (Visa requires 3)
+            scenario.onActivity { activity ->
+                activity.cardFields.cardNumberEditText().setText("4111111111111111")
+            }
+            waitForMain()
+            // Blur CVV to trigger validation against the new brand
+            scenario.onActivity { activity ->
+                activity.cardFields.expirationEditText().requestFocus()
+            }
+            waitForMain()
+            scenario.onActivity { activity ->
+                val errorLabel = activity.cardFields.cvvErrorLabel()
+                assertTrue(errorLabel.visibility == View.VISIBLE)
+                assertTrue(errorLabel.text.isNotEmpty())
+            }
+        }
+    }
+
+
     // endregion
 
     // region Submit before initialize

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
@@ -343,6 +343,28 @@ class CardFieldsTest {
         }
     }
 
+    @Test
+    fun cardFields_payButton_remainsDisabled_afterConfigurationChange_whenFormIsInvalid() {
+        launchActivity().use { scenario ->
+            scenario.onActivity { activity ->
+                activity.cardFields.cardNumberEditText().setText("4111111111111111")
+                activity.cardFields.expirationEditText().setText("1245")
+                // CVV intentionally left empty — form is invalid
+            }
+            waitForMain()
+            scenario.onActivity { activity ->
+                assertFalse("Pay button should be disabled before rotation", activity.payButton.isEnabled)
+            }
+
+            scenario.recreate()
+            waitForMain()
+
+            scenario.onActivity { activity ->
+                assertFalse("Pay button should remain disabled after rotation", activity.payButton.isEnabled)
+            }
+        }
+    }
+
     // endregion
 
     // region Submit before initialize

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
@@ -314,7 +314,6 @@ class CardFieldsTest {
         }
     }
 
-
     // endregion
 
     // region Submit before initialize

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTest.kt
@@ -316,6 +316,35 @@ class CardFieldsTest {
 
     // endregion
 
+    // region Configuration change (rotation)
+
+    @Test
+    fun cardFields_payButton_remainsEnabled_afterConfigurationChange() {
+        launchActivity().use { scenario ->
+            scenario.onActivity { activity ->
+                activity.cardFields.cardNumberEditText().setText("4111111111111111")
+                activity.cardFields.expirationEditText().setText("1245")
+                activity.cardFields.cvvEditText().also { cvv ->
+                    cvv.setText("123")
+                    cvv.clearFocus()
+                }
+            }
+            waitForMain()
+            scenario.onActivity { activity ->
+                assertTrue("Pay button should be enabled before rotation", activity.payButton.isEnabled)
+            }
+
+            scenario.recreate()
+            waitForMain()
+
+            scenario.onActivity { activity ->
+                assertTrue("Pay button should remain enabled after rotation", activity.payButton.isEnabled)
+            }
+        }
+    }
+
+    // endregion
+
     // region Submit before initialize
 
     @Test

--- a/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTestActivity.kt
+++ b/UIComponents/src/androidTest/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsTestActivity.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.uicomponents.cardfields
 
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
@@ -8,13 +9,22 @@ import androidx.appcompat.app.AppCompatActivity
 
 class CardFieldsTestActivity : AppCompatActivity() {
 
+    companion object {
+        val CARD_FIELDS_VIEW_ID: Int = View.generateViewId()
+    }
+
     lateinit var cardFields: CardFields
     lateinit var payButton: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        cardFields = CardFields(this)
+        cardFields = CardFields(this).apply {
+            // Stable ID so Android saves/restores this view's state on rotation.
+            // generateViewId() is called once per process; scenario.recreate() stays in the same
+            // process, so both Activity instances use the same ID.
+            id = CARD_FIELDS_VIEW_ID
+        }
         payButton = Button(this).apply {
             text = "Pay"
             isEnabled = false

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardBrand.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardBrand.kt
@@ -15,6 +15,8 @@ internal enum class CardBrand(
     val relaxedPrefixPatterns: List<Regex> = emptyList(),
     val validLengths: Set<Int>,
     val cvvLength: Int,
+    /** Minimum accepted CVV length. Equals [cvvLength] for all known brands; UNKNOWN accepts 3–4. */
+    val minCvvLength: Int = cvvLength,
     val formatGaps: IntArray = intArrayOf(4, 8, 12)
 ) {
     VISA(
@@ -118,7 +120,8 @@ internal enum class CardBrand(
     UNKNOWN(
         prefixPatterns = emptyList(),
         validLengths = setOf(12, 13, 14, 15, 16, 17, 18, 19),
-        cvvLength = 3
+        cvvLength = 4,
+        minCvvLength = 3
     );
 
     val minLength: Int get() = validLengths.min()

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFields.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFields.kt
@@ -264,6 +264,9 @@ class CardFields internal constructor(
         restoreFieldError(state.cardNumberHasError, CardField.CARD_NUMBER)
         restoreFieldError(state.expirationHasError, CardField.EXPIRY)
         restoreFieldError(state.cvvHasError, CardField.CVV)
+
+        // Re-notifying here ensures the pay button reflects the restored validity state when phone is rotated.
+        validationChangedListener?.onValidationChanged(viewModel.isFormValid.value)
     }
 
     private fun restoreFieldError(hadError: Boolean, field: CardField) {

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModel.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModel.kt
@@ -122,7 +122,9 @@ internal class CardFieldsViewModel(
     /** Re-runs CVV validation when the detected card brand changes (e.g., Amex requires 4 digits). */
     private fun revalidateCvv() {
         val result = cvvValidationUseCase(currentCvv, _detectedCardBrand.value)
-        if (_cvvValidation.value is ValidationResult.Valid) {
+        if (_cvvValidation.value is ValidationResult.Valid && result is ValidationResult.Validating) {
+            _cvvValidation.value = ValidationResult.Invalid(R.string.cvv_error)
+        } else if (_cvvValidation.value is ValidationResult.Valid) {
             _cvvValidation.value = result
         } else {
             suppressErrorDuringTyping(_cvvValidation, result)

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModel.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModel.kt
@@ -122,7 +122,11 @@ internal class CardFieldsViewModel(
     /** Re-runs CVV validation when the detected card brand changes (e.g., Amex requires 4 digits). */
     private fun revalidateCvv() {
         val result = cvvValidationUseCase(currentCvv, _detectedCardBrand.value)
-        suppressErrorDuringTyping(_cvvValidation, result)
+        if (_cvvValidation.value is ValidationResult.Valid) {
+            _cvvValidation.value = result
+        } else {
+            suppressErrorDuringTyping(_cvvValidation, result)
+        }
     }
 
     /**

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CvvTextInputView.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CvvTextInputView.kt
@@ -37,13 +37,8 @@ class CvvTextInputView @JvmOverloads constructor(
 
     internal fun updateCardBrand(brand: CardBrand) {
         formatter.updateCvvLength(brand.cvvLength)
-        val currentCvv = getRawCvv()
-        if (currentCvv.length > brand.cvvLength) {
-            setText(currentCvv.take(brand.cvvLength))
-        } else {
-            editText.filters = (editText.filters.filterNot { it is InputFilter.LengthFilter } +
-                InputFilter.LengthFilter(brand.cvvLength)).toTypedArray()
-        }
+        editText.filters = (editText.filters.filterNot { it is InputFilter.LengthFilter } +
+            InputFilter.LengthFilter(brand.cvvLength)).toTypedArray()
     }
 
     internal fun getRawCvv(): String {

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CvvValidationUseCase.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/cardfields/CvvValidationUseCase.kt
@@ -7,8 +7,8 @@ internal class CvvValidationUseCase {
     operator fun invoke(cvv: String, cardBrand: CardBrand): ValidationResult {
         return when {
             cvv.isEmpty() -> ValidationResult.Validating
-            cvv.length < cardBrand.cvvLength -> ValidationResult.Validating
-            cvv.length == cardBrand.cvvLength -> ValidationResult.Valid
+            cvv.length < cardBrand.minCvvLength -> ValidationResult.Validating
+            cvv.length <= cardBrand.cvvLength -> ValidationResult.Valid
             else -> ValidationResult.Invalid(R.string.cvv_error)
         }
     }

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsUnitTest.kt
@@ -801,6 +801,26 @@ class CardFieldsUnitTest {
             assertEquals("1234", restored.cvvView().editText().text.toString())
         }
 
+    @Test
+    fun `restoring re-notifies the validation listener so pay button reflects restored validity`() {
+        val original = createCardFields().withSaveId()
+        val container = SparseArray<Parcelable>()
+        original.saveHierarchyState(container)
+
+        // Simulate the view model reflecting valid state after all fields are restored.
+        isFormValid.value = true
+        val restored = createCardFields().withSaveId()
+        val received = mutableListOf<Boolean>()
+        restored.setOnValidationChangedListener { received.add(it) }
+        // Clear the immediate call from setOnValidationChangedListener so we only assert
+        // what onRestoreInstanceState contributes.
+        received.clear()
+
+        restored.restoreHierarchyState(container)
+
+        assertEquals(listOf(true), received)
+    }
+
     // endregion
 
     private fun CardFields.withSaveId() = apply { id = SAVE_VIEW_ID }

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModelUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModelUnitTest.kt
@@ -285,7 +285,7 @@ class CardFieldsViewModelUnitTest {
         assertEquals(ValidationResult.Valid, vm.cvvValidation.value)
 
         vm.onCardNumberChanged("378282246310005")
-        assertEquals(ValidationResult.Validating, vm.cvvValidation.value)
+        assertEquals(ValidationResult.Invalid(R.string.cvv_error), vm.cvvValidation.value)
     }
 
     @Test

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModelUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CardFieldsViewModelUnitTest.kt
@@ -234,6 +234,7 @@ class CardFieldsViewModelUnitTest {
     @Test
     fun `over-length CVV does not show error during typing`() {
         val vm = createViewModel()
+        vm.onCardNumberChanged("4111111111111111") // Visa — 3-digit CVV
         vm.onCvvChanged("1234")
         assertEquals(ValidationResult.Validating, vm.cvvValidation.value)
     }

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CvvTextInputViewUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CvvTextInputViewUnitTest.kt
@@ -94,14 +94,14 @@ class CvvTextInputViewUnitTest {
     }
 
     @Test
-    fun `updateCardBrand from AMEX to VISA truncates existing 4-digit cvv to 3`() {
+    fun `updateCardBrand from AMEX to VISA preserves existing 4-digit cvv`() {
         val view = CvvTextInputView(context)
 
         view.updateCardBrand(CardBrand.AMEX)
         view.setText("1234")
         view.updateCardBrand(CardBrand.VISA)
 
-        assertEquals("123", view.getRawCvv())
+        assertEquals("1234", view.getRawCvv())
     }
 
     @Test
@@ -125,13 +125,33 @@ class CvvTextInputViewUnitTest {
     }
 
     @Test
-    fun `updateCardBrand with UNKNOWN keeps 3 digit limit`() {
+    fun `updateCardBrand with UNKNOWN allows 3 digits`() {
+        val view = CvvTextInputView(context)
+
+        view.updateCardBrand(CardBrand.UNKNOWN)
+        view.setText("123")
+
+        assertEquals("123", view.getRawCvv())
+    }
+
+    @Test
+    fun `updateCardBrand with UNKNOWN allows 4 digits`() {
         val view = CvvTextInputView(context)
 
         view.updateCardBrand(CardBrand.UNKNOWN)
         view.setText("1234")
 
-        assertEquals("123", view.getRawCvv())
+        assertEquals("1234", view.getRawCvv())
+    }
+
+    @Test
+    fun `updateCardBrand with UNKNOWN truncates to 4 digits`() {
+        val view = CvvTextInputView(context)
+
+        view.updateCardBrand(CardBrand.UNKNOWN)
+        view.setText("12345")
+
+        assertEquals("1234", view.getRawCvv())
     }
 
     @Test

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CvvValidationUseCaseUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/cardfields/CvvValidationUseCaseUnitTest.kt
@@ -44,8 +44,13 @@ class CvvValidationUseCaseUnitTest {
     }
 
     @Test
-    fun `4-digit CVV with UNKNOWN brand returns Invalid`() {
-        assertEquals(ValidationResult.Invalid(R.string.cvv_error), sut("1234", CardBrand.UNKNOWN))
+    fun `4-digit CVV with UNKNOWN brand returns Valid`() {
+        assertEquals(ValidationResult.Valid, sut("1234", CardBrand.UNKNOWN))
+    }
+
+    @Test
+    fun `2-digit CVV with UNKNOWN brand returns Validating`() {
+        assertEquals(ValidationResult.Validating, sut("12", CardBrand.UNKNOWN))
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes
- This is a similar issue that iOS encountered [in this PR](https://github.com/braintree/braintree_ios/pull/1822) where if the CVV is already entered and the card type changes to a type with a different length CVV then the error doesn't trigger unless the field is specifically focused and then moved off focus. This PR fixes that bug by re-triggering the error check:

[Screen_recording_20260624_114145.webm](https://github.com/user-attachments/assets/938329a0-e5f2-48d1-a27a-d4487b060a95)


### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Had Claude analyze my iOS PR and then check for same issue on Android to get my unit test to pass that was created to test for this specific scenario

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 