### PR TITLE
feat: add instrumentation tests support for android 17

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ "37.0" ]
-        target: [ google_apis_ps16k ]
+        target: [ playstore_ps16k ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -69,6 +69,14 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
+          emulator-options: >
+            -no-window
+            -gpu auto
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -memory 4096
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
           script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
 
       - name: retry tests
@@ -79,4 +87,12 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
+          emulator-options: >
+            -no-window
+            -gpu auto
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -memory 4096
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
           script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 37 ]
+        api-level: [ "37.0" ]
         target: [ google_apis_ps16k ]
     steps:
       - name: checkout

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -1,15 +1,37 @@
 name: Instrumentation tests
 on: [pull_request, workflow_dispatch]
+
+env:
+  ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+  EMULATOR_OPTIONS: -no-window -gpu auto -dns-server 8.8.8.8 -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+  CONNECTED_CHECK_TASKS: >-
+    :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck
+    :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck
+    :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck
+    :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck
+    :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 23, 31, 35 ]
-        target: [ default, google_apis ]
+        include:
+          - api-level: 23
+            target: default
+          - api-level: 23
+            target: google_apis
+          - api-level: 31
+            target: default
+          - api-level: 31
+            target: google_apis
+          - api-level: 35
+            target: default
+          - api-level: 35
+            target: google_apis
+          - api-level: "37.0" # Preview API: emulator runner/system image requires quoted "37.0" format
+            target: playstore_ps16k
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -29,7 +51,8 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
+          script: ./gradlew ${{ env.CONNECTED_CHECK_TASKS }} --stacktrace
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
@@ -39,62 +62,5 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
-
-  test_android_17:
-    runs-on: ubuntu-latest
-    env:
-      ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
-    strategy:
-      fail-fast: false
-      matrix:
-        api-level: [ "37.0" ]
-        target: [ playstore_ps16k ]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: run tests
-        id: run_tests
-        uses: reactivecircus/android-emulator-runner@v2
-        continue-on-error: true
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: x86_64
-          profile: pixel_7_pro
-          emulator-options: >
-            -no-window
-            -gpu auto
-            -dns-server 8.8.8.8
-            -noaudio
-            -no-boot-anim
-            -camera-back none
-            -memory 4096
-            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
-
-      - name: retry tests
-        if: steps.run_tests.outcome == 'failure'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: x86_64
-          profile: pixel_7_pro
-          emulator-options: >
-            -no-window
-            -gpu auto
-            -dns-server 8.8.8.8
-            -noaudio
-            -no-boot-anim
-            -camera-back none
-            -memory 4096
-            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
-          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
+          script: ./gradlew ${{ env.CONNECTED_CHECK_TASKS }} --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -72,6 +72,7 @@ jobs:
           emulator-options: >
             -no-window
             -gpu auto
+            -dns-server 8.8.8.8 
             -noaudio
             -no-boot-anim
             -camera-back none

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           profile: pixel_7_pro
           script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
 
-  test_new_api:
+  test_android_17:
     runs-on: ubuntu-latest
     env:
       ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
@@ -72,7 +72,7 @@ jobs:
           emulator-options: >
             -no-window
             -gpu auto
-            -dns-server 8.8.8.8 
+            -dns-server 8.8.8.8
             -noaudio
             -no-boot-anim
             -camera-back none
@@ -91,6 +91,7 @@ jobs:
           emulator-options: >
             -no-window
             -gpu auto
+            -dns-server 8.8.8.8
             -noaudio
             -no-boot-anim
             -camera-back none

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -1,37 +1,15 @@
 name: Instrumentation tests
 on: [pull_request, workflow_dispatch]
