### PR TITLE
feature(PayPal): auto-link on manual return via handleReturnToApp

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -28,6 +28,7 @@ import com.braintreepayments.api.paypal.PayPalPaymentAuthResult;
 import com.braintreepayments.api.paypal.PayPalPendingRequest;
 import com.braintreepayments.api.paypal.PayPalRequest;
 import com.braintreepayments.api.paypal.PayPalResult;
+import com.braintreepayments.api.paypal.PayPalTokenizeCallback;
 import com.google.android.material.textfield.TextInputEditText;
 
 public class PayPalFragment extends BaseFragment {
@@ -228,11 +229,24 @@ public class PayPalFragment extends BaseFragment {
                     isAmountBreakdownEnabled
             );
         }
+        // For billing agreement flows, pass a tokenizeCallback to enable auto-link re-click:
+        // if the user re-taps PayPal after a failed App Link return, the SDK will deliver
+        // the nonce directly here instead of restarting the full flow.
+        PayPalTokenizeCallback tokenizeCallback = isBillingAgreement
+            ? payPalResult -> {
+                if (payPalResult instanceof PayPalResult.Failure) {
+                    handleError(((PayPalResult.Failure) payPalResult).getError());
+                } else if (payPalResult instanceof PayPalResult.Success) {
+                    handlePayPalResult(((PayPalResult.Success) payPalResult).getNonce());
+                }
+            }
+            : null;
+
         payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,
             (paymentAuthRequest) -> {
                 if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.Failure) {
                     handleError(((PayPalPaymentAuthRequest.Failure) paymentAuthRequest).getError());
-                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch){
+                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch) {
                     PayPalPendingRequest request = payPalLauncher.launch(requireActivity(),
                             ((PayPalPaymentAuthRequest.ReadyToLaunch) paymentAuthRequest));
                     if (request instanceof PayPalPendingRequest.Started) {
@@ -241,7 +255,8 @@ public class PayPalFragment extends BaseFragment {
                         handleError(((PayPalPendingRequest.Failure) request).getError());
                     }
                 }
-            });
+            },
+            tokenizeCallback);
     }
 
     private void completePayPalFlow(PayPalPaymentAuthResult.Success paymentAuthResult) {

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
@@ -1,0 +1,45 @@
+package com.braintreepayments.api.paypal
+
+import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
+import org.json.JSONObject
+
+/**
+ * Tokenizes a billing agreement directly with BTGW using a stored BA token,
+ * bypassing the normal URL-return flow.
+ *
+ * In the auto-link scenario, the SDK does not have a return URL (the App Link failed).
+ * Instead, the BA token is sent as a standalone `billing_agreement_token` field in the
+ * `paypal_account` payload — the same field the Web SDK uses.
+ *
+ * @param internalPayPalClient used to call [PayPalInternalClient.tokenize]
+ */
+internal class AutoLinkTokenizeUseCase(
+    private val internalPayPalClient: PayPalInternalClient
+) {
+
+    /**
+     * Builds a [PayPalAccount] from the stored [PendingPaymentStore.PendingSession]
+     * and tokenizes it via BTGW.
+     *
+     * @param session the captured session data from the original app switch
+     * @return a [PayPalAccountNonce] on successful tokenization
+     * @throws Exception on BTGW errors (e.g. 422 BILLING_AGREEMENT_NOT_APPROVED)
+     */
+    suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce {
+        val account = PayPalAccount(
+            clientMetadataId = session.clientMetadataId,
+            urlResponseData = buildAutoLinkResponseData(session),
+            intent = session.intent?.let { fromString(it) },
+            merchantAccountId = session.merchantAccountId,
+            paymentType = session.paymentType
+        )
+        return internalPayPalClient.tokenize(account)
+    }
+
+    private fun buildAutoLinkResponseData(session: PendingPaymentStore.PendingSession): JSONObject {
+        return JSONObject().apply {
+            put("billing_agreement_token", session.baToken)
+            put("response_type", "web")
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -23,4 +23,18 @@ internal object PayPalAnalytics {
     const val APP_SWITCH_SUCCEEDED = "paypal:tokenize:app-switch:succeeded"
     const val APP_SWITCH_FAILED = "paypal:tokenize:app-switch:failed"
     const val APP_SWITCH_CANCELED = "paypal:tokenize:app-switch:canceled"
+
+    // Auto-Link events — tokenization via stored BA token when App Link return fails
+    const val AUTO_LINK_TOKENIZE_STARTED = "paypal:tokenize:auto-link:started"
+    const val AUTO_LINK_TOKENIZE_SUCCEEDED = "paypal:tokenize:auto-link:succeeded"
+    const val AUTO_LINK_TOKENIZE_FAILED = "paypal:tokenize:auto-link:failed"
+    const val AUTO_LINK_EXPIRED = "paypal:tokenize:auto-link:expired"
+
+    // Auto-Link via handle-return — completeRequest returned NoResult but a session is pending
+    const val AUTO_LINK_HANDLE_RETURN_PENDING = "paypal:tokenize:auto-link:handle-return:pending"
+
+    // Auto-Link via re-click — user re-taps PayPal before normal return completes
+    const val AUTO_LINK_RECLICK_STARTED = "paypal:tokenize:auto-link:reclick:started"
+    const val AUTO_LINK_RECLICK_SUCCEEDED = "paypal:tokenize:auto-link:reclick:succeeded"
+    const val AUTO_LINK_RECLICK_FAILED = "paypal:tokenize:auto-link:reclick:failed"
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -15,8 +15,10 @@ import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.UserCanceledException
 import com.braintreepayments.api.core.usecase.GetAppLinksCompatibleBrowserUseCase
+import com.braintreepayments.api.core.usecase.GetAppSwitchUseCase
 import com.braintreepayments.api.core.usecase.GetDefaultAppUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase.ReturnLinkTypeResult
@@ -50,6 +52,11 @@ class PayPalClient internal constructor(
     ),
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val appSwitchRepository: AppSwitchRepository = AppSwitchRepository.instance,
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(appSwitchRepository),
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance,
+    private val autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase =
+        AutoLinkTokenizeUseCase(internalPayPalClient),
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val coroutineScope: CoroutineScope = CoroutineScope(dispatcher)
 ) {
@@ -114,9 +121,81 @@ class PayPalClient internal constructor(
         payPalRequest: PayPalRequest,
         callback: PayPalPaymentAuthCallback
     ) {
+        createPaymentAuthRequest(context, payPalRequest, callback, tokenizeCallback = null)
+    }
+
+    /**
+     * Starts the PayPal payment flow with auto-link re-click support.
+     *
+     * If a previous app switch session exists (BA approved but App Link return failed) and the
+     * user taps PayPal again, the SDK will attempt to tokenize the stored BA token directly.
+     * On success, the nonce is delivered via [tokenizeCallback] — skipping launch,
+     * handleReturnToApp, and tokenize entirely.
+     *
+     * If auto-link fails or no pending session exists, the normal flow proceeds via [callback].
+     *
+     * @param context          Android Context
+     * @param payPalRequest    a [PayPalRequest] used to customize the request
+     * @param callback         [PayPalPaymentAuthCallback] for the normal flow
+     * @param tokenizeCallback optional [PayPalTokenizeCallback] for auto-link re-click delivery
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    fun createPaymentAuthRequest(
+        context: Context,
+        payPalRequest: PayPalRequest,
+        callback: PayPalPaymentAuthCallback,
+        tokenizeCallback: PayPalTokenizeCallback?
+    ) {
         coroutineScope.launch {
+            if (tokenizeCallback != null && tryAutoLinkReclick(payPalRequest, tokenizeCallback)) {
+                return@launch
+            }
             val result = createPaymentAuthRequest(context, payPalRequest)
             callback.onPayPalPaymentAuthRequest(result)
+        }
+    }
+
+    /**
+     * Attempts auto-link tokenization when the user re-taps PayPal after a failed App Link return.
+     *
+     * @return true if a nonce was delivered via [tokenizeCallback] and the normal flow should be
+     * skipped; false if there was no eligible pending session or auto-link failed (fall through to
+     * the normal flow).
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun tryAutoLinkReclick(
+        payPalRequest: PayPalRequest,
+        tokenizeCallback: PayPalTokenizeCallback
+    ): Boolean {
+        val session = pendingPaymentStore.pendingSession ?: return false
+        if (session.isExpired() || !getAppSwitchUseCase()) return false
+
+        val analyticsParams = AnalyticsEventParams(
+            contextId = session.baToken,
+            isVaultRequest = true,
+            shopperSessionId = payPalRequest.shopperSessionId
+        )
+        braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_RECLICK_STARTED, analyticsParams)
+
+        return try {
+            val nonce = attemptAutoLinkTokenization()
+            if (nonce != null) {
+                pendingPaymentStore.clear()
+                braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_RECLICK_SUCCEEDED, analyticsParams)
+                tokenizeCallback.onPayPalResult(PayPalResult.Success(nonce))
+                true
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            pendingPaymentStore.clear()
+            braintreeClient.sendAnalyticsEvent(
+                PayPalAnalytics.AUTO_LINK_RECLICK_FAILED,
+                analyticsParams.copy(errorDescription = e.message)
+            )
+            false
         }
     }
 
@@ -190,6 +269,7 @@ class PayPalClient internal constructor(
 
             try {
                 payPalResponse.browserSwitchOptions = buildBrowserSwitchOptions(payPalResponse)
+                storePendingSessionIfEligible(payPalResponse)
                 PayPalPaymentAuthRequest.ReadyToLaunch(payPalResponse)
             } catch (exception: Exception) {
                 when (exception) {
@@ -293,7 +373,13 @@ class PayPalClient internal constructor(
     suspend fun tokenize(
         paymentAuthResult: PayPalPaymentAuthResult.Success
     ): PayPalResult {
+        // Auto-link path: no URL return — tokenize the stored BA token directly with BTGW.
+        if (paymentAuthResult.autoLinkPending) {
+            return tokenizeAutoLink()
+        }
+
         val browserSwitchResult = paymentAuthResult.browserSwitchSuccess
+            ?: return PayPalResult.Failure(BraintreeException("Missing browser switch result"))
         val metadata = browserSwitchResult.requestMetadata
         val clientMetadataId = Json.optString(metadata, "client-metadata-id", null)
         val merchantAccountId = Json.optString(metadata, "merchant-account-id", null)
@@ -311,7 +397,7 @@ class PayPalClient internal constructor(
             contextId = contextId,
             isVaultRequest = isVaultRequest,
             shopperSessionId = shopperSessionId,
-            appSwitchUrl = paymentAuthResult.browserSwitchSuccess.returnUrl.toString()
+            appSwitchUrl = browserSwitchResult.returnUrl.toString()
         )
 
         return try {
@@ -381,6 +467,104 @@ class PayPalClient internal constructor(
         }
     }
 
+    /**
+     * Stores a [PendingPaymentStore.PendingSession] when the current request is an app switch
+     * vault flow. The stored session enables auto-link tokenization if the App Link return fails.
+     */
+    private fun storePendingSessionIfEligible(payPalResponse: PayPalPaymentAuthRequestParams) {
+        if (getAppSwitchUseCase() && payPalResponse.isVaultRequest) {
+            val baToken = payPalResponse.approvalUrl?.toUri()?.getQueryParameter("ba_token")
+            if (baToken != null) {
+                pendingPaymentStore.pendingSession = PendingPaymentStore.PendingSession(
+                    baToken = baToken,
+                    clientMetadataId = payPalResponse.clientMetadataId,
+                    merchantAccountId = payPalResponse.merchantAccountId,
+                    intent = payPalResponse.intent?.stringValue,
+                    paymentType = "billing-agreement"
+                )
+            }
+        }
+    }
+
+    /**
+     * Tokenizes a pending billing agreement session directly with BTGW (auto-link).
+     * Invoked from [tokenize] when [PayPalPaymentAuthResult.Success.autoLinkPending] is true.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun tokenizeAutoLink(): PayPalResult {
+        val analyticsEventParams = AnalyticsEventParams(
+            isVaultRequest = true,
+            shopperSessionId = shopperSessionId
+        )
+        return try {
+            val nonce = attemptAutoLinkTokenization()
+            if (nonce != null) {
+                pendingPaymentStore.clear()
+                sendTokenizeSuccessEvent(analyticsEventParams)
+                PayPalResult.Success(nonce)
+            } else {
+                pendingPaymentStore.clear()
+                PayPalResult.Failure(BraintreeException(AUTO_LINK_EXPIRED_MESSAGE))
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            pendingPaymentStore.clear()
+            sendTokenizeFailureEvent(PayPalResult.Failure(e), analyticsEventParams)
+            PayPalResult.Failure(e)
+        }
+    }
+
+    /**
+     * Attempts to tokenize a stored BA token directly with BTGW via [AutoLinkTokenizeUseCase].
+     *
+     * Uses [PendingPaymentStore.getOrCreateDeferred] to ensure exactly one BTGW call:
+     * - If this caller is the initiator, it makes the call and completes the deferred.
+     * - If another entry point already started the call, this caller awaits the same deferred.
+     *
+     * @return the resolved [PayPalAccountNonce], or null if the session is missing or expired.
+     * @throws Exception if the BTGW tokenization call fails.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun attemptAutoLinkTokenization(): PayPalAccountNonce? {
+        val session = pendingPaymentStore.pendingSession ?: return null
+        val analyticsParams = AnalyticsEventParams(
+            contextId = session.baToken,
+            isVaultRequest = true,
+            shopperSessionId = shopperSessionId
+        )
+        if (session.isExpired()) {
+            pendingPaymentStore.clear()
+            braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_EXPIRED, analyticsParams)
+            return null
+        }
+
+        val (deferred, isInitiator) = pendingPaymentStore.getOrCreateDeferred()
+        return if (isInitiator) {
+            braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_TOKENIZE_STARTED, analyticsParams)
+            try {
+                val nonce = autoLinkTokenizeUseCase(session)
+                pendingPaymentStore.autoLinkNonce = nonce
+                deferred.complete(nonce)
+                braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_TOKENIZE_SUCCEEDED, analyticsParams)
+                nonce
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                deferred.completeExceptionally(e)
+                pendingPaymentStore.autoLinkNonce = null
+                pendingPaymentStore.tokenizeDeferred = null
+                braintreeClient.sendAnalyticsEvent(
+                    PayPalAnalytics.AUTO_LINK_TOKENIZE_FAILED,
+                    analyticsParams.copy(errorDescription = e.message)
+                )
+                throw e
+            }
+        } else {
+            val nonce = deferred.await()
+            pendingPaymentStore.autoLinkNonce = nonce
+            nonce
+        }
+    }
+
     private fun sendCreatePaymentAuthFailureEvent(
         failure: PayPalPaymentAuthRequest.Failure,
         analyticsEventParams: AnalyticsEventParams
@@ -428,5 +612,8 @@ class PayPalClient internal constructor(
             "for more information."
 
         internal const val BROWSER_SWITCH_EXCEPTION_MESSAGE = "The response contained inconsistent data."
+
+        internal const val AUTO_LINK_EXPIRED_MESSAGE =
+            "The billing agreement session has expired. Please restart the PayPal flow."
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -25,7 +25,8 @@ class PayPalLauncher internal constructor(
     private val resolvePayPalUseCase: ResolvePayPalUseCase =
         ResolvePayPalUseCase(MerchantRepository.instance),
     lazyAnalyticsClient: Lazy<AnalyticsClient>,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance
 ) {
     /**
      * Used to launch the PayPal flow in a web browser and deliver results to your Activity
@@ -166,6 +167,8 @@ class PayPalLauncher internal constructor(
             val browserSwitchResult = browserSwitchClient.completeRequest(intent, pendingRequest.pendingRequestString)
         ) {
             is BrowserSwitchFinalResult.Success -> {
+                // URL return is authoritative: it supersedes any pending auto-link session.
+                pendingPaymentStore.clear()
                 analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_SUCCEEDED, analyticsEventParams)
                 PayPalPaymentAuthResult.Success(browserSwitchResult)
             }
@@ -180,10 +183,23 @@ class PayPalLauncher internal constructor(
                 PayPalPaymentAuthResult.Failure(browserSwitchResult.error)
             }
 
-            is BrowserSwitchFinalResult.NoResult -> {
-                analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, analyticsEventParams)
-                PayPalPaymentAuthResult.NoResult
-            }
+            is BrowserSwitchFinalResult.NoResult -> handleNoResult(analyticsEventParams)
+        }
+    }
+
+    /**
+     * No URL return arrived — the deterministic "manual return / App Link failed" signal.
+     * If a valid billing agreement session is pending, route to auto-link so
+     * [PayPalClient.tokenize] can tokenize the stored BA token directly with BTGW.
+     */
+    private fun handleNoResult(analyticsEventParams: AnalyticsEventParams): PayPalPaymentAuthResult {
+        val session = pendingPaymentStore.pendingSession
+        return if (session != null && !session.isExpired()) {
+            analyticsClient.sendEvent(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_PENDING, analyticsEventParams)
+            PayPalPaymentAuthResult.Success(autoLinkPending = true)
+        } else {
+            analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, analyticsEventParams)
+            PayPalPaymentAuthResult.NoResult
         }
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
@@ -8,11 +8,27 @@ import com.braintreepayments.api.BrowserSwitchFinalResult
 sealed class PayPalPaymentAuthResult {
 
     /**
-     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow
+     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow.
+     *
+     * Two internal construction paths exist:
+     * - URL return: wraps a [BrowserSwitchFinalResult.Success] from the normal browser switch flow
+     * - Auto-link: [autoLinkPending] is true when the App Link return failed but a stored billing
+     *   agreement session exists. [PayPalClient.tokenize] will tokenize the BA token directly
+     *   with BTGW.
      */
-    class Success internal constructor(
-        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success
-    ) : PayPalPaymentAuthResult()
+    class Success private constructor(
+        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success?,
+        internal val autoLinkPending: Boolean
+    ) : PayPalPaymentAuthResult() {
+
+        /** URL return path — nonce will be resolved in [PayPalClient.tokenize]. */
+        internal constructor(browserSwitchSuccess: BrowserSwitchFinalResult.Success) :
+            this(browserSwitchSuccess, false)
+
+        /** Auto-link path — [PayPalClient.tokenize] will tokenize the stored BA token. */
+        internal constructor(autoLinkPending: Boolean) :
+            this(null, autoLinkPending)
+    }
 
     /**
      * The browser switch failed.

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,0 +1,84 @@
+package com.braintreepayments.api.paypal
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Process-level singleton that holds state for the auto-link on manual return flow.
+ *
+ * When a PayPal app switch completes but the App Link return fails, the user manually
+ * switches back to the merchant app. This store persists the billing agreement token and
+ * session metadata across that round trip so the SDK can tokenize directly with BTGW
+ * without a URL return.
+ *
+ * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
+ *
+ * This class must outlive individual [PayPalClient] instances because the client is
+ * per-Fragment and may be GC'd during the app switch.
+ */
+internal class PendingPaymentStore {
+
+    /**
+     * Captured session data needed to tokenize a billing agreement without a URL return.
+     *
+     * @property baToken the billing agreement token from the PayPal approval URL
+     * @property clientMetadataId correlation ID for fraud detection
+     * @property merchantAccountId optional merchant account override
+     * @property intent the PayPal payment intent string value (e.g. "authorize", "sale")
+     * @property paymentType always "billing-agreement" for auto-link flows
+     * @property timestampMs creation time for TTL expiry checks
+     * @property ttlMs time-to-live in milliseconds (default 30 minutes)
+     */
+    data class PendingSession(
+        val baToken: String,
+        val clientMetadataId: String?,
+        val merchantAccountId: String?,
+        val intent: String?,
+        val paymentType: String,
+        val timestampMs: Long = System.currentTimeMillis(),
+        val ttlMs: Long = TTL_MS
+    ) {
+        /** Returns true if this session has exceeded its time-to-live. */
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
+    }
+
+    var pendingSession: PendingSession? = null
+    var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
+
+    /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
+    @Volatile
+    var autoLinkNonce: PayPalAccountNonce? = null
+
+    /**
+     * Returns an existing or newly created [CompletableDeferred] along with a flag
+     * indicating whether this caller is the initiator (created the deferred).
+     *
+     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * Subsequent callers receive the same deferred and should await it.
+     *
+     * @return pair of (deferred, isInitiator)
+     */
+    @Synchronized
+    fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
+        val existing = tokenizeDeferred
+        if (existing != null) return Pair(existing, false)
+        val new = CompletableDeferred<PayPalAccountNonce>()
+        tokenizeDeferred = new
+        return Pair(new, true)
+    }
+
+    /** Resets all state and cancels any in-flight deferred. */
+    fun clear() {
+        pendingSession = null
+        tokenizeDeferred?.cancel()
+        tokenizeDeferred = null
+        autoLinkNonce = null
+    }
+
+    companion object {
+        /** Default session TTL: 30 minutes. */
+        internal const val TTL_MS = 30 * 60 * 1000L
+
+        val instance by lazy { PendingPaymentStore() }
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
@@ -1,0 +1,108 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AutoLinkTokenizeUseCaseUnitTest {
+
+    private val internalPayPalClient: PayPalInternalClient = mockk(relaxed = true)
+    private lateinit var sut: AutoLinkTokenizeUseCase
+
+    @Before
+    fun setup() {
+        sut = AutoLinkTokenizeUseCase(internalPayPalClient)
+    }
+
+    @Test
+    fun `invoke tokenizes with correct PayPalAccount fields`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TEST123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = "merchant-acct",
+            intent = "authorize",
+            paymentType = "billing-agreement"
+        )
+
+        val result = sut(session)
+
+        assertSame(expectedNonce, result)
+
+        val captured = accountSlot.captured
+        assertEquals("metadata-id", captured.clientMetadataId)
+        assertEquals("merchant-acct", captured.merchantAccountId)
+        assertEquals("billing-agreement", captured.paymentType)
+        assertEquals(PayPalPaymentIntent.AUTHORIZE, captured.intent)
+    }
+
+    @Test
+    fun `invoke builds urlResponseData with billing_agreement_token`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TOKEN-ABC",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        val urlResponseData = accountSlot.captured.urlResponseData
+        assertEquals("BA-TOKEN-ABC", urlResponseData.getString("billing_agreement_token"))
+        assertEquals("web", urlResponseData.getString("response_type"))
+    }
+
+    @Test
+    fun `invoke with null intent sets null on PayPalAccount`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        assertEquals(null, accountSlot.captured.intent)
+    }
+
+    @Test(expected = Exception::class)
+    fun `invoke propagates tokenization errors`() = runTest {
+        coEvery {
+            internalPayPalClient.tokenize(any())
+        } throws Exception("BTGW error")
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -15,6 +15,8 @@ import com.braintreepayments.api.core.Configuration.Companion.fromJson
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.AppSwitchRepository
+import com.braintreepayments.api.core.usecase.GetAppSwitchUseCase
 import com.braintreepayments.api.core.usecase.GetAppLinksCompatibleBrowserUseCase
 import com.braintreepayments.api.core.usecase.GetDefaultAppUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase
@@ -42,6 +44,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -68,6 +71,10 @@ class PayPalClientUnitTest {
         mockk<GetReturnLinkTypeUseCase>(relaxed = true)
     private val getReturnLinkUseCase: GetReturnLinkUseCase = mockk(relaxed = true)
     private val analyticsParamRepository: AnalyticsParamRepository = mockk(relaxed = true)
+    private val appSwitchRepository: AppSwitchRepository = mockk(relaxed = true)
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = mockk(relaxed = true)
+    private val pendingPaymentStore = PendingPaymentStore()
+    private val autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase = mockk(relaxed = true)
 
     @Before
     @Throws(JSONException::class)
@@ -935,21 +942,138 @@ class PayPalClientUnitTest {
         verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
     }
 
+    // region auto-link
+
+    private fun autoLinkSession() = PendingPaymentStore.PendingSession(
+        baToken = "BA-XYZ",
+        clientMetadataId = "cmid",
+        merchantAccountId = null,
+        intent = "authorize",
+        paymentType = "billing-agreement"
+    )
+
+    @Test
+    fun `tokenize with autoLinkPending returns Success and clears store`() = runTest(testDispatcher) {
+        val nonce = mockk<PayPalAccountNonce>(relaxed = true)
+        coEvery { autoLinkTokenizeUseCase(any()) } returns nonce
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Success)
+        assertEquals(nonce, (result as PayPalResult.Success).nonce)
+        assertNull(pendingPaymentStore.pendingSession)
+        verify { braintreeClient.sendAnalyticsEvent(eq(PayPalAnalytics.TOKENIZATION_SUCCEEDED), any()) }
+    }
+
+    @Test
+    fun `tokenize with autoLinkPending returns Failure when BTGW fails`() = runTest(testDispatcher) {
+        coEvery { autoLinkTokenizeUseCase(any()) } throws BraintreeException("BTGW 422")
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Failure)
+        assertNull(pendingPaymentStore.pendingSession)
+        verify { braintreeClient.sendAnalyticsEvent(eq(PayPalAnalytics.AUTO_LINK_TOKENIZE_FAILED), any()) }
+    }
+
+    @Test
+    fun `tokenize with autoLinkPending returns Failure when no session`() = runTest(testDispatcher) {
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Failure)
+    }
+
+    @Test
+    fun `createPaymentAuthRequest re-click delivers nonce via tokenizeCallback`() = runTest(testDispatcher) {
+        every { getAppSwitchUseCase() } returns true
+        val nonce = mockk<PayPalAccountNonce>(relaxed = true)
+        coEvery { autoLinkTokenizeUseCase(any()) } returns nonce
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        sut.createPaymentAuthRequest(activity, PayPalVaultRequest(true), paymentAuthCallback, payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        verify { payPalTokenizeCallback.onPayPalResult(any<PayPalResult.Success>()) }
+        verify(exactly = 0) { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+        assertNull(pendingPaymentStore.pendingSession)
+    }
+
+    @Test
+    fun `createPaymentAuthRequest re-click falls through to normal flow when no session`() =
+        runTest(testDispatcher) {
+            every { getAppSwitchUseCase() } returns true
+            val payPalVaultRequest = PayPalVaultRequest(true)
+            val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+                payPalVaultRequest, null, "https://example.com/approval/url",
+                "sample-client-metadata-id", null, "https://example.com/success/url"
+            )
+            val payPalInternalClient =
+                MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest).build()
+            val braintreeClient =
+                MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+            val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this)
+
+            sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback, payPalTokenizeCallback)
+            advanceUntilIdle()
+
+            verify { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+            verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
+        }
+
+    @Test
+    fun `createPaymentAuthRequest stores pending session for app-switch vault flow`() =
+        runTest(testDispatcher) {
+            every { getAppSwitchUseCase() } returns true
+            every { getReturnLinkUseCase.invoke(any()) } returns AppLink("www.example.com".toUri())
+            val payPalVaultRequest = PayPalVaultRequest(true)
+            val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+                payPalVaultRequest, null, "https://example.com/approval/url?ba_token=BA-STORED",
+                "sample-client-metadata-id", null, "https://example.com/success/url"
+            )
+            val payPalInternalClient =
+                MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest).build()
+            val braintreeClient =
+                MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+            val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this)
+
+            sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback)
+            advanceUntilIdle()
+
+            assertEquals("BA-STORED", pendingPaymentStore.pendingSession?.baToken)
+        }
+
+    // endregion auto-link
+
     private fun testPaypalClient(
         braintreeClient: BraintreeClient,
         payPalInternalClient: PayPalInternalClient,
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
         scope: CoroutineScope = CoroutineScope(dispatcher)
     ): PayPalClient = PayPalClient(
-        braintreeClient,
-        payPalInternalClient,
-        merchantRepository,
-        getDefaultAppUseCase,
-        getAppLinksCompatibleBrowserUseCase,
-        getReturnLinkTypeUseCase,
-        getReturnLinkUseCase,
-        analyticsParamRepository,
-        dispatcher,
-        scope
+        braintreeClient = braintreeClient,
+        internalPayPalClient = payPalInternalClient,
+        merchantRepository = merchantRepository,
+        getDefaultAppUseCase = getDefaultAppUseCase,
+        getAppLinksCompatibleBrowserUseCase = getAppLinksCompatibleBrowserUseCase,
+        getReturnLinkTypeUseCase = getReturnLinkTypeUseCase,
+        getReturnLinkUseCase = getReturnLinkUseCase,
+        analyticsParamRepository = analyticsParamRepository,
+        appSwitchRepository = appSwitchRepository,
+        getAppSwitchUseCase = getAppSwitchUseCase,
+        pendingPaymentStore = pendingPaymentStore,
+        autoLinkTokenizeUseCase = autoLinkTokenizeUseCase,
+        dispatcher = dispatcher,
+        coroutineScope = scope
     )
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.json.JSONException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -44,6 +45,8 @@ class PayPalLauncherUnitTest {
     private val isPurchase = true
     private val recurringBillingPlanType = PayPalRecurringBillingPlanType.RECURRING.name
 
+    private val pendingPaymentStore = PendingPaymentStore()
+
     private lateinit var sut: PayPalLauncher
 
     @Before
@@ -63,9 +66,18 @@ class PayPalLauncherUnitTest {
             getAppSwitchUseCase = getAppSwitchUseCase,
             resolvePayPalUseCase = resolvePayPalUseCase,
             lazyAnalyticsClient = lazy { analyticsClient },
-            analyticsParamRepository = analyticsParamRepository
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = pendingPaymentStore
         )
     }
