### PR TITLE
Add Android 17 support, bump AGP

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 23, 31, 35 ]
+        api-level: [ 23, 31, 35, 37 ]
         target: [ default, google_apis ]
     steps:
       - name: checkout

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -8,8 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 23, 31, 35, 37 ]
+        api-level: [ 23, 31, 35 ]
         target: [ default, google_apis ]
+        # API 37 (Android 17) has no `default` or plain `google_apis` image yet —
+        # it only ships as `google_apis_ps16k` under system image level `37.0`,
+        # so it is added as a dedicated combination rather than in the cross-product.
+        include:
+          - api-level: 37
+            target: google_apis_ps16k
+            system-image-api-level: "37.0"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -26,6 +33,7 @@ jobs:
         continue-on-error: true
         with:
           api-level: ${{ matrix.api-level }}
+          system-image-api-level: ${{ matrix.system-image-api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
@@ -36,6 +44,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          system-image-api-level: ${{ matrix.system-image-api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -14,7 +14,7 @@ jobs:
         # it only ships as `google_apis_ps16k` under system image level `37.0`,
         # so it is added as a dedicated combination rather than in the cross-product.
         include:
-          - api-level: 37
+          - api-level: "37.0"
             target: google_apis_ps16k
             system-image-api-level: "37.0"
     steps:

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 23, 31, 35, 37 ]
-        target: [ default, google_apis, google_apis_ps16k ]
+        api-level: [ 23, 31, 35 ]
+        target: [ default, google_apis ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
 
       - name: run tests
         id: run_tests
-        uses: reactivecircus/android-emulator-runner@v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true
         with:
           api-level: ${{ matrix.api-level }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
-        uses: reactivecircus/android-emulator-runner@v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: run tests
         id: run_tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         continue-on-error: true
         with:
           api-level: ${{ matrix.api-level }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -8,15 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 23, 31, 35 ]
-        target: [ default, google_apis ]
-        # API 37 (Android 17) has no `default` or plain `google_apis` image yet —
-        # it only ships as `google_apis_ps16k` under system image level `37.0`,
-        # so it is added as a dedicated combination rather than in the cross-product.
-        include:
-          - api-level: "37.0"
-            target: google_apis_ps16k
-            system-image-api-level: "37.0"
+        api-level: [ 23, 31, 35, 37 ]
+        target: [ default, google_apis, google_apis_ps16k ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -33,7 +26,6 @@ jobs:
         continue-on-error: true
         with:
           api-level: ${{ matrix.api-level }}
-          system-image-api-level: ${{ matrix.system-image-api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
@@ -44,7 +36,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          system-image-api-level: ${{ matrix.system-image-api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Venmo
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
+* BraintreeCore
+    * Update Android Gradle Plugin version to 8.13.2
+    * Update compileSdkVersion and targetSdkVersion to 37
   
 ## 5.29.0 (2026-06-30)
 * GooglePay

--- a/build.gradle
+++ b/build.gradle
@@ -50,11 +50,11 @@ allprojects {
 version '5.29.1-SNAPSHOT'
 group 'com.braintreepayments'
 ext {
-    compileSdkVersion = 36
+    compileSdkVersion = 37
     minSdkVersion = 23
     minSdkVersionPayPalMessaging = 23
     versionCode = 226
-    targetSdkVersion = 36
+    targetSdkVersion = 37
     versionName = version
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.9.1"
+gradle = "8.11.2"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"
 kotlin = "1.9.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.11.2"
+gradle = "8.13.2"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"
 kotlin = "1.9.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.13.2"
+androidGradlePlugin = "8.13.2"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"
 kotlin = "1.9.10"
@@ -75,7 +75,7 @@ kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", vers
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
 cardinal = { group = "org.jfrog.cardinalcommerce.gradle", name = "cardinalmobilesdk", version.ref = "cardinal" }
 paypal-messages = { module = "com.paypal.messages:paypal-messages", version.ref = "paypalMessages" }
@@ -123,8 +123,8 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 google-pay-button = { module = "com.google.pay.button:compose-pay-button", version.ref = "googlePayButton" }
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "gradle" }
-android-library = { id = "com.android.library", version.ref = "gradle" }
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 10 15:53:55 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 10 15:53:55 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary of changes
- Bump `compileSdk` and `targetSdk` to 37 to enable android 17 support
- Bump AGP version to the latest version that does not requiere big dependency update

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
used AI to try to make instrumentation tests run on CI, the support for api 37 emulators is still not available, so the support for it will be added later 

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 