### PR TITLE
feat(PayPal): add AutoLinkTokenizeUseCase for auto-link tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * PayPal
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
+    * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
     * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
+    * Add internal `AutoLinkTokenizeUseCase` for auto-link tokenization (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
@@ -1,0 +1,45 @@
+package com.braintreepayments.api.paypal
+
+import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
+import org.json.JSONObject
+
+/**
+ * Tokenizes a billing agreement directly with BTGW using a stored BA token,
+ * bypassing the normal URL-return flow.
+ *
+ * In the auto-link scenario, the SDK does not have a return URL (the App Link failed).
+ * Instead, the BA token is sent as a standalone `billing_agreement_token` field in the
+ * `paypal_account` payload — the same field the Web SDK uses.
+ *
+ * @param internalPayPalClient used to call [PayPalInternalClient.tokenize]
+ */
+internal class AutoLinkTokenizeUseCase(
+    private val internalPayPalClient: PayPalInternalClient
+) {
+
+    /**
+     * Builds a [PayPalAccount] from the stored [PendingPaymentStore.PendingSession]
+     * and tokenizes it via BTGW.
+     *
+     * @param session the captured session data from the original app switch
+     * @return a [PayPalAccountNonce] on successful tokenization
+     * @throws Exception on BTGW errors (e.g. 422 BILLING_AGREEMENT_NOT_APPROVED)
+     */
+    suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce {
+        val account = PayPalAccount(
+            clientMetadataId = session.clientMetadataId,
+            urlResponseData = buildAutoLinkResponseData(session),
+            intent = session.intent?.let { fromString(it) },
+            merchantAccountId = session.merchantAccountId,
+            paymentType = session.paymentType
+        )
+        return internalPayPalClient.tokenize(account)
+    }
+
+    private fun buildAutoLinkResponseData(session: PendingPaymentStore.PendingSession): JSONObject {
+        return JSONObject().apply {
+            put("billing_agreement_token", session.baToken)
+            put("response_type", "web")
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,0 +1,84 @@
+package com.braintreepayments.api.paypal
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Process-level singleton that holds state for the auto-link on manual return flow.
+ *
+ * When a PayPal app switch completes but the App Link return fails, the user manually
+ * switches back to the merchant app. This store persists the billing agreement token and
+ * session metadata across that round trip so the SDK can tokenize directly with BTGW
+ * without a URL return.
+ *
+ * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
+ *
+ * This class must outlive individual [PayPalClient] instances because the client is
+ * per-Fragment and may be GC'd during the app switch.
+ */
+internal class PendingPaymentStore {
+
+    /**
+     * Captured session data needed to tokenize a billing agreement without a URL return.
+     *
+     * @property baToken the billing agreement token from the PayPal approval URL
+     * @property clientMetadataId correlation ID for fraud detection
+     * @property merchantAccountId optional merchant account override
+     * @property intent the PayPal payment intent string value (e.g. "authorize", "sale")
+     * @property paymentType always "billing-agreement" for auto-link flows
+     * @property timestampMs creation time for TTL expiry checks
+     * @property ttlMs time-to-live in milliseconds (default 30 minutes)
+     */
+    data class PendingSession(
+        val baToken: String,
+        val clientMetadataId: String?,
+        val merchantAccountId: String?,
+        val intent: String?,
+        val paymentType: String,
+        val timestampMs: Long = System.currentTimeMillis(),
+        val ttlMs: Long = TTL_MS
+    ) {
+        /** Returns true if this session has exceeded its time-to-live. */
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
+    }
+
+    var pendingSession: PendingSession? = null
+    var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
+
+    /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
+    @Volatile
+    var autoLinkNonce: PayPalAccountNonce? = null
+
+    /**
+     * Returns an existing or newly created [CompletableDeferred] along with a flag
+     * indicating whether this caller is the initiator (created the deferred).
+     *
+     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * Subsequent callers receive the same deferred and should await it.
+     *
+     * @return pair of (deferred, isInitiator)
+     */
+    @Synchronized
+    fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
+        val existing = tokenizeDeferred
+        if (existing != null) return Pair(existing, false)
+        val new = CompletableDeferred<PayPalAccountNonce>()
+        tokenizeDeferred = new
+        return Pair(new, true)
+    }
+
+    /** Resets all state and cancels any in-flight deferred. */
+    fun clear() {
+        pendingSession = null
+        tokenizeDeferred?.cancel()
+        tokenizeDeferred = null
+        autoLinkNonce = null
+    }
+
+    companion object {
+        /** Default session TTL: 30 minutes. */
+        internal const val TTL_MS = 30 * 60 * 1000L
+
+        val instance by lazy { PendingPaymentStore() }
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
@@ -1,0 +1,108 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AutoLinkTokenizeUseCaseUnitTest {
+
+    private val internalPayPalClient: PayPalInternalClient = mockk(relaxed = true)
+    private lateinit var sut: AutoLinkTokenizeUseCase
+
+    @Before
+    fun setup() {
+        sut = AutoLinkTokenizeUseCase(internalPayPalClient)
+    }
+
+    @Test
+    fun `invoke tokenizes with correct PayPalAccount fields`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TEST123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = "merchant-acct",
+            intent = "authorize",
+            paymentType = "billing-agreement"
+        )
+
+        val result = sut(session)
+
+        assertSame(expectedNonce, result)
+
+        val captured = accountSlot.captured
+        assertEquals("metadata-id", captured.clientMetadataId)
+        assertEquals("merchant-acct", captured.merchantAccountId)
+        assertEquals("billing-agreement", captured.paymentType)
+        assertEquals(PayPalPaymentIntent.AUTHORIZE, captured.intent)
+    }
+
+    @Test
+    fun `invoke builds urlResponseData with billing_agreement_token`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TOKEN-ABC",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        val urlResponseData = accountSlot.captured.urlResponseData
+        assertEquals("BA-TOKEN-ABC", urlResponseData.getString("billing_agreement_token"))
+        assertEquals("web", urlResponseData.getString("response_type"))
+    }
+
+    @Test
+    fun `invoke with null intent sets null on PayPalAccount`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        assertEquals(null, accountSlot.captured.intent)
+    }
+
+    @Test(expected = Exception::class)
+    fun `invoke propagates tokenization errors`() = runTest {
+        coEvery {
+            internalPayPalClient.tokenize(any())
+        } throws Exception("BTGW error")
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -1,0 +1,115 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PendingPaymentStoreUnitTest {
+
+    private lateinit var sut: PendingPaymentStore
+
+    @Before
+    fun setup() {
+        sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial pendingSession is null`() {
+        assertNull(sut.pendingSession)
+    }
+
+    @Test
+    fun `initial autoLinkNonce is null`() {
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `PendingSession isExpired returns false when within TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis(),
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertFalse(session.isExpired())
+    }
+
+    @Test
+    fun `PendingSession isExpired returns true when past TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertTrue(session.isExpired())
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates new deferred on first call`() {
+        val (deferred, isInitiator) = sut.getOrCreateDeferred()
+        assertTrue(isInitiator)
+        assertSame(deferred, sut.tokenizeDeferred)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns existing deferred on second call`() {
+        val (first, isFirstInitiator) = sut.getOrCreateDeferred()
+        val (second, isSecondInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isFirstInitiator)
+        assertFalse(isSecondInitiator)
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        sut.pendingSession = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+        sut.tokenizeDeferred = CompletableDeferred()
+        sut.autoLinkNonce = nonce
+
+        sut.clear()
+
+        assertNull(sut.pendingSession)
+        assertNull(sut.tokenizeDeferred)
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `clear cancels active deferred`() {
+        val deferred = CompletableDeferred<PayPalAccountNonce>()
+        sut.tokenizeDeferred = deferred
+
+        sut.clear()
+
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates fresh deferred after clear`() {
+        val (first, _) = sut.getOrCreateDeferred()
+        sut.clear()
+        val (second, isInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isInitiator)
+        assertFalse(first === second)
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds `AutoLinkTokenizeUseCase`, which tokenizes a stored billing agreement (BA) token directly with BTGW, bypassing the normal URL-return flow. This is PR 2 of 5 in the "auto-link on manual return" re-split — see PR 1 (#1640) for the `PendingPaymentStore` this use case reads from.

> **Note:** This PR is stacked on #1640 — the diff below includes both `PendingPaymentStore` (from #1640) and `AutoLinkTokenizeUseCase` (new in this PR). Please review/merge #1640 first; once it merges into `feature/paypal-autolink-manual-return`, this PR's diff will shrink to just the new `AutoLinkTokenizeUseCase` commit.

### Background

PR 1 (#1640) introduced `PendingPaymentStore`, the in-memory store that persists a pending billing agreement session (BA token + correlation ID + merchant account ID + intent) across the App Switch round trip, for cases where the universal-link return never fires `handleOpen(url)`.

This PR adds the tokenization step that consumes that stored session: `AutoLinkTokenizeUseCase` builds a `PayPalAccount` from a `PendingPaymentStore.PendingSession` and sends the BA token to BTGW as a standalone `billing_agreement_token` field in the `paypal_account` payload — the same field the Web SDK already uses — so tokenization can succeed without ever having a return URL.

Still no `PayPalClient`/`PayPalLauncher` wiring in this PR (that's PR 3 and PR 4); this PR only adds the tokenization primitive, kept small and independently reviewable.

**Changes:**
- `AutoLinkTokenizeUseCase` (internal): `suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce` — builds a `PayPalAccount` (clientMetadataId, intent, merchantAccountId, paymentType from the session) with `urlResponseData = {"billing_agreement_token": <token>, "response_type": "web"}`, and calls `PayPalInternalClient.tokenize(account)`.

### Steps to Test

This PR only adds a tokenization primitive with no wiring into the checkout flow yet, so it has no end-user-visible behavior to exercise manually. Verification is via the included unit tests:

1. Run `./gradlew :PayPal:testDebugUnitTest --tests "*.AutoLinkTokenizeUseCaseUnitTest"`
2. Confirm all tests pass: the `PayPalAccount` is built with the correct fields from a `PendingSession`, the `billing_agreement_token`/`response_type=web` payload is constructed correctly, null `intent` is handled, and tokenization errors propagate from `PayPalInternalClient.tokenize`.

### AI Usage

**Which AI Agent Was Used?**
- [x] Claude

**How was AI used?**
Code generation and unit test authoring for `AutoLinkTokenizeUseCase`, based on an existing HLD/LLD design and a prior reference implementation for this feature.

**Estimated AI Code Contribution**
- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected (no flow wiring yet in this PR; unit-tested in isolation)

### Authors
- @pedrofsn

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [x] Added all labels to the PR
- [x] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable — not applicable, this PR adds a tokenization primitive only, no user-visible behavior yet
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true — **this is PR 2 of 5 in a stacked series, based on PR 1 (#1640); both target `feature/paypal-autolink-manual-return`**
- [x] Unit tests and builds have been run locally and pass/compile as expected

## PR series

Part of a 5-PR series re-splitting the original "auto-link on manual return" feature (previously opened as #1633 and #1634, closed for being too large to review):

1. `PendingPaymentStore` (session persistence) - [#1640](https://github.com/braintree/braintree_android/pull/1640)
2. **This PR** - `AutoLinkTokenizeUseCase` (tokenization logic) - stacked on PR 1
3. `PayPalClient` wiring (handleReturnToApp + re-click) - stacked on this PR
4. `PayPalLauncher`/`PayPalPaymentAuthResult`/Demo wiring - stacked on PR 3
5. `AppForegroundDetector` merchant-independent foreground trigger - stacked on PR 4

Please review/merge in order 1 -> 5.


