### PR TITLE
feat(PayPal): auto-link on manual return when App Link fails

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -28,6 +28,7 @@ import com.braintreepayments.api.paypal.PayPalPaymentAuthResult;
 import com.braintreepayments.api.paypal.PayPalPendingRequest;
 import com.braintreepayments.api.paypal.PayPalRequest;
 import com.braintreepayments.api.paypal.PayPalResult;
+import com.braintreepayments.api.paypal.PayPalTokenizeCallback;
 import com.google.android.material.textfield.TextInputEditText;
 
 public class PayPalFragment extends BaseFragment {
@@ -228,11 +229,24 @@ public class PayPalFragment extends BaseFragment {
                     isAmountBreakdownEnabled
             );
         }
+        // For billing agreement flows, pass a tokenizeCallback to enable auto-link Path 2:
+        // if the user re-taps PayPal after a failed App Link return, the SDK will deliver
+        // the nonce directly here instead of restarting the full flow.
+        PayPalTokenizeCallback tokenizeCallback = isBillingAgreement
+            ? payPalResult -> {
+                if (payPalResult instanceof PayPalResult.Failure) {
+                    handleError(((PayPalResult.Failure) payPalResult).getError());
+                } else if (payPalResult instanceof PayPalResult.Success) {
+                    handlePayPalResult(((PayPalResult.Success) payPalResult).getNonce());
+                }
+            }
+            : null;
+
         payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,
             (paymentAuthRequest) -> {
                 if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.Failure) {
                     handleError(((PayPalPaymentAuthRequest.Failure) paymentAuthRequest).getError());
-                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch){
+                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch) {
                     PayPalPendingRequest request = payPalLauncher.launch(requireActivity(),
                             ((PayPalPaymentAuthRequest.ReadyToLaunch) paymentAuthRequest));
                     if (request instanceof PayPalPendingRequest.Started) {
@@ -241,7 +255,8 @@ public class PayPalFragment extends BaseFragment {
                         handleError(((PayPalPendingRequest.Failure) request).getError());
                     }
                 }
-            });
+            },
+            tokenizeCallback);
     }
 
     private void completePayPalFlow(PayPalPaymentAuthResult.Success paymentAuthResult) {

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api project(':BraintreeCore')
 
     implementation libs.androidx.appcompat
+    implementation libs.androidx.lifecycle.process
     implementation project(':DataCollector')
 
     testImplementation libs.robolectric

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
@@ -1,0 +1,26 @@
+package com.braintreepayments.api.paypal
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+internal class AppForegroundDetector(
+    private val store: PendingPaymentStore
+) : DefaultLifecycleObserver {
+
+    override fun onStop(owner: LifecycleOwner) {
+        if (store.state == PendingPaymentStore.State.SWITCH_LAUNCHED) {
+            store.state = PendingPaymentStore.State.AWAITING_RETURN
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (store.state == PendingPaymentStore.State.AWAITING_RETURN) {
+            store.onReturnFromAppSwitch?.let { callback ->
+                CoroutineScope(Dispatchers.Main).launch { callback() }
+            }
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
@@ -6,6 +6,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+/**
+ * Observes process-level lifecycle events via [ProcessLifecycleOwner] to detect when the
+ * merchant app returns to the foreground after a PayPal app switch.
+ *
+ * Registered once in [PendingPaymentStore.instance] initialization — not per [PayPalClient]
+ * instance — to prevent observer accumulation.
+ *
+ * State transitions:
+ * - [onStop]: if state is [SWITCH_LAUNCHED][PendingPaymentStore.State.SWITCH_LAUNCHED],
+ *   transitions to [AWAITING_RETURN][PendingPaymentStore.State.AWAITING_RETURN]
+ * - [onStart]: if state is [AWAITING_RETURN][PendingPaymentStore.State.AWAITING_RETURN],
+ *   invokes [PendingPaymentStore.onReturnFromAppSwitch] to attempt auto-link tokenization
+ *
+ * @param store the process-level [PendingPaymentStore] singleton
+ */
 internal class AppForegroundDetector(
     private val store: PendingPaymentStore
 ) : DefaultLifecycleObserver {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
@@ -1,0 +1,27 @@
+package com.braintreepayments.api.paypal
+
+import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
+import org.json.JSONObject
+
+internal class AutoLinkTokenizeUseCase(
+    private val internalPayPalClient: PayPalInternalClient
+) {
+
+    suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce {
+        val account = PayPalAccount(
+            clientMetadataId = session.clientMetadataId,
+            urlResponseData = buildAutoLinkResponseData(session),
+            intent = session.intent?.let { fromString(it) },
+            merchantAccountId = session.merchantAccountId,
+            paymentType = session.paymentType
+        )
+        return internalPayPalClient.tokenize(account)
+    }
+
+    private fun buildAutoLinkResponseData(session: PendingPaymentStore.PendingSession): JSONObject {
+        return JSONObject().apply {
+            put("billing_agreement_token", session.baToken)
+            put("response_type", "web")
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
@@ -3,10 +3,28 @@ package com.braintreepayments.api.paypal
 import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
 import org.json.JSONObject
 
+/**
+ * Tokenizes a billing agreement directly with BTGW using a stored BA token,
+ * bypassing the normal URL-return flow.
+ *
+ * In the auto-link scenario, the SDK does not have a return URL (the App Link failed).
+ * Instead, the BA token is sent as a standalone `billing_agreement_token` field in the
+ * `paypal_account` payload — the same field the Web SDK uses.
+ *
+ * @param internalPayPalClient used to call [PayPalInternalClient.tokenize]
+ */
 internal class AutoLinkTokenizeUseCase(
     private val internalPayPalClient: PayPalInternalClient
 ) {
 
+    /**
+     * Builds a [PayPalAccount] from the stored [PendingPaymentStore.PendingSession]
+     * and tokenizes it via BTGW.
+     *
+     * @param session the captured session data from the original app switch
+     * @return a [PayPalAccountNonce] on successful tokenization
+     * @throws Exception on BTGW errors (e.g. 422 BILLING_AGREEMENT_NOT_APPROVED)
+     */
     suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce {
         val account = PayPalAccount(
             clientMetadataId = session.clientMetadataId,

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -24,14 +24,20 @@ internal object PayPalAnalytics {
     const val APP_SWITCH_FAILED = "paypal:tokenize:app-switch:failed"
     const val APP_SWITCH_CANCELED = "paypal:tokenize:app-switch:canceled"
 
-    // Auto-Link events
+    // Auto-Link events — tokenization via stored BA token when App Link return fails
     const val AUTO_LINK_TOKENIZE_STARTED = "paypal:tokenize:auto-link:started"
     const val AUTO_LINK_TOKENIZE_SUCCEEDED = "paypal:tokenize:auto-link:succeeded"
     const val AUTO_LINK_TOKENIZE_FAILED = "paypal:tokenize:auto-link:failed"
     const val AUTO_LINK_EXPIRED = "paypal:tokenize:auto-link:expired"
+
+    // Auto-Link Path 1 — foreground return detected by ProcessLifecycleOwner
     const val AUTO_LINK_HANDLE_RETURN_SUCCEEDED = "paypal:tokenize:auto-link:handle-return:succeeded"
+
+    // Auto-Link Path 2 — user re-clicks PayPal before normal return completes
     const val AUTO_LINK_PATH2_STARTED = "paypal:tokenize:auto-link:path2:started"
     const val AUTO_LINK_PATH2_SUCCEEDED = "paypal:tokenize:auto-link:path2:succeeded"
     const val AUTO_LINK_PATH2_FAILED = "paypal:tokenize:auto-link:path2:failed"
+
+    // Auto-Link launch — pending request string stored for later handleReturnToApp
     const val AUTO_LINK_LAUNCH_STORED = "paypal:tokenize:auto-link:launch:stored"
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -23,4 +23,15 @@ internal object PayPalAnalytics {
     const val APP_SWITCH_SUCCEEDED = "paypal:tokenize:app-switch:succeeded"
     const val APP_SWITCH_FAILED = "paypal:tokenize:app-switch:failed"
     const val APP_SWITCH_CANCELED = "paypal:tokenize:app-switch:canceled"
+
+    // Auto-Link events
+    const val AUTO_LINK_TOKENIZE_STARTED = "paypal:tokenize:auto-link:started"
+    const val AUTO_LINK_TOKENIZE_SUCCEEDED = "paypal:tokenize:auto-link:succeeded"
+    const val AUTO_LINK_TOKENIZE_FAILED = "paypal:tokenize:auto-link:failed"
+    const val AUTO_LINK_EXPIRED = "paypal:tokenize:auto-link:expired"
+    const val AUTO_LINK_HANDLE_RETURN_SUCCEEDED = "paypal:tokenize:auto-link:handle-return:succeeded"
+    const val AUTO_LINK_PATH2_STARTED = "paypal:tokenize:auto-link:path2:started"
+    const val AUTO_LINK_PATH2_SUCCEEDED = "paypal:tokenize:auto-link:path2:succeeded"
+    const val AUTO_LINK_PATH2_FAILED = "paypal:tokenize:auto-link:path2:failed"
+    const val AUTO_LINK_LAUNCH_STORED = "paypal:tokenize:auto-link:launch:stored"
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -15,8 +15,10 @@ import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.UserCanceledException
 import com.braintreepayments.api.core.usecase.GetAppLinksCompatibleBrowserUseCase
+import com.braintreepayments.api.core.usecase.GetAppSwitchUseCase
 import com.braintreepayments.api.core.usecase.GetDefaultAppUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase.ReturnLinkTypeResult
@@ -50,6 +52,11 @@ class PayPalClient internal constructor(
     ),
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val appSwitchRepository: AppSwitchRepository = AppSwitchRepository.instance,
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(appSwitchRepository),
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance,
+    private val autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase =
+        AutoLinkTokenizeUseCase(internalPayPalClient),
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val coroutineScope: CoroutineScope = CoroutineScope(dispatcher)
 ) {
@@ -93,6 +100,7 @@ class PayPalClient internal constructor(
             ReturnLinkTypeResult.APP_LINK -> LinkType.APP_LINK
             ReturnLinkTypeResult.DEEP_LINK -> LinkType.DEEP_LINK
         }
+        pendingPaymentStore.onReturnFromAppSwitch = ::attemptAutoLinkTokenization
     }
 
     /**
@@ -114,7 +122,66 @@ class PayPalClient internal constructor(
         payPalRequest: PayPalRequest,
         callback: PayPalPaymentAuthCallback
     ) {
+        createPaymentAuthRequest(context, payPalRequest, callback, tokenizeCallback = null)
+    }
+
+    /**
+     * Starts the PayPal payment flow with auto-link Path 2 support.
+     *
+     * If a previous app switch session exists (BA approved but App Link return failed) and the
+     * user taps PayPal again, the SDK will attempt to tokenize the stored BA token directly.
+     * On success, the nonce is delivered via [tokenizeCallback] — skipping launch,
+     * handleReturnToApp, and tokenize entirely.
+     *
+     * If auto-link fails or no pending session exists, the normal flow proceeds via [callback].
+     *
+     * @param context          Android Context
+     * @param payPalRequest    a [PayPalRequest] used to customize the request
+     * @param callback         [PayPalPaymentAuthCallback] for the normal flow
+     * @param tokenizeCallback optional [PayPalTokenizeCallback] for auto-link Path 2 delivery
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    fun createPaymentAuthRequest(
+        context: Context,
+        payPalRequest: PayPalRequest,
+        callback: PayPalPaymentAuthCallback,
+        tokenizeCallback: PayPalTokenizeCallback?
+    ) {
         coroutineScope.launch {
+            if (tokenizeCallback != null) {
+                val session = pendingPaymentStore.pendingSession
+                if (session != null && !session.isExpired() && getAppSwitchUseCase()) {
+                    val analyticsParams = AnalyticsEventParams(
+                        contextId = session.baToken,
+                        isVaultRequest = true,
+                        shopperSessionId = payPalRequest.shopperSessionId
+                    )
+                    braintreeClient.sendAnalyticsEvent(
+                        PayPalAnalytics.AUTO_LINK_PATH2_STARTED, analyticsParams
+                    )
+
+                    try {
+                        attemptAutoLinkTokenization()
+                        val nonce = pendingPaymentStore.autoLinkNonce
+                        if (nonce != null) {
+                            pendingPaymentStore.clear()
+                            braintreeClient.sendAnalyticsEvent(
+                                PayPalAnalytics.AUTO_LINK_PATH2_SUCCEEDED, analyticsParams
+                            )
+                            tokenizeCallback.onPayPalResult(PayPalResult.Success(nonce))
+                            return@launch
+                        }
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        pendingPaymentStore.clear()
+                        braintreeClient.sendAnalyticsEvent(
+                            PayPalAnalytics.AUTO_LINK_PATH2_FAILED,
+                            analyticsParams.copy(errorDescription = e.message)
+                        )
+                    }
+                }
+            }
+
             val result = createPaymentAuthRequest(context, payPalRequest)
             callback.onPayPalPaymentAuthRequest(result)
         }
@@ -190,6 +257,7 @@ class PayPalClient internal constructor(
 
             try {
                 payPalResponse.browserSwitchOptions = buildBrowserSwitchOptions(payPalResponse)
+                storePendingSessionIfEligible(payPalResponse)
                 PayPalPaymentAuthRequest.ReadyToLaunch(payPalResponse)
             } catch (exception: Exception) {
                 when (exception) {
@@ -293,7 +361,20 @@ class PayPalClient internal constructor(
     suspend fun tokenize(
         paymentAuthResult: PayPalPaymentAuthResult.Success
     ): PayPalResult {
+        // Auto-link path: nonce already resolved — short-circuit
+        paymentAuthResult.autoLinkNonce?.let { nonce ->
+            pendingPaymentStore.clear()
+            sendTokenizeSuccessEvent(
+                AnalyticsEventParams(
+                    isVaultRequest = true,
+                    shopperSessionId = shopperSessionId
+                )
+            )
+            return PayPalResult.Success(nonce)
+        }
+
         val browserSwitchResult = paymentAuthResult.browserSwitchSuccess
+            ?: return PayPalResult.Failure(BraintreeException("Missing browser switch result"))
         val metadata = browserSwitchResult.requestMetadata
         val clientMetadataId = Json.optString(metadata, "client-metadata-id", null)
         val merchantAccountId = Json.optString(metadata, "merchant-account-id", null)
@@ -378,6 +459,94 @@ class PayPalClient internal constructor(
             return urlResponseData
         } else {
             throw PayPalBrowserSwitchException(BROWSER_SWITCH_EXCEPTION_MESSAGE)
+        }
+    }
+
+    /**
+     * Stores a [PendingPaymentStore.PendingSession] when the current request is an app switch
+     * vault flow. The stored session enables auto-link tokenization if the App Link return fails.
+     */
+    private fun storePendingSessionIfEligible(payPalResponse: PayPalPaymentAuthRequestParams) {
+        if (getAppSwitchUseCase() && payPalResponse.isVaultRequest) {
+            val baToken = payPalResponse.approvalUrl
+                ?.toUri()?.getQueryParameter("ba_token")
+            if (baToken != null) {
+                pendingPaymentStore.pendingSession = PendingPaymentStore.PendingSession(
+                    baToken = baToken,
+                    clientMetadataId = payPalResponse.clientMetadataId,
+                    merchantAccountId = payPalResponse.merchantAccountId,
+                    intent = payPalResponse.intent?.stringValue,
+                    paymentType = "billing-agreement"
+                )
+                pendingPaymentStore.state = PendingPaymentStore.State.SWITCH_LAUNCHED
+            }
+        }
+    }
+
+    /**
+     * Attempts to tokenize a stored BA token directly with BTGW via [AutoLinkTokenizeUseCase].
+     *
+     * Uses [PendingPaymentStore.getOrCreateDeferred] to ensure exactly one BTGW call:
+     * - If this caller is the initiator, it makes the call and completes the deferred
+     * - If another path already started the call, this caller awaits the same deferred
+     *
+     * On failure, resets state to [IDLE][PendingPaymentStore.State.IDLE] and clears the deferred
+     * so a subsequent Path 2 attempt can create a fresh one. The [pendingSession] is preserved
+     * to allow retry.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun attemptAutoLinkTokenization() {
+        val session = pendingPaymentStore.pendingSession ?: return
+        if (session.isExpired()) {
+            pendingPaymentStore.clear()
+            braintreeClient.sendAnalyticsEvent(
+                PayPalAnalytics.AUTO_LINK_EXPIRED,
+                AnalyticsEventParams(
+                    contextId = session.baToken,
+                    isVaultRequest = true,
+                    shopperSessionId = shopperSessionId
+                )
+            )
+            return
+        }
+
+        val (deferred, isInitiator) = pendingPaymentStore.getOrCreateDeferred()
+
+        if (isInitiator) {
+            val analyticsParams = AnalyticsEventParams(
+                contextId = session.baToken,
+                isVaultRequest = true,
+                shopperSessionId = shopperSessionId
+            )
+            braintreeClient.sendAnalyticsEvent(
+                PayPalAnalytics.AUTO_LINK_TOKENIZE_STARTED, analyticsParams
+            )
+
+            try {
+                val nonce = autoLinkTokenizeUseCase(session)
+                pendingPaymentStore.autoLinkNonce = nonce
+                deferred.complete(nonce)
+                braintreeClient.sendAnalyticsEvent(
+                    PayPalAnalytics.AUTO_LINK_TOKENIZE_SUCCEEDED, analyticsParams
+                )
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                deferred.completeExceptionally(e)
+                pendingPaymentStore.autoLinkNonce = null
+                pendingPaymentStore.state = PendingPaymentStore.State.IDLE
+                pendingPaymentStore.tokenizeDeferred = null
+                braintreeClient.sendAnalyticsEvent(
+                    PayPalAnalytics.AUTO_LINK_TOKENIZE_FAILED,
+                    analyticsParams.copy(errorDescription = e.message)
+                )
+            }
+        } else {
+            try {
+                val nonce = deferred.await()
+                pendingPaymentStore.autoLinkNonce = nonce
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+            }
         }
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -125,6 +125,16 @@ class PayPalLauncher internal constructor(
                     eventName = event,
                     analyticsEventParams = analyticsEventParams
                 )
+
+                // Store pending request string for auto-link handleReturnToApp path
+                val store = PendingPaymentStore.instance
+                if (store.pendingSession != null) {
+                    store.originalPendingRequestString = request.pendingRequest
+                    analyticsClient.sendEvent(
+                        PayPalAnalytics.AUTO_LINK_LAUNCH_STORED, analyticsEventParams
+                    )
+                }
+
                 PayPalPendingRequest.Started(request.pendingRequest)
             }
         }
@@ -162,10 +172,21 @@ class PayPalLauncher internal constructor(
 
         analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_STARTED, analyticsEventParams)
 
+        // Auto-link: check for resolved nonce before calling completeRequest
+        val store = PendingPaymentStore.instance
+        val autoNonce = store.autoLinkNonce
+        if (autoNonce != null) {
+            analyticsClient.sendEvent(
+                PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_SUCCEEDED, analyticsEventParams
+            )
+            return PayPalPaymentAuthResult.Success(autoNonce)
+        }
+
         return when (
             val browserSwitchResult = browserSwitchClient.completeRequest(intent, pendingRequest.pendingRequestString)
         ) {
             is BrowserSwitchFinalResult.Success -> {
+                store.clear()
                 analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_SUCCEEDED, analyticsEventParams)
                 PayPalPaymentAuthResult.Success(browserSwitchResult)
             }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -25,7 +25,8 @@ class PayPalLauncher internal constructor(
     private val resolvePayPalUseCase: ResolvePayPalUseCase =
         ResolvePayPalUseCase(MerchantRepository.instance),
     lazyAnalyticsClient: Lazy<AnalyticsClient>,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance
 ) {
     /**
      * Used to launch the PayPal flow in a web browser and deliver results to your Activity
@@ -127,9 +128,8 @@ class PayPalLauncher internal constructor(
                 )
 
                 // Store pending request string for auto-link handleReturnToApp path
-                val store = PendingPaymentStore.instance
-                if (store.pendingSession != null) {
-                    store.originalPendingRequestString = request.pendingRequest
+                if (pendingPaymentStore.pendingSession != null) {
+                    pendingPaymentStore.originalPendingRequestString = request.pendingRequest
                     analyticsClient.sendEvent(
                         PayPalAnalytics.AUTO_LINK_LAUNCH_STORED, analyticsEventParams
                     )
@@ -173,8 +173,7 @@ class PayPalLauncher internal constructor(
         analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_STARTED, analyticsEventParams)
 
         // Auto-link: check for resolved nonce before calling completeRequest
-        val store = PendingPaymentStore.instance
-        val autoNonce = store.autoLinkNonce
+        val autoNonce = pendingPaymentStore.autoLinkNonce
         if (autoNonce != null) {
             analyticsClient.sendEvent(
                 PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_SUCCEEDED, analyticsEventParams
@@ -186,7 +185,7 @@ class PayPalLauncher internal constructor(
             val browserSwitchResult = browserSwitchClient.completeRequest(intent, pendingRequest.pendingRequestString)
         ) {
             is BrowserSwitchFinalResult.Success -> {
-                store.clear()
+                pendingPaymentStore.clear()
                 analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_SUCCEEDED, analyticsEventParams)
                 PayPalPaymentAuthResult.Success(browserSwitchResult)
             }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
@@ -8,11 +8,26 @@ import com.braintreepayments.api.BrowserSwitchFinalResult
 sealed class PayPalPaymentAuthResult {
 
     /**
-     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow
+     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow.
+     *
+     * Two internal construction paths exist:
+     * - URL return: wraps a [BrowserSwitchFinalResult.Success] from the normal browser switch flow
+     * - Auto-link: carries a pre-resolved [PayPalAccountNonce] when the App Link return failed
+     *   and the SDK tokenized the BA token directly with BTGW
      */
-    class Success internal constructor(
-        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success
-    ) : PayPalPaymentAuthResult()
+    class Success private constructor(
+        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success?,
+        internal val autoLinkNonce: PayPalAccountNonce?
+    ) : PayPalPaymentAuthResult() {
+
+        /** URL return path — nonce will be resolved in [PayPalClient.tokenize]. */
+        internal constructor(browserSwitchSuccess: BrowserSwitchFinalResult.Success) :
+            this(browserSwitchSuccess, null)
+
+        /** Auto-link path — nonce already resolved via [AutoLinkTokenizeUseCase]. */
+        internal constructor(autoLinkNonce: PayPalAccountNonce) :
+            this(null, autoLinkNonce)
+    }
 
     /**
      * The browser switch failed.

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,0 +1,66 @@
+package com.braintreepayments.api.paypal
+
+import androidx.lifecycle.ProcessLifecycleOwner
+import kotlinx.coroutines.CompletableDeferred
+
+internal class PendingPaymentStore {
+
+    enum class State { IDLE, SWITCH_LAUNCHED, AWAITING_RETURN }
+
+    data class PendingSession(
+        val baToken: String,
+        val clientMetadataId: String?,
+        val merchantAccountId: String?,
+        val intent: String?,
+        val paymentType: String,
+        val timestampMs: Long = System.currentTimeMillis(),
+        val ttlMs: Long = TTL_MS
+    ) {
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
+    }
+
+    var state: State = State.IDLE
+    var pendingSession: PendingSession? = null
+    var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
+
+    @Volatile
+    var autoLinkNonce: PayPalAccountNonce? = null
+    var originalPendingRequestString: String? = null
+
+    var onReturnFromAppSwitch: (suspend () -> Unit)? = null
+
+    @Synchronized
+    fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
+        val existing = tokenizeDeferred
+        if (existing != null) return Pair(existing, false)
+        val new = CompletableDeferred<PayPalAccountNonce>()
+        tokenizeDeferred = new
+        return Pair(new, true)
+    }
+
+    fun clear() {
+        state = State.IDLE
+        pendingSession = null
+        tokenizeDeferred?.cancel()
+        tokenizeDeferred = null
+        autoLinkNonce = null
+        originalPendingRequestString = null
+    }
+
+    companion object {
+        internal const val TTL_MS = 30 * 60 * 1000L
+
+        val instance by lazy {
+            val store = PendingPaymentStore()
+            try {
+                ProcessLifecycleOwner.get().lifecycle.addObserver(
+                    AppForegroundDetector(store)
+                )
+            } catch (_: Exception) {
+                // ProcessLifecycleOwner not available — Path 1 silently disabled.
+                // Path 2 (re-click) still works independently.
+            }
+            store
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -3,10 +3,41 @@ package com.braintreepayments.api.paypal
 import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CompletableDeferred
 
+/**
+ * Process-level singleton that holds state for the auto-link on manual return flow.
+ *
+ * When a PayPal app switch completes but the App Link return fails, the user manually
+ * switches back to the merchant app. This store persists the billing agreement token and
+ * session metadata across that round trip so the SDK can tokenize directly with BTGW
+ * without a URL return.
+ *
+ * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * both Path 1 (foreground detection) and Path 2 (user re-click) race to tokenize.
+ *
+ * This class must outlive individual [PayPalClient] instances because the client is
+ * per-Fragment and may be GC'd during the app switch.
+ */
 internal class PendingPaymentStore {
 
+    /**
+     * State machine for tracking app switch lifecycle.
+     * - [IDLE]: no active app switch session
+     * - [SWITCH_LAUNCHED]: browser/app switch started, app still in foreground
+     * - [AWAITING_RETURN]: app went to background after launch, waiting for user to return
+     */
     enum class State { IDLE, SWITCH_LAUNCHED, AWAITING_RETURN }
 
+    /**
+     * Captured session data needed to tokenize a billing agreement without a URL return.
+     *
+     * @property baToken the billing agreement token from the PayPal approval URL
+     * @property clientMetadataId correlation ID for fraud detection
+     * @property merchantAccountId optional merchant account override
+     * @property intent the PayPal payment intent string value (e.g. "authorize", "sale")
+     * @property paymentType always "billing-agreement" for auto-link flows
+     * @property timestampMs creation time for TTL expiry checks
+     * @property ttlMs time-to-live in milliseconds (default 30 minutes)
+     */
     data class PendingSession(
         val baToken: String,
         val clientMetadataId: String?,
@@ -16,6 +47,7 @@ internal class PendingPaymentStore {
         val timestampMs: Long = System.currentTimeMillis(),
         val ttlMs: Long = TTL_MS
     ) {
+        /** Returns true if this session has exceeded its time-to-live. */
         fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
     }
 
@@ -23,12 +55,28 @@ internal class PendingPaymentStore {
     var pendingSession: PendingSession? = null
     var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
 
+    /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
     @Volatile
     var autoLinkNonce: PayPalAccountNonce? = null
+
+    /** Original pending request string from [PayPalLauncher.launch], preserved for handleReturnToApp. */
     var originalPendingRequestString: String? = null
 
+    /**
+     * Callback invoked by [AppForegroundDetector] when the app returns to foreground.
+     * Set by each [PayPalClient] in its init block — always points to the latest instance.
+     */
     var onReturnFromAppSwitch: (suspend () -> Unit)? = null
 
+    /**
+     * Returns an existing or newly created [CompletableDeferred] along with a flag
+     * indicating whether this caller is the initiator (created the deferred).
+     *
+     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * Subsequent callers receive the same deferred and should await it.
+     *
+     * @return pair of (deferred, isInitiator)
+     */
     @Synchronized
     fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
         val existing = tokenizeDeferred
@@ -38,6 +86,7 @@ internal class PendingPaymentStore {
         return Pair(new, true)
     }
 
+    /** Resets all state and cancels any in-flight deferred. */
     fun clear() {
         state = State.IDLE
         pendingSession = null
@@ -48,6 +97,7 @@ internal class PendingPaymentStore {
     }
 
     companion object {
+        /** Default session TTL: 30 minutes. */
         internal const val TTL_MS = 30 * 60 * 1000L
 
         val instance by lazy {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AppForegroundDetectorUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AppForegroundDetectorUnitTest.kt
@@ -1,0 +1,96 @@
+package com.braintreepayments.api.paypal
+
+import androidx.lifecycle.LifecycleOwner
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import android.os.Looper
+
+@RunWith(RobolectricTestRunner::class)
+class AppForegroundDetectorUnitTest {
+
+    private lateinit var store: PendingPaymentStore
+    private lateinit var sut: AppForegroundDetector
+    private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        store = PendingPaymentStore()
+        sut = AppForegroundDetector(store)
+    }
+
+    @Test
+    fun `onStop transitions SWITCH_LAUNCHED to AWAITING_RETURN`() {
+        store.state = PendingPaymentStore.State.SWITCH_LAUNCHED
+
+        sut.onStop(lifecycleOwner)
+
+        assertEquals(PendingPaymentStore.State.AWAITING_RETURN, store.state)
+    }
+
+    @Test
+    fun `onStop does not transition IDLE state`() {
+        store.state = PendingPaymentStore.State.IDLE
+
+        sut.onStop(lifecycleOwner)
+
+        assertEquals(PendingPaymentStore.State.IDLE, store.state)
+    }
+
+    @Test
+    fun `onStop does not transition AWAITING_RETURN state`() {
+        store.state = PendingPaymentStore.State.AWAITING_RETURN
+
+        sut.onStop(lifecycleOwner)
+
+        assertEquals(PendingPaymentStore.State.AWAITING_RETURN, store.state)
+    }
+
+    @Test
+    fun `onStart invokes callback when state is AWAITING_RETURN`() {
+        var callbackInvoked = false
+        store.state = PendingPaymentStore.State.AWAITING_RETURN
+        store.onReturnFromAppSwitch = { callbackInvoked = true }
+
+        sut.onStart(lifecycleOwner)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(true, callbackInvoked)
+    }
+
+    @Test
+    fun `onStart does not invoke callback when state is IDLE`() {
+        var callbackInvoked = false
+        store.state = PendingPaymentStore.State.IDLE
+        store.onReturnFromAppSwitch = { callbackInvoked = true }
+
+        sut.onStart(lifecycleOwner)
+
+        assertEquals(false, callbackInvoked)
+    }
+
+    @Test
+    fun `onStart does not invoke callback when state is SWITCH_LAUNCHED`() {
+        var callbackInvoked = false
+        store.state = PendingPaymentStore.State.SWITCH_LAUNCHED
+        store.onReturnFromAppSwitch = { callbackInvoked = true }
+
+        sut.onStart(lifecycleOwner)
+
+        assertEquals(false, callbackInvoked)
+    }
+
+    @Test
+    fun `onStart is no-op when callback is null`() {
+        store.state = PendingPaymentStore.State.AWAITING_RETURN
+        store.onReturnFromAppSwitch = null
+
+        sut.onStart(lifecycleOwner)
+
+        assertEquals(PendingPaymentStore.State.AWAITING_RETURN, store.state)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
@@ -1,0 +1,110 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AutoLinkTokenizeUseCaseUnitTest {
+
+    private val internalPayPalClient: PayPalInternalClient = mockk(relaxed = true)
+    private lateinit var sut: AutoLinkTokenizeUseCase
+
+    @Before
+    fun setup() {
+        sut = AutoLinkTokenizeUseCase(internalPayPalClient)
+    }
+
+    @Test
+    fun `invoke tokenizes with correct PayPalAccount fields`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TEST123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = "merchant-acct",
+            intent = "authorize",
+            paymentType = "billing-agreement"
+        )
+
+        val result = sut(session)
+
+        assertSame(expectedNonce, result)
+
+        val captured = accountSlot.captured
+        assertEquals("metadata-id", captured.clientMetadataId)
+        assertEquals("merchant-acct", captured.merchantAccountId)
+        assertEquals("billing-agreement", captured.paymentType)
+        assertEquals(PayPalPaymentIntent.AUTHORIZE, captured.intent)
+    }
+
+    @Test
+    fun `invoke builds urlResponseData with billing_agreement_token`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TOKEN-ABC",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        val urlResponseData = accountSlot.captured.urlResponseData
+        assertEquals("BA-TOKEN-ABC", urlResponseData.getString("billing_agreement_token"))
+        assertEquals("web", urlResponseData.getString("response_type"))
+    }
+
+    @Test
+    fun `invoke with null intent sets null on PayPalAccount`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        assertEquals(null, accountSlot.captured.intent)
+    }
+
+    @Test(expected = Exception::class)
+    fun `invoke propagates tokenization errors`() = runTest {
+        coEvery {
+            internalPayPalClient.tokenize(any())
+        } throws Exception("BTGW error")
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -935,11 +935,183 @@ class PayPalClientUnitTest {
         verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
     }
 
+    // region auto-link tests
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `tokenize short-circuits and delivers nonce when autoLinkNonce is set`() = runTest(testDispatcher) {
+        val expectedNonce = mockk<PayPalAccountNonce>(relaxed = true)
+        val store = PendingPaymentStore().apply { autoLinkNonce = expectedNonce }
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this, store)
+        sut.tokenize(PayPalPaymentAuthResult.Success(expectedNonce), payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        val slot = slot<PayPalResult>()
+        verify { payPalTokenizeCallback.onPayPalResult(capture(slot)) }
+        assertTrue(slot.captured is PayPalResult.Success)
+        assertEquals(expectedNonce, (slot.captured as PayPalResult.Success).nonce)
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `tokenize short-circuit clears pending store`() = runTest(testDispatcher) {
+        val expectedNonce = mockk<PayPalAccountNonce>(relaxed = true)
+        val store = PendingPaymentStore().apply {
+            autoLinkNonce = expectedNonce
+            state = PendingPaymentStore.State.AWAITING_RETURN
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = null,
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement"
+            )
+        }
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this, store)
+        sut.tokenize(PayPalPaymentAuthResult.Success(expectedNonce), payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        assertEquals(PendingPaymentStore.State.IDLE, store.state)
+        assertTrue(store.autoLinkNonce == null)
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `createPaymentAuthRequest with tokenizeCallback delivers nonce via Path 2 when session exists`() = runTest(testDispatcher) {
+        val expectedNonce = mockk<PayPalAccountNonce>(relaxed = true)
+        val store = PendingPaymentStore().apply {
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = "metadata",
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement"
+            )
+        }
+        val autoLinkTokenizeUseCase = mockk<AutoLinkTokenizeUseCase>()
+        coEvery {
+            autoLinkTokenizeUseCase.invoke(any<PendingPaymentStore.PendingSession>())
+        } returns expectedNonce
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .configurationSuccess(payPalEnabledConfig).build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+        val appSwitchRepository = com.braintreepayments.api.core.AppSwitchRepository().also {
+            it.isAppSwitchFlow = true
+        }
+
+        val sut = PayPalClient(
+            braintreeClient,
+            payPalInternalClient,
+            merchantRepository,
+            getDefaultAppUseCase,
+            getAppLinksCompatibleBrowserUseCase,
+            getReturnLinkTypeUseCase,
+            getReturnLinkUseCase,
+            analyticsParamRepository,
+            appSwitchRepository = appSwitchRepository,
+            pendingPaymentStore = store,
+            autoLinkTokenizeUseCase = autoLinkTokenizeUseCase,
+            dispatcher = testDispatcher,
+            coroutineScope = this
+        )
+
+        val payPalVaultRequest = PayPalVaultRequest(true)
+        sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback, payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        val slot = slot<PayPalResult>()
+        verify { payPalTokenizeCallback.onPayPalResult(capture(slot)) }
+        assertTrue(slot.captured is PayPalResult.Success)
+        assertEquals(expectedNonce, (slot.captured as PayPalResult.Success).nonce)
+        verify(exactly = 0) { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `createPaymentAuthRequest with tokenizeCallback falls through to normal flow when session expired`() = runTest(testDispatcher) {
+        val store = PendingPaymentStore().apply {
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = null,
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement",
+                timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1
+            )
+        }
+        val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+            PayPalVaultRequest(true), null,
+            "https://example.com/approval?ba_token=BA-456", "client-meta", null
+        )
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .configurationSuccess(payPalEnabledConfig).build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder()
+            .sendRequestSuccess(paymentAuthRequest).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this, store)
+        sut.createPaymentAuthRequest(activity, PayPalVaultRequest(true), paymentAuthCallback, payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+        verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `createPaymentAuthRequest without tokenizeCallback falls through to normal flow`() = runTest(testDispatcher) {
+        val store = PendingPaymentStore().apply {
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = null,
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement"
+            )
+        }
+        val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+            PayPalVaultRequest(true), null,
+            "https://example.com/approval?ba_token=BA-123", "client-meta", null
+        )
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .configurationSuccess(payPalEnabledConfig).build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder()
+            .sendRequestSuccess(paymentAuthRequest).build()
+
+        val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this, store)
+        sut.createPaymentAuthRequest(activity, PayPalVaultRequest(true), paymentAuthCallback)
+        advanceUntilIdle()
+
+        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+        verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    fun `init sets onReturnFromAppSwitch on store`() {
+        val store = mockk<PendingPaymentStore>(relaxed = true)
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        testPaypalClient(braintreeClient, payPalInternalClient, pendingPaymentStore = store)
+
+        verify { store.onReturnFromAppSwitch = any() }
+    }
+
+    // endregion
+
     private fun testPaypalClient(
         braintreeClient: BraintreeClient,
         payPalInternalClient: PayPalInternalClient,
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
-        scope: CoroutineScope = CoroutineScope(dispatcher)
+        scope: CoroutineScope = CoroutineScope(dispatcher),
+        pendingPaymentStore: PendingPaymentStore = PendingPaymentStore(),
+        autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase = AutoLinkTokenizeUseCase(payPalInternalClient)
     ): PayPalClient = PayPalClient(
         braintreeClient,
         payPalInternalClient,
@@ -949,7 +1121,9 @@ class PayPalClientUnitTest {
         getReturnLinkTypeUseCase,
         getReturnLinkUseCase,
         analyticsParamRepository,
-        dispatcher,
-        scope
+        pendingPaymentStore = pendingPaymentStore,
+        autoLinkTokenizeUseCase = autoLinkTokenizeUseCase,
+        dispatcher = dispatcher,
+        coroutineScope = scope
     )
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -564,4 +564,135 @@ class PayPalLauncherUnitTest {
 
         verify { browserSwitchClient.start(activity, options, false) }
     }
+
+    // region auto-link tests
+
+    @Test
+    fun `handleReturnToApp returns Success with autoLinkNonce when nonce is pre-resolved`() {
+        val store = PendingPaymentStore()
+        val expectedNonce = mockk<PayPalAccountNonce>(relaxed = true)
+        store.autoLinkNonce = expectedNonce
+
+        val sutWithStore = PayPalLauncher(
+            browserSwitchClient = browserSwitchClient,
+            getAppSwitchUseCase = getAppSwitchUseCase,
+            resolvePayPalUseCase = resolvePayPalUseCase,
+            lazyAnalyticsClient = lazy { analyticsClient },
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = store
+        )
+
+        val result = sutWithStore.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(result is PayPalPaymentAuthResult.Success)
+        assertEquals(expectedNonce, (result as PayPalPaymentAuthResult.Success).autoLinkNonce)
+        verify(exactly = 0) { browserSwitchClient.completeRequest(any(), any()) }
+    }
+
+    @Test
+    fun `handleReturnToApp sends AUTO_LINK_HANDLE_RETURN_SUCCEEDED analytics when nonce is pre-resolved`() {
+        val store = PendingPaymentStore()
+        store.autoLinkNonce = mockk(relaxed = true)
+
+        val sutWithStore = PayPalLauncher(
+            browserSwitchClient = browserSwitchClient,
+            getAppSwitchUseCase = getAppSwitchUseCase,
+            resolvePayPalUseCase = resolvePayPalUseCase,
+            lazyAnalyticsClient = lazy { analyticsClient },
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = store
+        )
+
+        sutWithStore.handleReturnToApp(PayPalPendingRequest.Started(pendingRequestString), intent)
+
+        verify {
+            analyticsClient.sendEvent(
+                PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_SUCCEEDED,
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `handleReturnToApp clears store on normal URL success`() {
+        val store = PendingPaymentStore().apply {
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = null,
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement"
+            )
+            state = PendingPaymentStore.State.AWAITING_RETURN
+        }
+        val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
+        every { browserSwitchClient.completeRequest(intent, pendingRequestString) } returns browserSwitchFinalResult
+
+        val sutWithStore = PayPalLauncher(
+            browserSwitchClient = browserSwitchClient,
+            getAppSwitchUseCase = getAppSwitchUseCase,
+            resolvePayPalUseCase = resolvePayPalUseCase,
+            lazyAnalyticsClient = lazy { analyticsClient },
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = store
+        )
+
+        sutWithStore.handleReturnToApp(PayPalPendingRequest.Started(pendingRequestString), intent)
+
+        assertEquals(PendingPaymentStore.State.IDLE, store.state)
+        assertTrue(store.pendingSession == null)
+    }
+
+    @Test
+    fun `launch stores originalPendingRequestString when pendingSession exists`() {
+        val store = PendingPaymentStore().apply {
+            pendingSession = PendingPaymentStore.PendingSession(
+                baToken = "BA-123",
+                clientMetadataId = null,
+                merchantAccountId = null,
+                intent = null,
+                paymentType = "billing-agreement"
+            )
+        }
+        val startedPendingRequest = BrowserSwitchStartResult.Started(pendingRequestString)
+        every { browserSwitchClient.start(activity, options, any()) } returns startedPendingRequest
+
+        val sutWithStore = PayPalLauncher(
+            browserSwitchClient = browserSwitchClient,
+            getAppSwitchUseCase = getAppSwitchUseCase,
+            resolvePayPalUseCase = resolvePayPalUseCase,
+            lazyAnalyticsClient = lazy { analyticsClient },
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = store
+        )
+
+        sutWithStore.launch(activity, PayPalPaymentAuthRequest.ReadyToLaunch(paymentAuthRequestParams))
+
+        assertEquals(pendingRequestString, store.originalPendingRequestString)
+    }
+
+    @Test
+    fun `launch does not store originalPendingRequestString when no pendingSession`() {
+        val store = PendingPaymentStore()
+        val startedPendingRequest = BrowserSwitchStartResult.Started(pendingRequestString)
+        every { browserSwitchClient.start(activity, options, any()) } returns startedPendingRequest
+
+        val sutWithStore = PayPalLauncher(
+            browserSwitchClient = browserSwitchClient,
+            getAppSwitchUseCase = getAppSwitchUseCase,
+            resolvePayPalUseCase = resolvePayPalUseCase,
+            lazyAnalyticsClient = lazy { analyticsClient },
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = store
+        )
+
+        sutWithStore.launch(activity, PayPalPaymentAuthRequest.ReadyToLaunch(paymentAuthRequestParams))
+
+        assertTrue(store.originalPendingRequestString == null)
+    }
+
+    // endregion
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -1,0 +1,125 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PendingPaymentStoreUnitTest {
+
+    private lateinit var sut: PendingPaymentStore
+
+    @Before
+    fun setup() {
+        sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial state is IDLE`() {
+        assertEquals(PendingPaymentStore.State.IDLE, sut.state)
+    }
+
+    @Test
+    fun `initial pendingSession is null`() {
+        assertNull(sut.pendingSession)
+    }
+
+    @Test
+    fun `initial autoLinkNonce is null`() {
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `PendingSession isExpired returns false when within TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis(),
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertFalse(session.isExpired())
+    }
+
+    @Test
+    fun `PendingSession isExpired returns true when past TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertTrue(session.isExpired())
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates new deferred on first call`() {
+        val (deferred, isInitiator) = sut.getOrCreateDeferred()
+        assertTrue(isInitiator)
+        assertSame(deferred, sut.tokenizeDeferred)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns existing deferred on second call`() {
+        val (first, isFirstInitiator) = sut.getOrCreateDeferred()
+        val (second, isSecondInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isFirstInitiator)
+        assertFalse(isSecondInitiator)
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        sut.state = PendingPaymentStore.State.AWAITING_RETURN
+        sut.pendingSession = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+        sut.tokenizeDeferred = CompletableDeferred()
+        sut.autoLinkNonce = nonce
+        sut.originalPendingRequestString = "pending-request"
+
+        sut.clear()
+
+        assertEquals(PendingPaymentStore.State.IDLE, sut.state)
+        assertNull(sut.pendingSession)
+        assertNull(sut.tokenizeDeferred)
+        assertNull(sut.autoLinkNonce)
+        assertNull(sut.originalPendingRequestString)
+    }
+
+    @Test
+    fun `clear cancels active deferred`() {
+        val deferred = CompletableDeferred<PayPalAccountNonce>()
+        sut.tokenizeDeferred = deferred
+
+        sut.clear()
+
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates fresh deferred after clear`() {
+        val (first, _) = sut.getOrCreateDeferred()
+        sut.clear()
+        val (second, isInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isInitiator)
+        assertFalse(first === second)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ androidx-annotation = { group = "androidx.annotation", name = "annotation", vers
 androidx-autofill = { group = "androidx.autofill", name = "autofill", version.ref = "androidxAutofill" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidxLifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-navigation-safe-args-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigationSafeArgsGradlePlugin" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "androidxWork" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidxWork" }


### PR DESCRIPTION
## Summary

Implements auto-link on manual return for PayPal app switch flows (DTINAPPXO-4750).

When a user completes BA approval in the PayPal app but the App Link return fails, they manually switch back to the merchant app. Previously the SDK had no way to deliver the nonce in this scenario. This PR adds auto-link — the SDK detects the foreground return, tokenizes the BA token directly with BTGW, and delivers the nonce through the existing callback flow.

**LLD:** [LLD - Android - Auto Link on Manual Return](https://paypal.atlassian.net/wiki/spaces/Checkout/pages/2906858999)

### What changed

**New files:**
- `PendingPaymentStore` — process-level singleton holding state machine (`IDLE → SWITCH_LAUNCHED → AWAITING_RETURN`), `PendingSession` with BA token + metadata, and a `CompletableDeferred` ensuring exactly one BTGW call across racing paths
- `AppForegroundDetector` — `DefaultLifecycleObserver` registered once via `ProcessLifecycleOwner`; triggers auto-link tokenization when the app returns to foreground after an app switch
- `AutoLinkTokenizeUseCase` — tokenizes stored BA token directly with BTGW via `billing_agreement_token` field (same path as Web SDK, no URL construction needed)

**Modified files:**
- `PayPalPaymentAuthResult.Success` — dual internal constructors for URL-return and auto-link paths
- `PayPalClient` — stores `PendingSession` after `ReadyToLaunch` is built; `attemptAutoLinkTokenization()` with shared `CompletableDeferred`; overloaded `createPaymentAuthRequest()` with optional `PayPalTokenizeCallback` for Path 2; `tokenize()` short-circuit when nonce is pre-resolved
- `PayPalLauncher` — stores `originalPendingRequestString` on launch; checks `autoLinkNonce` before `completeRequest()` in `handleReturnToApp()`; clears store on normal URL success
- `PayPalAnalytics` — 9 new auto-link event constants
- `Demo/PayPalFragment` — wires Path 2 `PayPalTokenizeCallback` for billing agreement flows

### Two delivery paths

**Path 1 — foreground return:** `ProcessLifecycleOwner.onStart()` detects the app returning → `attemptAutoLinkTokenization()` → nonce stored → `handleReturnToApp()` delivers it, bypassing `completeRequest()`

**Path 2 — user re-clicks PayPal:** `createPaymentAuthRequest()` detects a pending unexpired session + `tokenizeCallback` provided → awaits the shared deferred (or becomes initiator) → delivers nonce directly via callback, skipping launch/handleReturnToApp/tokenize entirely

**Deferred coordination:** `getOrCreateDeferred()` is `@Synchronized` — first caller makes the BTGW call, second caller awaits the same result. Zero duplicate BTGW calls regardless of race.

### Merchant integration change

Existing 3-param `createPaymentAuthRequest()` is unchanged — backward compatible, Path 1 works without any merchant code change.

For Path 2, merchants pass their existing tokenize callback as the new 4th param:

```kotlin
// Before (unchanged, Path 1 still works)
payPalClient.createPaymentAuthRequest(context, request, authCallback)

// After (enables Path 2 as well)
payPalClient.createPaymentAuthRequest(context, request, authCallback, tokenizeCallback)
```

### New dependencies

- `androidx.lifecycle:lifecycle-process:2.6.2` — for `ProcessLifecycleOwner` / `DefaultLifecycleObserver` (version already in catalog)

## Test plan

- [ ] Run unit tests: `./gradlew :PayPal:testRelease` (182 tests, 0 failures)
- [ ] Run lint: `./ci lint`
- [ ] Install Demo app on device with PayPal app installed: `./gradlew :Demo:installDebug`
- [ ] In Demo Settings, enable **"Enable PayPal App Switch"**
- [ ] **Path 1:** Tap "Billing Agreement" → approve in PayPal → switch back via task switcher (not return button) → verify nonce delivered
- [ ] **Path 2:** After failed return, tap "Billing Agreement" again → verify nonce delivered via tokenize callback, no second app switch
- [ ] **Normal flow regression:** Approve in PayPal → let App Link return normally → verify nonce delivered via existing URL path
- [ ] **Cancel regression:** Open PayPal → press Back → verify `NoResult` returned, no crash

## Open questions (from LLD)

- [ ] BTGW team to confirm `billing_agreement_token` field is read the same way as the Web SDK path (LLD Q1/Q3)
- [ ] Confirm `lifecycle-process` acceptable as transitive dependency (LLD Q4)
- [ ] Validate `ProcessLifecycleOwner` behaviour in RN/Flutter integrations (LLD Q6)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
