### PR TITLE
feat: add PendingPaymentStore for auto-link session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * PayPal
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
+    * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * PayPal
     * Collect device information to improve PayPal app switch eligibility when it's enabled
+    * Add internal `PendingPaymentStore` for auto-link on manual return
 
 ## 5.30.0 (2026-07-21)
 
@@ -28,7 +29,6 @@
 * PayPal
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
-    * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,0 +1,84 @@
+package com.braintreepayments.api.paypal
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Process-level singleton that holds state for the auto-link on manual return flow.
+ *
+ * When a PayPal app switch completes but the App Link return fails, the user manually
+ * switches back to the merchant app. This store persists the billing agreement token and
+ * session metadata across that round trip so the SDK can tokenize directly with BTGW
+ * without a URL return.
+ *
+ * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
+ *
+ * This class must outlive individual [PayPalClient] instances because the client is
+ * per-Fragment and may be GC'd during the app switch.
+ */
+internal class PendingPaymentStore {
+
+    /**
+     * Captured session data needed to tokenize a billing agreement without a URL return.
+     *
+     * @property baToken the billing agreement token from the PayPal approval URL
+     * @property clientMetadataId correlation ID for fraud detection
+     * @property merchantAccountId optional merchant account override
+     * @property intent the PayPal payment intent string value (e.g. "authorize", "sale")
+     * @property paymentType always "billing-agreement" for auto-link flows
+     * @property timestampMs creation time for TTL expiry checks
+     * @property ttlMs time-to-live in milliseconds (default 30 minutes)
+     */
+    data class PendingSession(
+        val baToken: String,
+        val clientMetadataId: String?,
+        val merchantAccountId: String?,
+        val intent: String?,
+        val paymentType: String,
+        val timestampMs: Long = System.currentTimeMillis(),
+        val ttlMs: Long = TTL_MS
+    ) {
+        /** Returns true if this session has exceeded its time-to-live. */
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
+    }
+
+    var pendingSession: PendingSession? = null
+    var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
+
+    /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
+    @Volatile
+    var autoLinkNonce: PayPalAccountNonce? = null
+
+    /**
+     * Returns an existing or newly created [CompletableDeferred] along with a flag
+     * indicating whether this caller is the initiator (created the deferred).
+     *
+     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * Subsequent callers receive the same deferred and should await it.
+     *
+     * @return pair of (deferred, isInitiator)
+     */
+    @Synchronized
+    fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
+        val existing = tokenizeDeferred
+        if (existing != null) return Pair(existing, false)
+        val new = CompletableDeferred<PayPalAccountNonce>()
+        tokenizeDeferred = new
+        return Pair(new, true)
+    }
+
+    /** Resets all state and cancels any in-flight deferred. */
+    fun clear() {
+        pendingSession = null
+        tokenizeDeferred?.cancel()
+        tokenizeDeferred = null
+        autoLinkNonce = null
+    }
+
+    companion object {
+        /** Default session TTL: 30 minutes. */
+        internal const val TTL_MS = 30 * 60 * 1000L
+
+        val instance by lazy { PendingPaymentStore() }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -42,7 +42,10 @@ internal class PendingPaymentStore {
         fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
     }
 
+    @Volatile
     var pendingSession: PendingSession? = null
+
+    @Volatile
     var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
 
     /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -7,10 +7,10 @@ import kotlinx.coroutines.CompletableDeferred
  *
  * When a PayPal app switch completes but the App Link return fails, the user manually
  * switches back to the merchant app. This store persists the billing agreement token and
- * session metadata across that round trip so the SDK can tokenize directly with BTGW
- * without a URL return.
+ * session metadata across that round trip so the SDK can tokenize directly with the
+ * Braintree Gateway (BTGW) without a URL return.
  *
- * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * A [CompletableDeferred] ensures exactly one Braintree Gateway (BTGW) tokenization call is made, even when
  * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
  *
  * This class must outlive individual [PayPalClient] instances because the client is
@@ -56,7 +56,7 @@ internal class PendingPaymentStore {
      * Returns an existing or newly created [CompletableDeferred] along with a flag
      * indicating whether this caller is the initiator (created the deferred).
      *
-     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * The initiator is responsible for making the Braintree Gateway (BTGW) call and completing the deferred.
      * Subsequent callers receive the same deferred and should await it.
      *
      * @return pair of (deferred, isInitiator)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -1,0 +1,115 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PendingPaymentStoreUnitTest {
+
+    private lateinit var sut: PendingPaymentStore
+
+    @Before
+    fun setup() {
+        sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial pendingSession is null`() {
+        assertNull(sut.pendingSession)
+    }
+
+    @Test
+    fun `initial autoLinkNonce is null`() {
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `PendingSession isExpired returns false when within TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis(),
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertFalse(session.isExpired())
+    }
+
+    @Test
+    fun `PendingSession isExpired returns true when past TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertTrue(session.isExpired())
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates new deferred on first call`() {
+        val (deferred, isInitiator) = sut.getOrCreateDeferred()
+        assertTrue(isInitiator)
+        assertSame(deferred, sut.tokenizeDeferred)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns existing deferred on second call`() {
+        val (first, isFirstInitiator) = sut.getOrCreateDeferred()
+        val (second, isSecondInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isFirstInitiator)
+        assertFalse(isSecondInitiator)
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        sut.pendingSession = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+        sut.tokenizeDeferred = CompletableDeferred()
+        sut.autoLinkNonce = nonce
+
+        sut.clear()
+
+        assertNull(sut.pendingSession)
+        assertNull(sut.tokenizeDeferred)
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `clear cancels active deferred`() {
+        val deferred = CompletableDeferred<PayPalAccountNonce>()
+        sut.tokenizeDeferred = deferred
+
+        sut.clear()
+
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates fresh deferred after clear`() {
+        val (first, _) = sut.getOrCreateDeferred()
+        sut.clear()
+        val (second, isInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isInitiator)
+        assertFalse(first === second)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -8,6 +8,10 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class PendingPaymentStoreUnitTest {
 
@@ -111,5 +115,33 @@ class PendingPaymentStoreUnitTest {
 
         assertTrue(isInitiator)
         assertFalse(first === second)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns same deferred and exactly one initiator under concurrent access`() {
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            repeat(500) {
+                val store = PendingPaymentStore()
+                val barrier = CyclicBarrier(2)
+
+                val task = Callable {
+                    barrier.await()
+                    store.getOrCreateDeferred()
+                }
+
+                val future1 = executor.submit(task)
+                val future2 = executor.submit(task)
+
+                val result1 = future1.get(5, TimeUnit.SECONDS)
+                val result2 = future2.get(5, TimeUnit.SECONDS)
+
+                assertSame(result1.first, result2.first)
+                assertTrue(result1.second != result2.second)
+                assertTrue(result1.second || result2.second)
+            }
+        } finally {
+            executor.shutdown()
+        }
     }
 }


### PR DESCRIPTION

## Summary of changes

Adds `PendingPaymentStore`, the in-memory session store used by the PayPal auto-link on manual return feature to carry a pending billing agreement token across the App Switch round trip.

### Background

When a user approves a PayPal Billing Agreement (BA) via App Switch and returns to the merchant app, the return can fail to convert into a tokenized payment method in two cases:
- The universal link fails to reopen the merchant app (~5% of returns).
- The user manually switches back to the merchant app before the universal link launches.

Today, when `handleOpen(url)` is never called, the SDK has no reference to the approved BA token and cannot tokenize it — the BA is approved on PayPal's side but the merchant never receives a nonce.

This PR is **PR 1 of a multi-PR series** that adds "auto-link on manual return": the SDK persists the BA token before app switch and retries tokenization when the user returns, regardless of how they returned. This PR introduces only the storage primitive; no tokenization logic and no `PayPalClient` wiring are included here, so each PR in the series stays independently reviewable.

**Changes:**
- `PendingPaymentStore` (internal, in-memory, process-level singleton): holds a `PendingSession` (BA token + correlation ID + merchant account ID + intent + payment type + timestamp/TTL) and a `CompletableDeferred<PayPalAccountNonce>` used by later PRs to guarantee exactly one BTGW tokenization call across the multiple entry points (return-handling and re-click) that can race to trigger it.

### Steps to Test

This PR only adds a storage primitive with no wiring into the checkout flow yet, so it has no end-user-visible behavior to exercise manually. Verification is via the included unit tests:

1. Run `./gradlew :PayPal:testDebugUnitTest --tests "*.PendingPaymentStoreUnitTest"`
2. Confirm all tests pass: initial state is null, `PendingSession.isExpired()` correctly reflects TTL boundaries, `getOrCreateDeferred()` returns the same deferred to a second caller while the first remains the initiator, and `clear()` resets all fields and cancels any in-flight deferred.

### AI Usage

**Which AI Agent Was Used?**
- [x] Claude

**How was AI used?**
Code generation and unit test authoring for `PendingPaymentStore`, based on an existing HLD/LLD design and a prior reference implementation for this feature.

**Estimated AI Code Contribution**
- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected (no flow wiring yet in this PR; unit-tested in isolation)

### Authors
- @pedrofsn

### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [x] Added all labels to the PR
- [x] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable — not applicable, this PR adds a storage primitive only, no user-visible behavior yet
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true — **this is PR 1 of 5 in a stacked series; PRs 2-5 will follow, each building on the previous one's branch, same pattern as the earlier #1633/#1634 split**
- [x] Unit tests and builds have been run locally and pass/compile as expected

## PR series

Part of a 5-PR series re-splitting the original "auto-link on manual return" feature (previously opened as #1633 and #1634, closed for being too large to review):

1. **This PR** - `PendingPaymentStore` (session persistence)
2. `AutoLinkTokenizeUseCase` (tokenization logic) - stacked on this PR
3. `PayPalClient` wiring (handleReturnToApp + re-click) - stacked on PR 2
4. `PayPalLauncher`/`PayPalPaymentAuthResult`/Demo wiring - stacked on PR 3
5. `AppForegroundDetector` merchant-independent foreground trigger - stacked on PR 4

Please review/merge in order 1 -> 5.