-
-env:
-  ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
-  EMULATOR_OPTIONS: -no-window -gpu auto -dns-server 8.8.8.8 -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
-  CONNECTED_CHECK_TASKS: >-
-    :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck
-    :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck
-    :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck
-    :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck
-    :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - api-level: 23
-            target: default
-          - api-level: 23
-            target: google_apis
-          - api-level: 31
-            target: default
-          - api-level: 31
-            target: google_apis
-          - api-level: 35
-            target: default
-          - api-level: 35
-            target: google_apis
-          - api-level: "37.0" # Preview API: emulator runner/system image requires quoted "37.0" format
-            target: playstore_ps16k
+        api-level: [ 23, 31, 35 ]
+        target: [ default, google_apis ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -51,8 +29,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          emulator-options: ${{ env.EMULATOR_OPTIONS }}
-          script: ./gradlew ${{ env.CONNECTED_CHECK_TASKS }} --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
 
       - name: retry tests
         if: steps.run_tests.outcome == 'failure'
@@ -62,5 +39,62 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
-          emulator-options: ${{ env.EMULATOR_OPTIONS }}
-          script: ./gradlew ${{ env.CONNECTED_CHECK_TASKS }} --stacktrace
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+
+  test_android_17:
+    runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [ "37.0" ]
+        target: [ playstore_ps16k ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: run tests
+        id: run_tests
+        uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_7_pro
+          emulator-options: >
+            -no-window
+            -gpu auto
+            -dns-server 8.8.8.8
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -memory 4096
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+
+      - name: retry tests
+        if: steps.run_tests.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_7_pro
+          emulator-options: >
+            -no-window
+            -gpu auto
+            -dns-server 8.8.8.8
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -memory 4096
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -40,3 +40,43 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+
+  test_new_api:
+    runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_org.gradle.jvmargs: "-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [ 37 ]
+        target: [ google_apis_ps16k ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: run tests
+        id: run_tests
+        uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_7_pro
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace
+
+      - name: retry tests
+        if: steps.run_tests.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_7_pro
+          script: ./gradlew :BraintreeCore:connectedCheck :Card:connectedCheck :SharedUtils:connectedCheck :LocalPayment:connectedCheck :DataCollector:connectedCheck :GooglePay:connectedCheck :Demo:connectedCheck :PayPal:connectedCheck :PayPalMessaging:connectedCheck :AmericanExpress:connectedCheck :SEPADirectDebit:connectedCheck :ShopperInsights:connectedCheck :ThreeDSecure:connectedCheck :UIComponents:connectedCheck :Venmo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ "37.0" ]
+        api-level: [ "37.0" ]  # Preview API: emulator runner/system image requires quoted "37.0" format
         target: [ playstore_ps16k ]
     steps:
       - name: checkout

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -106,7 +106,7 @@ dependencies {
 
     androidTestImplementation libs.device.automator
     androidTestImplementation project(':TestUtils')
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation libs.androidx.test.espresso.core
 
     testImplementation libs.junit
     testImplementation libs.test.parameter.injector

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,12 +7,13 @@ ksp = "1.9.10-1.0.13"
 coreKtx = "1.12.0"
 androidxLifecycle = "2.6.2"
 androidxRoom = "2.6.1"
-androidxTest = "1.5.0"
+androidxTest = "1.7.0"
 androidxAppcompat = "1.6.0"
 androidxAnnotation = "1.7.0"
 androidxAutofill = "1.3.0"
 androidxWork = "2.8.1"
-androidxJunit = "1.1.5"
+androidxJunit = "1.3.0"
+espresso = "3.7.0"
 coroutines = "1.7.1"
 browserSwitch = "3.5.1"
 cardinal = "2.2.7-7"
@@ -67,6 +68,7 @@ androidx-test-core = { group = "androidx.test", name = "core", version.ref = "an
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTest" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
 
 # Kotlin
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }


### PR DESCRIPTION
### Summary of changes
- add a new job (`test_android_17`) to try and run out instrumentation tests with the new android 17 api - i decided to make it and keep it as a separate job since it needs extra set up for the emulator to boot correctly, but I am open to suggestions
- bump the versions of `androidxJunit`, `androidxTest`, `espresso` to make tests pass on the emulator that uses api 37

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
NA

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 