+
+    private fun pendingSession() = PendingPaymentStore.PendingSession(
+        baToken = paymentToken,
+        clientMetadataId = "cmid",
+        merchantAccountId = null,
+        intent = "authorize",
+        paymentType = "billing-agreement"
+    )
 
     @Test
     fun `launch starts browser switch and returns pending request`() {
@@ -539,6 +551,61 @@ class PayPalLauncherUnitTest {
 
         assertSame(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, slot1.captured)
         assertEquals(paymentToken, slot2.captured.contextId)
+    }
+
+    @Test
+    fun `handleReturnToApp when URL return succeeds clears pending auto-link session`() {
+        pendingPaymentStore.pendingSession = pendingSession()
+        val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns browserSwitchFinalResult
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.Success)
+        assertNull(pendingPaymentStore.pendingSession)
+    }
+
+    @Test
+    fun `handleReturnToApp NoResult with valid pending session returns auto-link pending`() {
+        pendingPaymentStore.pendingSession = pendingSession()
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns BrowserSwitchFinalResult.NoResult
+
+        val slot1 = CapturingSlot<String>()
+        every { analyticsClient.sendEvent(capture(slot1), any()) } returns Unit
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.Success)
+        assertTrue((paymentAuthResult as PayPalPaymentAuthResult.Success).autoLinkPending)
+        assertSame(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_PENDING, slot1.captured)
+    }
+
+    @Test
+    fun `handleReturnToApp NoResult with expired pending session returns NoResult`() {
+        pendingPaymentStore.pendingSession = pendingSession().copy(
+            timestampMs = 0L,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns BrowserSwitchFinalResult.NoResult
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.NoResult)
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -1,0 +1,115 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PendingPaymentStoreUnitTest {
+
+    private lateinit var sut: PendingPaymentStore
+
+    @Before
+    fun setup() {
+        sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial pendingSession is null`() {
+        assertNull(sut.pendingSession)
+    }
+
+    @Test
+    fun `initial autoLinkNonce is null`() {
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `PendingSession isExpired returns false when within TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis(),
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertFalse(session.isExpired())
+    }
+
+    @Test
+    fun `PendingSession isExpired returns true when past TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertTrue(session.isExpired())
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates new deferred on first call`() {
+        val (deferred, isInitiator) = sut.getOrCreateDeferred()
+        assertTrue(isInitiator)
+        assertSame(deferred, sut.tokenizeDeferred)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns existing deferred on second call`() {
+        val (first, isFirstInitiator) = sut.getOrCreateDeferred()
+        val (second, isSecondInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isFirstInitiator)
+        assertFalse(isSecondInitiator)
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        sut.pendingSession = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+        sut.tokenizeDeferred = CompletableDeferred()
+        sut.autoLinkNonce = nonce
+
+        sut.clear()
+
+        assertNull(sut.pendingSession)
+        assertNull(sut.tokenizeDeferred)
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `clear cancels active deferred`() {
+        val deferred = CompletableDeferred<PayPalAccountNonce>()
+        sut.tokenizeDeferred = deferred
+
+        sut.clear()
+
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates fresh deferred after clear`() {
+        val (first, _) = sut.getOrCreateDeferred()
+        sut.clear()
+        val (second, isInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isInitiator)
+        assertFalse(first === second)
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 2 for the PayPal **auto-link on manual return** feature.

When a PayPal app-switch vault flow completes but the App Link return fails, the user manually returns to the merchant app. This PR adds the **deterministic** auto-link path so the SDK can tokenize the billing agreement directly with BTGW without a URL return.

## What changed

- **`handleReturnToApp` runs `completeRequest` first.** A real URL return is authoritative and clears any pending session; a `NoResult` with a valid pending billing-agreement session routes to auto-link. `NoResult` is the deterministic "manual return / App Link failed" signal — no timers or lifecycle guessing.
- **Auto-link tokenization** (`AutoLinkTokenizeUseCase`) — the stored BA token is sent as a standalone `billing_agreement_token` in the `paypal_account` payload (same field the Web SDK uses).
- **Re-click path folded in** — passing a `tokenizeCallback` to `createPaymentAuthRequest` delivers the nonce directly if the user re-taps PayPal after a failed return.
- **`PendingPaymentStore`** (minimal) persists the session across the round trip; a `CompletableDeferred` guarantees exactly one BTGW call across entry points.

## Compatibility

- **Non-breaking.** The only public API addition is an overload `createPaymentAuthRequest(context, request, callback, tokenizeCallback)`; the existing 3-arg method delegates to it with `tokenizeCallback = null`. All other new types are `internal`.

## Analytics events added

```
paypal:tokenize:auto-link:started | succeeded | failed
paypal:tokenize:auto-link:expired
paypal:tokenize:auto-link:handle-return:pending
paypal:tokenize:auto-link:reclick:started | succeeded | failed
```

## New files
- `PendingPaymentStore.kt`
- `AutoLinkTokenizeUseCase.kt`
- `PendingPaymentStoreUnitTest.kt`, `AutoLinkTokenizeUseCaseUnitTest.kt`

## Not in this PR (deferred to PR 2)
- `AppForegroundDetector` / `ProcessLifecycleOwner` merchant-independent foreground trigger
- `androidx-lifecycle-process` dependency and the `State` enum

## Test plan
- [x] Unit tests: 71 passing across `PayPalClientUnitTest`, `PayPalLauncherUnitTest`, `PendingPaymentStoreUnitTest`, `AutoLinkTokenizeUseCaseUnitTest` (0 failures)
- [ ] Detekt / lint (not run locally — will rely on CI)
- [x] Manual QA: app-switch vault flow, uncheck "Open supported links", complete BA in PayPal, manually return → nonce resolved on `handleReturnToApp`; re-tap PayPal → nonce delivered via `tokenizeCallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Testing

Manual E2E on a real device (PayPal sandbox, Billing Agreement app-switch flow). Full plan + captured logs:
- [Test plan](https://github.com/santugowda/braintree_android/blob/paypal-autolink-qa-testing/PAYPAL_AUTOLINK_QA.md) · [E2E results & logs](https://github.com/santugowda/braintree_android/blob/paypal-autolink-qa-testing/PAYPAL_AUTOLINK_E2E_RESULTS.md)

| Scenario | Result |
|---|---|
| Path A — `handleReturnToApp` NoResult → auto-link, nonce returned | ✅ |
| Path B — re-click delivers nonce via `tokenizeCallback` | ✅ |
| URL return wins — real App Link return suppresses auto-link | ✅ |
| Failure — BTGW error → `PayPalResult.Failure` (Path A shows error; Path B falls through) | ✅ |


https://github.com/user-attachments/assets/79b6fcc2-d7a8-4eaf-b562-de7561690b30


https://github.com/user-attachments/assets/b9cbd4dd-94f0-4f83-805d-40a22bb3003b