### PR TITLE
feat(PayPal): add merchant-independent foreground auto-link trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     * Add internal `AutoLinkTokenizeUseCase` for auto-link tokenization (no public API changes)
     * Wire `PendingPaymentStore`/`AutoLinkTokenizeUseCase` into `PayPalClient` for auto-link on manual return (adds a new `createPaymentAuthRequest` overload accepting an optional tokenize callback for re-click support)
     * Complete auto-link wiring in `PayPalLauncher`/`PayPalPaymentAuthResult` and the Demo app; add auto-link analytics events
+    * Add `AppForegroundDetector` for merchant-independent auto-link on manual return when the app is foregrounded (no public API changes; adds `androidx-lifecycle-process` dependency)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
     * Add internal `AutoLinkTokenizeUseCase` for auto-link tokenization (no public API changes)
     * Wire `PendingPaymentStore`/`AutoLinkTokenizeUseCase` into `PayPalClient` for auto-link on manual return (adds a new `createPaymentAuthRequest` overload accepting an optional tokenize callback for re-click support)
+    * Complete auto-link wiring in `PayPalLauncher`/`PayPalPaymentAuthResult` and the Demo app; add auto-link analytics events
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * PayPal
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
+    * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     * Expose `tokenize` as a public suspend function
     * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
     * Add internal `AutoLinkTokenizeUseCase` for auto-link tokenization (no public API changes)
+    * Wire `PendingPaymentStore`/`AutoLinkTokenizeUseCase` into `PayPalClient` for auto-link on manual return (adds a new `createPaymentAuthRequest` overload accepting an optional tokenize callback for re-click support)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function
     * Add internal `PendingPaymentStore` for auto-link on manual return (no public API changes)
+    * Add internal `AutoLinkTokenizeUseCase` for auto-link tokenization (no public API changes)
 * SEPADirectDebit
     * Expose `createPaymentAuthRequest` as a public suspend function
     * Expose `tokenize` as a public suspend function

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -28,6 +28,7 @@ import com.braintreepayments.api.paypal.PayPalPaymentAuthResult;
 import com.braintreepayments.api.paypal.PayPalPendingRequest;
 import com.braintreepayments.api.paypal.PayPalRequest;
 import com.braintreepayments.api.paypal.PayPalResult;
+import com.braintreepayments.api.paypal.PayPalTokenizeCallback;
 import com.google.android.material.textfield.TextInputEditText;
 
 public class PayPalFragment extends BaseFragment {
@@ -228,11 +229,24 @@ public class PayPalFragment extends BaseFragment {
                     isAmountBreakdownEnabled
             );
         }
+        // For billing agreement flows, pass a tokenizeCallback to enable auto-link re-click:
+        // if the user re-taps PayPal after a failed App Link return, the SDK will deliver
+        // the nonce directly here instead of restarting the full flow.
+        PayPalTokenizeCallback tokenizeCallback = isBillingAgreement
+            ? payPalResult -> {
+                if (payPalResult instanceof PayPalResult.Failure) {
+                    handleError(((PayPalResult.Failure) payPalResult).getError());
+                } else if (payPalResult instanceof PayPalResult.Success) {
+                    handlePayPalResult(((PayPalResult.Success) payPalResult).getNonce());
+                }
+            }
+            : null;
+
         payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,
             (paymentAuthRequest) -> {
                 if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.Failure) {
                     handleError(((PayPalPaymentAuthRequest.Failure) paymentAuthRequest).getError());
-                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch){
+                } else if (paymentAuthRequest instanceof PayPalPaymentAuthRequest.ReadyToLaunch) {
                     PayPalPendingRequest request = payPalLauncher.launch(requireActivity(),
                             ((PayPalPaymentAuthRequest.ReadyToLaunch) paymentAuthRequest));
                     if (request instanceof PayPalPendingRequest.Started) {
@@ -241,7 +255,8 @@ public class PayPalFragment extends BaseFragment {
                         handleError(((PayPalPendingRequest.Failure) request).getError());
                     }
                 }
-            });
+            },
+            tokenizeCallback);
     }
 
     private void completePayPalFlow(PayPalPaymentAuthResult.Success paymentAuthResult) {

--- a/PayPal/build.gradle
+++ b/PayPal/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api project(':BraintreeCore')
 
     implementation libs.androidx.appcompat
+    implementation libs.androidx.lifecycle.process
     implementation project(':DataCollector')
 
     testImplementation libs.robolectric

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AppForegroundDetector.kt
@@ -1,0 +1,56 @@
+package com.braintreepayments.api.paypal
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Observes process-level lifecycle events via [ProcessLifecycleOwner] to detect when the
+ * merchant app returns to the foreground after a PayPal app switch. This is the
+ * merchant-independent trigger for the auto-link on manual return flow — it fires regardless
+ * of whether the merchant wires `handleReturnToApp`, covering `onNewIntent`/`singleTop`
+ * integrations that receive no new intent on a manual return.
+ *
+ * Registered once in [PendingPaymentStore.instance] initialization — not per [PayPalClient]
+ * instance — to prevent observer accumulation.
+ *
+ * State transitions:
+ * - [onStop]: if state is [SWITCH_LAUNCHED][PendingPaymentStore.State.SWITCH_LAUNCHED],
+ *   transitions to [AWAITING_RETURN][PendingPaymentStore.State.AWAITING_RETURN].
+ * - [onStart]: if state is [AWAITING_RETURN][PendingPaymentStore.State.AWAITING_RETURN],
+ *   posts [PendingPaymentStore.onReturnFromAppSwitch] to the main-queue tail.
+ *
+ * ### Timer-free race resolution
+ * A real URL return arriving in the same foreground pass calls `handleReturnToApp`, whose
+ * `Success` clears the store (state → [IDLE][PendingPaymentStore.State.IDLE]). By posting the
+ * auto-link attempt to the tail of the main queue and re-checking the state inside the
+ * coroutine, a synchronous `handleReturnToApp(Success)` wins the race without any suppression
+ * timer — the posted attempt observes [IDLE] and no-ops.
+ *
+ * @param store the process-level [PendingPaymentStore] singleton
+ * @param scope coroutine scope used to post the deferred foreground trigger; injectable for tests
+ */
+internal class AppForegroundDetector(
+    private val store: PendingPaymentStore,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main)
+) : DefaultLifecycleObserver {
+
+    override fun onStop(owner: LifecycleOwner) {
+        if (store.state == PendingPaymentStore.State.SWITCH_LAUNCHED) {
+            store.state = PendingPaymentStore.State.AWAITING_RETURN
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (store.state != PendingPaymentStore.State.AWAITING_RETURN) return
+        val callback = store.onReturnFromAppSwitch ?: return
+        scope.launch {
+            // Re-check after the queue-tail hop: a URL return's Success may have cleared the store.
+            if (store.state == PendingPaymentStore.State.AWAITING_RETURN) {
+                callback()
+            }
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCase.kt
@@ -1,0 +1,45 @@
+package com.braintreepayments.api.paypal
+
+import com.braintreepayments.api.paypal.PayPalPaymentIntent.Companion.fromString
+import org.json.JSONObject
+
+/**
+ * Tokenizes a billing agreement directly with BTGW using a stored BA token,
+ * bypassing the normal URL-return flow.
+ *
+ * In the auto-link scenario, the SDK does not have a return URL (the App Link failed).
+ * Instead, the BA token is sent as a standalone `billing_agreement_token` field in the
+ * `paypal_account` payload — the same field the Web SDK uses.
+ *
+ * @param internalPayPalClient used to call [PayPalInternalClient.tokenize]
+ */
+internal class AutoLinkTokenizeUseCase(
+    private val internalPayPalClient: PayPalInternalClient
+) {
+
+    /**
+     * Builds a [PayPalAccount] from the stored [PendingPaymentStore.PendingSession]
+     * and tokenizes it via BTGW.
+     *
+     * @param session the captured session data from the original app switch
+     * @return a [PayPalAccountNonce] on successful tokenization
+     * @throws Exception on BTGW errors (e.g. 422 BILLING_AGREEMENT_NOT_APPROVED)
+     */
+    suspend operator fun invoke(session: PendingPaymentStore.PendingSession): PayPalAccountNonce {
+        val account = PayPalAccount(
+            clientMetadataId = session.clientMetadataId,
+            urlResponseData = buildAutoLinkResponseData(session),
+            intent = session.intent?.let { fromString(it) },
+            merchantAccountId = session.merchantAccountId,
+            paymentType = session.paymentType
+        )
+        return internalPayPalClient.tokenize(account)
+    }
+
+    private fun buildAutoLinkResponseData(session: PendingPaymentStore.PendingSession): JSONObject {
+        return JSONObject().apply {
+            put("billing_agreement_token", session.baToken)
+            put("response_type", "web")
+        }
+    }
+}

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -33,6 +33,10 @@ internal object PayPalAnalytics {
     // Auto-Link via handle-return — completeRequest returned NoResult but a session is pending
     const val AUTO_LINK_HANDLE_RETURN_PENDING = "paypal:tokenize:auto-link:handle-return:pending"
 
+    // Auto-Link via foreground trigger — nonce pre-resolved by ProcessLifecycleOwner and
+    // delivered on handle-return
+    const val AUTO_LINK_HANDLE_RETURN_SUCCEEDED = "paypal:tokenize:auto-link:handle-return:succeeded"
+
     // Auto-Link via re-click — user re-taps PayPal before normal return completes
     const val AUTO_LINK_RECLICK_STARTED = "paypal:tokenize:auto-link:reclick:started"
     const val AUTO_LINK_RECLICK_SUCCEEDED = "paypal:tokenize:auto-link:reclick:succeeded"

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalAnalytics.kt
@@ -23,4 +23,18 @@ internal object PayPalAnalytics {
     const val APP_SWITCH_SUCCEEDED = "paypal:tokenize:app-switch:succeeded"
     const val APP_SWITCH_FAILED = "paypal:tokenize:app-switch:failed"
     const val APP_SWITCH_CANCELED = "paypal:tokenize:app-switch:canceled"
+
+    // Auto-Link events — tokenization via stored BA token when App Link return fails
+    const val AUTO_LINK_TOKENIZE_STARTED = "paypal:tokenize:auto-link:started"
+    const val AUTO_LINK_TOKENIZE_SUCCEEDED = "paypal:tokenize:auto-link:succeeded"
+    const val AUTO_LINK_TOKENIZE_FAILED = "paypal:tokenize:auto-link:failed"
+    const val AUTO_LINK_EXPIRED = "paypal:tokenize:auto-link:expired"
+
+    // Auto-Link via handle-return — completeRequest returned NoResult but a session is pending
+    const val AUTO_LINK_HANDLE_RETURN_PENDING = "paypal:tokenize:auto-link:handle-return:pending"
+
+    // Auto-Link via re-click — user re-taps PayPal before normal return completes
+    const val AUTO_LINK_RECLICK_STARTED = "paypal:tokenize:auto-link:reclick:started"
+    const val AUTO_LINK_RECLICK_SUCCEEDED = "paypal:tokenize:auto-link:reclick:succeeded"
+    const val AUTO_LINK_RECLICK_FAILED = "paypal:tokenize:auto-link:reclick:failed"
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -15,8 +15,10 @@ import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.AppSwitchRepository
 import com.braintreepayments.api.core.UserCanceledException
 import com.braintreepayments.api.core.usecase.GetAppLinksCompatibleBrowserUseCase
+import com.braintreepayments.api.core.usecase.GetAppSwitchUseCase
 import com.braintreepayments.api.core.usecase.GetDefaultAppUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase.ReturnLinkTypeResult
@@ -50,6 +52,11 @@ class PayPalClient internal constructor(
     ),
     private val getReturnLinkUseCase: GetReturnLinkUseCase = GetReturnLinkUseCase(merchantRepository),
     private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val appSwitchRepository: AppSwitchRepository = AppSwitchRepository.instance,
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = GetAppSwitchUseCase(appSwitchRepository),
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance,
+    private val autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase =
+        AutoLinkTokenizeUseCase(internalPayPalClient),
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val coroutineScope: CoroutineScope = CoroutineScope(dispatcher)
 ) {
@@ -114,9 +121,81 @@ class PayPalClient internal constructor(
         payPalRequest: PayPalRequest,
         callback: PayPalPaymentAuthCallback
     ) {
+        createPaymentAuthRequest(context, payPalRequest, callback, tokenizeCallback = null)
+    }
+
+    /**
+     * Starts the PayPal payment flow with auto-link re-click support.
+     *
+     * If a previous app switch session exists (BA approved but App Link return failed) and the
+     * user taps PayPal again, the SDK will attempt to tokenize the stored BA token directly.
+     * On success, the nonce is delivered via [tokenizeCallback] — skipping launch,
+     * handleReturnToApp, and tokenize entirely.
+     *
+     * If auto-link fails or no pending session exists, the normal flow proceeds via [callback].
+     *
+     * @param context          Android Context
+     * @param payPalRequest    a [PayPalRequest] used to customize the request
+     * @param callback         [PayPalPaymentAuthCallback] for the normal flow
+     * @param tokenizeCallback optional [PayPalTokenizeCallback] for auto-link re-click delivery
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    fun createPaymentAuthRequest(
+        context: Context,
+        payPalRequest: PayPalRequest,
+        callback: PayPalPaymentAuthCallback,
+        tokenizeCallback: PayPalTokenizeCallback?
+    ) {
         coroutineScope.launch {
+            if (tokenizeCallback != null && tryAutoLinkReclick(payPalRequest, tokenizeCallback)) {
+                return@launch
+            }
             val result = createPaymentAuthRequest(context, payPalRequest)
             callback.onPayPalPaymentAuthRequest(result)
+        }
+    }
+
+    /**
+     * Attempts auto-link tokenization when the user re-taps PayPal after a failed App Link return.
+     *
+     * @return true if a nonce was delivered via [tokenizeCallback] and the normal flow should be
+     * skipped; false if there was no eligible pending session or auto-link failed (fall through to
+     * the normal flow).
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun tryAutoLinkReclick(
+        payPalRequest: PayPalRequest,
+        tokenizeCallback: PayPalTokenizeCallback
+    ): Boolean {
+        val session = pendingPaymentStore.pendingSession ?: return false
+        if (session.isExpired() || !getAppSwitchUseCase()) return false
+
+        val analyticsParams = AnalyticsEventParams(
+            contextId = session.baToken,
+            isVaultRequest = true,
+            shopperSessionId = payPalRequest.shopperSessionId
+        )
+        braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_RECLICK_STARTED, analyticsParams)
+
+        return try {
+            val nonce = attemptAutoLinkTokenization()
+            if (nonce != null) {
+                pendingPaymentStore.clear()
+                braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_RECLICK_SUCCEEDED, analyticsParams)
+                tokenizeCallback.onPayPalResult(PayPalResult.Success(nonce))
+                true
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            pendingPaymentStore.clear()
+            braintreeClient.sendAnalyticsEvent(
+                PayPalAnalytics.AUTO_LINK_RECLICK_FAILED,
+                analyticsParams.copy(errorDescription = e.message)
+            )
+            false
         }
     }
 
@@ -190,6 +269,7 @@ class PayPalClient internal constructor(
 
             try {
                 payPalResponse.browserSwitchOptions = buildBrowserSwitchOptions(payPalResponse)
+                storePendingSessionIfEligible(payPalResponse)
                 PayPalPaymentAuthRequest.ReadyToLaunch(payPalResponse)
             } catch (exception: Exception) {
                 when (exception) {
@@ -293,7 +373,13 @@ class PayPalClient internal constructor(
     suspend fun tokenize(
         paymentAuthResult: PayPalPaymentAuthResult.Success
     ): PayPalResult {
+        // Auto-link path: no URL return — tokenize the stored BA token directly with BTGW.
+        if (paymentAuthResult.autoLinkPending) {
+            return tokenizeAutoLink()
+        }
+
         val browserSwitchResult = paymentAuthResult.browserSwitchSuccess
+            ?: return PayPalResult.Failure(BraintreeException("Missing browser switch result"))
         val metadata = browserSwitchResult.requestMetadata
         val clientMetadataId = Json.optString(metadata, "client-metadata-id", null)
         val merchantAccountId = Json.optString(metadata, "merchant-account-id", null)
@@ -311,7 +397,7 @@ class PayPalClient internal constructor(
             contextId = contextId,
             isVaultRequest = isVaultRequest,
             shopperSessionId = shopperSessionId,
-            appSwitchUrl = paymentAuthResult.browserSwitchSuccess.returnUrl.toString()
+            appSwitchUrl = browserSwitchResult.returnUrl.toString()
         )
 
         return try {
@@ -381,6 +467,104 @@ class PayPalClient internal constructor(
         }
     }
 
+    /**
+     * Stores a [PendingPaymentStore.PendingSession] when the current request is an app switch
+     * vault flow. The stored session enables auto-link tokenization if the App Link return fails.
+     */
+    private fun storePendingSessionIfEligible(payPalResponse: PayPalPaymentAuthRequestParams) {
+        if (getAppSwitchUseCase() && payPalResponse.isVaultRequest) {
+            val baToken = payPalResponse.approvalUrl?.toUri()?.getQueryParameter("ba_token")
+            if (baToken != null) {
+                pendingPaymentStore.pendingSession = PendingPaymentStore.PendingSession(
+                    baToken = baToken,
+                    clientMetadataId = payPalResponse.clientMetadataId,
+                    merchantAccountId = payPalResponse.merchantAccountId,
+                    intent = payPalResponse.intent?.stringValue,
+                    paymentType = "billing-agreement"
+                )
+            }
+        }
+    }
+
+    /**
+     * Tokenizes a pending billing agreement session directly with BTGW (auto-link).
+     * Invoked from [tokenize] when [PayPalPaymentAuthResult.Success.autoLinkPending] is true.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun tokenizeAutoLink(): PayPalResult {
+        val analyticsEventParams = AnalyticsEventParams(
+            isVaultRequest = true,
+            shopperSessionId = shopperSessionId
+        )
+        return try {
+            val nonce = attemptAutoLinkTokenization()
+            if (nonce != null) {
+                pendingPaymentStore.clear()
+                sendTokenizeSuccessEvent(analyticsEventParams)
+                PayPalResult.Success(nonce)
+            } else {
+                pendingPaymentStore.clear()
+                PayPalResult.Failure(BraintreeException(AUTO_LINK_EXPIRED_MESSAGE))
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            pendingPaymentStore.clear()
+            sendTokenizeFailureEvent(PayPalResult.Failure(e), analyticsEventParams)
+            PayPalResult.Failure(e)
+        }
+    }
+
+    /**
+     * Attempts to tokenize a stored BA token directly with BTGW via [AutoLinkTokenizeUseCase].
+     *
+     * Uses [PendingPaymentStore.getOrCreateDeferred] to ensure exactly one BTGW call:
+     * - If this caller is the initiator, it makes the call and completes the deferred.
+     * - If another entry point already started the call, this caller awaits the same deferred.
+     *
+     * @return the resolved [PayPalAccountNonce], or null if the session is missing or expired.
+     * @throws Exception if the BTGW tokenization call fails.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun attemptAutoLinkTokenization(): PayPalAccountNonce? {
+        val session = pendingPaymentStore.pendingSession ?: return null
+        val analyticsParams = AnalyticsEventParams(
+            contextId = session.baToken,
+            isVaultRequest = true,
+            shopperSessionId = shopperSessionId
+        )
+        if (session.isExpired()) {
+            pendingPaymentStore.clear()
+            braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_EXPIRED, analyticsParams)
+            return null
+        }
+
+        val (deferred, isInitiator) = pendingPaymentStore.getOrCreateDeferred()
+        return if (isInitiator) {
+            braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_TOKENIZE_STARTED, analyticsParams)
+            try {
+                val nonce = autoLinkTokenizeUseCase(session)
+                pendingPaymentStore.autoLinkNonce = nonce
+                deferred.complete(nonce)
+                braintreeClient.sendAnalyticsEvent(PayPalAnalytics.AUTO_LINK_TOKENIZE_SUCCEEDED, analyticsParams)
+                nonce
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                deferred.completeExceptionally(e)
+                pendingPaymentStore.autoLinkNonce = null
+                pendingPaymentStore.tokenizeDeferred = null
+                braintreeClient.sendAnalyticsEvent(
+                    PayPalAnalytics.AUTO_LINK_TOKENIZE_FAILED,
+                    analyticsParams.copy(errorDescription = e.message)
+                )
+                throw e
+            }
+        } else {
+            val nonce = deferred.await()
+            pendingPaymentStore.autoLinkNonce = nonce
+            nonce
+        }
+    }
+
     private fun sendCreatePaymentAuthFailureEvent(
         failure: PayPalPaymentAuthRequest.Failure,
         analyticsEventParams: AnalyticsEventParams
@@ -428,5 +612,8 @@ class PayPalClient internal constructor(
             "for more information."
 
         internal const val BROWSER_SWITCH_EXCEPTION_MESSAGE = "The response contained inconsistent data."
+
+        internal const val AUTO_LINK_EXPIRED_MESSAGE =
+            "The billing agreement session has expired. Please restart the PayPal flow."
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -100,6 +100,9 @@ class PayPalClient internal constructor(
             ReturnLinkTypeResult.APP_LINK -> LinkType.APP_LINK
             ReturnLinkTypeResult.DEEP_LINK -> LinkType.DEEP_LINK
         }
+        // Merchant-independent foreground trigger (AppForegroundDetector) resolves the nonce
+        // when the app returns after a manual return. Always points at the latest client.
+        pendingPaymentStore.onReturnFromAppSwitch = { attemptAutoLinkTokenizationSilently() }
     }
 
     /**
@@ -373,7 +376,16 @@ class PayPalClient internal constructor(
     suspend fun tokenize(
         paymentAuthResult: PayPalPaymentAuthResult.Success
     ): PayPalResult {
-        // Auto-link path: no URL return — tokenize the stored BA token directly with BTGW.
+        // Auto-link resolved path: foreground trigger already tokenized — short-circuit.
+        paymentAuthResult.autoLinkNonce?.let { nonce ->
+            pendingPaymentStore.clear()
+            sendTokenizeSuccessEvent(
+                AnalyticsEventParams(isVaultRequest = true, shopperSessionId = shopperSessionId)
+            )
+            return PayPalResult.Success(nonce)
+        }
+
+        // Auto-link pending path: no URL return — tokenize the stored BA token directly with BTGW.
         if (paymentAuthResult.autoLinkPending) {
             return tokenizeAutoLink()
         }
@@ -482,7 +494,23 @@ class PayPalClient internal constructor(
                     intent = payPalResponse.intent?.stringValue,
                     paymentType = "billing-agreement"
                 )
+                pendingPaymentStore.state = PendingPaymentStore.State.SWITCH_LAUNCHED
             }
+        }
+    }
+
+    /**
+     * Invoked by [AppForegroundDetector] on foreground return. Runs auto-link tokenization and
+     * stores the resolved nonce on [PendingPaymentStore] for later pickup by handleReturnToApp or
+     * a re-click. Failures are swallowed here — there is no caller to deliver to; analytics are
+     * emitted inside [attemptAutoLinkTokenization] and the session is preserved for retry.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun attemptAutoLinkTokenizationSilently() {
+        try {
+            attemptAutoLinkTokenization()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
         }
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -25,7 +25,8 @@ class PayPalLauncher internal constructor(
     private val resolvePayPalUseCase: ResolvePayPalUseCase =
         ResolvePayPalUseCase(MerchantRepository.instance),
     lazyAnalyticsClient: Lazy<AnalyticsClient>,
-    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance
+    private val analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
+    private val pendingPaymentStore: PendingPaymentStore = PendingPaymentStore.instance
 ) {
     /**
      * Used to launch the PayPal flow in a web browser and deliver results to your Activity
@@ -166,6 +167,8 @@ class PayPalLauncher internal constructor(
             val browserSwitchResult = browserSwitchClient.completeRequest(intent, pendingRequest.pendingRequestString)
         ) {
             is BrowserSwitchFinalResult.Success -> {
+                // URL return is authoritative: it supersedes any pending auto-link session.
+                pendingPaymentStore.clear()
                 analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_SUCCEEDED, analyticsEventParams)
                 PayPalPaymentAuthResult.Success(browserSwitchResult)
             }
@@ -180,10 +183,23 @@ class PayPalLauncher internal constructor(
                 PayPalPaymentAuthResult.Failure(browserSwitchResult.error)
             }
 
-            is BrowserSwitchFinalResult.NoResult -> {
-                analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, analyticsEventParams)
-                PayPalPaymentAuthResult.NoResult
-            }
+            is BrowserSwitchFinalResult.NoResult -> handleNoResult(analyticsEventParams)
+        }
+    }
+
+    /**
+     * No URL return arrived — the deterministic "manual return / App Link failed" signal.
+     * If a valid billing agreement session is pending, route to auto-link so
+     * [PayPalClient.tokenize] can tokenize the stored BA token directly with BTGW.
+     */
+    private fun handleNoResult(analyticsEventParams: AnalyticsEventParams): PayPalPaymentAuthResult {
+        val session = pendingPaymentStore.pendingSession
+        return if (session != null && !session.isExpired()) {
+            analyticsClient.sendEvent(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_PENDING, analyticsEventParams)
+            PayPalPaymentAuthResult.Success(autoLinkPending = true)
+        } else {
+            analyticsClient.sendEvent(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, analyticsEventParams)
+            PayPalPaymentAuthResult.NoResult
         }
     }
 

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalLauncher.kt
@@ -193,6 +193,13 @@ class PayPalLauncher internal constructor(
      * [PayPalClient.tokenize] can tokenize the stored BA token directly with BTGW.
      */
     private fun handleNoResult(analyticsEventParams: AnalyticsEventParams): PayPalPaymentAuthResult {
+        // Foreground trigger may have already resolved the nonce — return it directly.
+        val resolvedNonce = pendingPaymentStore.autoLinkNonce
+        if (resolvedNonce != null) {
+            analyticsClient.sendEvent(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_SUCCEEDED, analyticsEventParams)
+            return PayPalPaymentAuthResult.Success(resolvedNonce)
+        }
+
         val session = pendingPaymentStore.pendingSession
         return if (session != null && !session.isExpired()) {
             analyticsClient.sendEvent(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_PENDING, analyticsEventParams)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
@@ -8,11 +8,27 @@ import com.braintreepayments.api.BrowserSwitchFinalResult
 sealed class PayPalPaymentAuthResult {
 
     /**
-     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow
+     * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow.
+     *
+     * Two internal construction paths exist:
+     * - URL return: wraps a [BrowserSwitchFinalResult.Success] from the normal browser switch flow
+     * - Auto-link: [autoLinkPending] is true when the App Link return failed but a stored billing
+     *   agreement session exists. [PayPalClient.tokenize] will tokenize the BA token directly
+     *   with BTGW.
      */
-    class Success internal constructor(
-        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success
-    ) : PayPalPaymentAuthResult()
+    class Success private constructor(
+        internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success?,
+        internal val autoLinkPending: Boolean
+    ) : PayPalPaymentAuthResult() {
+
+        /** URL return path — nonce will be resolved in [PayPalClient.tokenize]. */
+        internal constructor(browserSwitchSuccess: BrowserSwitchFinalResult.Success) :
+            this(browserSwitchSuccess, false)
+
+        /** Auto-link path — [PayPalClient.tokenize] will tokenize the stored BA token. */
+        internal constructor(autoLinkPending: Boolean) :
+            this(null, autoLinkPending)
+    }
 
     /**
      * The browser switch failed.

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalPaymentAuthResult.kt
@@ -10,24 +10,31 @@ sealed class PayPalPaymentAuthResult {
     /**
      * A successful result that should be passed to [PayPalClient.tokenize] to complete the flow.
      *
-     * Two internal construction paths exist:
+     * Three internal construction paths exist:
      * - URL return: wraps a [BrowserSwitchFinalResult.Success] from the normal browser switch flow
-     * - Auto-link: [autoLinkPending] is true when the App Link return failed but a stored billing
-     *   agreement session exists. [PayPalClient.tokenize] will tokenize the BA token directly
-     *   with BTGW.
+     * - Auto-link resolved: carries a [autoLinkNonce] already tokenized by the process-level
+     *   foreground trigger ([AppForegroundDetector]); [PayPalClient.tokenize] returns it directly.
+     * - Auto-link pending: [autoLinkPending] is true when the App Link return failed but a stored
+     *   billing agreement session exists. [PayPalClient.tokenize] will tokenize the BA token
+     *   directly with BTGW.
      */
     class Success private constructor(
         internal val browserSwitchSuccess: BrowserSwitchFinalResult.Success?,
+        internal val autoLinkNonce: PayPalAccountNonce?,
         internal val autoLinkPending: Boolean
     ) : PayPalPaymentAuthResult() {
 
         /** URL return path — nonce will be resolved in [PayPalClient.tokenize]. */
         internal constructor(browserSwitchSuccess: BrowserSwitchFinalResult.Success) :
-            this(browserSwitchSuccess, false)
+            this(browserSwitchSuccess, null, false)
 
-        /** Auto-link path — [PayPalClient.tokenize] will tokenize the stored BA token. */
+        /** Auto-link resolved path — nonce already tokenized by the foreground trigger. */
+        internal constructor(autoLinkNonce: PayPalAccountNonce) :
+            this(null, autoLinkNonce, false)
+
+        /** Auto-link pending path — [PayPalClient.tokenize] will tokenize the stored BA token. */
         internal constructor(autoLinkPending: Boolean) :
-            this(null, autoLinkPending)
+            this(null, null, autoLinkPending)
     }
 
     /**

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.paypal
 
+import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CompletableDeferred
 
 /**
@@ -11,12 +12,21 @@ import kotlinx.coroutines.CompletableDeferred
  * without a URL return.
  *
  * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
- * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
+ * multiple entry points (handle-return NoResult, user re-click, and the process-level
+ * foreground trigger) race to tokenize.
  *
  * This class must outlive individual [PayPalClient] instances because the client is
  * per-Fragment and may be GC'd during the app switch.
  */
 internal class PendingPaymentStore {
+
+    /**
+     * State machine for tracking the app switch lifecycle, driven by [AppForegroundDetector].
+     * - [IDLE]: no active app switch session
+     * - [SWITCH_LAUNCHED]: browser/app switch started, app still in foreground
+     * - [AWAITING_RETURN]: app went to background after launch, waiting for the user to return
+     */
+    enum class State { IDLE, SWITCH_LAUNCHED, AWAITING_RETURN }
 
     /**
      * Captured session data needed to tokenize a billing agreement without a URL return.
@@ -42,12 +52,19 @@ internal class PendingPaymentStore {
         fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
     }
 
+    var state: State = State.IDLE
     var pendingSession: PendingSession? = null
     var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
 
     /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
     @Volatile
     var autoLinkNonce: PayPalAccountNonce? = null
+
+    /**
+     * Callback invoked by [AppForegroundDetector] when the app returns to the foreground.
+     * Set by each [PayPalClient] in its init block — always points to the latest instance.
+     */
+    var onReturnFromAppSwitch: (suspend () -> Unit)? = null
 
     /**
      * Returns an existing or newly created [CompletableDeferred] along with a flag
@@ -69,6 +86,7 @@ internal class PendingPaymentStore {
 
     /** Resets all state and cancels any in-flight deferred. */
     fun clear() {
+        state = State.IDLE
         pendingSession = null
         tokenizeDeferred?.cancel()
         tokenizeDeferred = null
@@ -79,6 +97,15 @@ internal class PendingPaymentStore {
         /** Default session TTL: 30 minutes. */
         internal const val TTL_MS = 30 * 60 * 1000L
 
-        val instance by lazy { PendingPaymentStore() }
+        val instance by lazy {
+            val store = PendingPaymentStore()
+            try {
+                ProcessLifecycleOwner.get().lifecycle.addObserver(AppForegroundDetector(store))
+            } catch (_: Exception) {
+                // ProcessLifecycleOwner unavailable — the foreground trigger is silently disabled.
+                // The handle-return NoResult and re-click paths still work independently.
+            }
+            store
+        }
     }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PendingPaymentStore.kt
@@ -1,0 +1,84 @@
+package com.braintreepayments.api.paypal
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Process-level singleton that holds state for the auto-link on manual return flow.
+ *
+ * When a PayPal app switch completes but the App Link return fails, the user manually
+ * switches back to the merchant app. This store persists the billing agreement token and
+ * session metadata across that round trip so the SDK can tokenize directly with BTGW
+ * without a URL return.
+ *
+ * A [CompletableDeferred] ensures exactly one BTGW tokenization call is made, even when
+ * multiple entry points (handle-return NoResult and user re-click) race to tokenize.
+ *
+ * This class must outlive individual [PayPalClient] instances because the client is
+ * per-Fragment and may be GC'd during the app switch.
+ */
+internal class PendingPaymentStore {
+
+    /**
+     * Captured session data needed to tokenize a billing agreement without a URL return.
+     *
+     * @property baToken the billing agreement token from the PayPal approval URL
+     * @property clientMetadataId correlation ID for fraud detection
+     * @property merchantAccountId optional merchant account override
+     * @property intent the PayPal payment intent string value (e.g. "authorize", "sale")
+     * @property paymentType always "billing-agreement" for auto-link flows
+     * @property timestampMs creation time for TTL expiry checks
+     * @property ttlMs time-to-live in milliseconds (default 30 minutes)
+     */
+    data class PendingSession(
+        val baToken: String,
+        val clientMetadataId: String?,
+        val merchantAccountId: String?,
+        val intent: String?,
+        val paymentType: String,
+        val timestampMs: Long = System.currentTimeMillis(),
+        val ttlMs: Long = TTL_MS
+    ) {
+        /** Returns true if this session has exceeded its time-to-live. */
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestampMs > ttlMs
+    }
+
+    var pendingSession: PendingSession? = null
+    var tokenizeDeferred: CompletableDeferred<PayPalAccountNonce>? = null
+
+    /** Resolved nonce from auto-link tokenization. Volatile for safe cross-thread reads. */
+    @Volatile
+    var autoLinkNonce: PayPalAccountNonce? = null
+
+    /**
+     * Returns an existing or newly created [CompletableDeferred] along with a flag
+     * indicating whether this caller is the initiator (created the deferred).
+     *
+     * The initiator is responsible for making the BTGW call and completing the deferred.
+     * Subsequent callers receive the same deferred and should await it.
+     *
+     * @return pair of (deferred, isInitiator)
+     */
+    @Synchronized
+    fun getOrCreateDeferred(): Pair<CompletableDeferred<PayPalAccountNonce>, Boolean> {
+        val existing = tokenizeDeferred
+        if (existing != null) return Pair(existing, false)
+        val new = CompletableDeferred<PayPalAccountNonce>()
+        tokenizeDeferred = new
+        return Pair(new, true)
+    }
+
+    /** Resets all state and cancels any in-flight deferred. */
+    fun clear() {
+        pendingSession = null
+        tokenizeDeferred?.cancel()
+        tokenizeDeferred = null
+        autoLinkNonce = null
+    }
+
+    companion object {
+        /** Default session TTL: 30 minutes. */
+        internal const val TTL_MS = 30 * 60 * 1000L
+
+        val instance by lazy { PendingPaymentStore() }
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AppForegroundDetectorUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AppForegroundDetectorUnitTest.kt
@@ -1,0 +1,89 @@
+package com.braintreepayments.api.paypal
+
+import androidx.lifecycle.LifecycleOwner
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppForegroundDetectorUnitTest {
+
+    private val owner = mockk<LifecycleOwner>(relaxed = true)
+
+    @Test
+    fun `onStop transitions SWITCH_LAUNCHED to AWAITING_RETURN`() {
+        val store = PendingPaymentStore().apply { state = PendingPaymentStore.State.SWITCH_LAUNCHED }
+        val sut = AppForegroundDetector(store)
+
+        sut.onStop(owner)
+
+        assertEquals(PendingPaymentStore.State.AWAITING_RETURN, store.state)
+    }
+
+    @Test
+    fun `onStop is a no-op when not SWITCH_LAUNCHED`() {
+        val store = PendingPaymentStore().apply { state = PendingPaymentStore.State.IDLE }
+        val sut = AppForegroundDetector(store)
+
+        sut.onStop(owner)
+
+        assertEquals(PendingPaymentStore.State.IDLE, store.state)
+    }
+
+    @Test
+    fun `onStart invokes callback when AWAITING_RETURN`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        var invoked = false
+        val store = PendingPaymentStore().apply {
+            state = PendingPaymentStore.State.AWAITING_RETURN
+            onReturnFromAppSwitch = { invoked = true }
+        }
+        val sut = AppForegroundDetector(store, CoroutineScope(dispatcher))
+
+        sut.onStart(owner)
+        advanceUntilIdle()
+
+        assertTrue(invoked)
+    }
+
+    @Test
+    fun `onStart does not invoke callback when state is not AWAITING_RETURN`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        var invoked = false
+        val store = PendingPaymentStore().apply {
+            state = PendingPaymentStore.State.SWITCH_LAUNCHED
+            onReturnFromAppSwitch = { invoked = true }
+        }
+        val sut = AppForegroundDetector(store, CoroutineScope(dispatcher))
+
+        sut.onStart(owner)
+        advanceUntilIdle()
+
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun `onStart no-ops when store cleared before queued attempt runs`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        var invoked = false
+        val store = PendingPaymentStore().apply {
+            state = PendingPaymentStore.State.AWAITING_RETURN
+            onReturnFromAppSwitch = { invoked = true }
+        }
+        val sut = AppForegroundDetector(store, CoroutineScope(dispatcher))
+
+        sut.onStart(owner)
+        // Simulate a URL return's Success clearing the store before the queued attempt runs.
+        store.clear()
+        advanceUntilIdle()
+
+        assertFalse(invoked)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/AutoLinkTokenizeUseCaseUnitTest.kt
@@ -1,0 +1,108 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AutoLinkTokenizeUseCaseUnitTest {
+
+    private val internalPayPalClient: PayPalInternalClient = mockk(relaxed = true)
+    private lateinit var sut: AutoLinkTokenizeUseCase
+
+    @Before
+    fun setup() {
+        sut = AutoLinkTokenizeUseCase(internalPayPalClient)
+    }
+
+    @Test
+    fun `invoke tokenizes with correct PayPalAccount fields`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TEST123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = "merchant-acct",
+            intent = "authorize",
+            paymentType = "billing-agreement"
+        )
+
+        val result = sut(session)
+
+        assertSame(expectedNonce, result)
+
+        val captured = accountSlot.captured
+        assertEquals("metadata-id", captured.clientMetadataId)
+        assertEquals("merchant-acct", captured.merchantAccountId)
+        assertEquals("billing-agreement", captured.paymentType)
+        assertEquals(PayPalPaymentIntent.AUTHORIZE, captured.intent)
+    }
+
+    @Test
+    fun `invoke builds urlResponseData with billing_agreement_token`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-TOKEN-ABC",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        val urlResponseData = accountSlot.captured.urlResponseData
+        assertEquals("BA-TOKEN-ABC", urlResponseData.getString("billing_agreement_token"))
+        assertEquals("web", urlResponseData.getString("response_type"))
+    }
+
+    @Test
+    fun `invoke with null intent sets null on PayPalAccount`() = runTest {
+        val expectedNonce = mockk<PayPalAccountNonce>()
+        val accountSlot = slot<PayPalAccount>()
+        coEvery { internalPayPalClient.tokenize(capture(accountSlot)) } returns expectedNonce
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+
+        assertEquals(null, accountSlot.captured.intent)
+    }
+
+    @Test(expected = Exception::class)
+    fun `invoke propagates tokenization errors`() = runTest {
+        coEvery {
+            internalPayPalClient.tokenize(any())
+        } throws Exception("BTGW error")
+
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+
+        sut(session)
+    }
+}

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -969,6 +969,23 @@ class PayPalClientUnitTest {
     }
 
     @Test
+    fun `tokenize with resolved auto-link nonce returns Success and clears store`() =
+        runTest(testDispatcher) {
+            val nonce = mockk<PayPalAccountNonce>(relaxed = true)
+            pendingPaymentStore.autoLinkNonce = nonce
+            pendingPaymentStore.pendingSession = autoLinkSession()
+            val braintreeClient = MockkBraintreeClientBuilder().build()
+            val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+            val result = sut.tokenize(PayPalPaymentAuthResult.Success(nonce))
+
+            assertTrue(result is PayPalResult.Success)
+            assertEquals(nonce, (result as PayPalResult.Success).nonce)
+            assertNull(pendingPaymentStore.pendingSession)
+            verify { braintreeClient.sendAnalyticsEvent(eq(PayPalAnalytics.TOKENIZATION_SUCCEEDED), any()) }
+        }
+
+    @Test
     fun `tokenize with autoLinkPending returns Failure when BTGW fails`() = runTest(testDispatcher) {
         coEvery { autoLinkTokenizeUseCase(any()) } throws BraintreeException("BTGW 422")
         pendingPaymentStore.pendingSession = autoLinkSession()

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -15,6 +15,8 @@ import com.braintreepayments.api.core.Configuration.Companion.fromJson
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.LinkType
 import com.braintreepayments.api.core.MerchantRepository
+import com.braintreepayments.api.core.AppSwitchRepository
+import com.braintreepayments.api.core.usecase.GetAppSwitchUseCase
 import com.braintreepayments.api.core.usecase.GetAppLinksCompatibleBrowserUseCase
 import com.braintreepayments.api.core.usecase.GetDefaultAppUseCase
 import com.braintreepayments.api.core.usecase.GetReturnLinkTypeUseCase
@@ -42,6 +44,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -68,6 +71,10 @@ class PayPalClientUnitTest {
         mockk<GetReturnLinkTypeUseCase>(relaxed = true)
     private val getReturnLinkUseCase: GetReturnLinkUseCase = mockk(relaxed = true)
     private val analyticsParamRepository: AnalyticsParamRepository = mockk(relaxed = true)
+    private val appSwitchRepository: AppSwitchRepository = mockk(relaxed = true)
+    private val getAppSwitchUseCase: GetAppSwitchUseCase = mockk(relaxed = true)
+    private val pendingPaymentStore = PendingPaymentStore()
+    private val autoLinkTokenizeUseCase: AutoLinkTokenizeUseCase = mockk(relaxed = true)
 
     @Before
     @Throws(JSONException::class)
@@ -935,21 +942,138 @@ class PayPalClientUnitTest {
         verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
     }
 
+    // region auto-link
+
+    private fun autoLinkSession() = PendingPaymentStore.PendingSession(
+        baToken = "BA-XYZ",
+        clientMetadataId = "cmid",
+        merchantAccountId = null,
+        intent = "authorize",
+        paymentType = "billing-agreement"
+    )
+
+    @Test
+    fun `tokenize with autoLinkPending returns Success and clears store`() = runTest(testDispatcher) {
+        val nonce = mockk<PayPalAccountNonce>(relaxed = true)
+        coEvery { autoLinkTokenizeUseCase(any()) } returns nonce
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Success)
+        assertEquals(nonce, (result as PayPalResult.Success).nonce)
+        assertNull(pendingPaymentStore.pendingSession)
+        verify { braintreeClient.sendAnalyticsEvent(eq(PayPalAnalytics.TOKENIZATION_SUCCEEDED), any()) }
+    }
+
+    @Test
+    fun `tokenize with autoLinkPending returns Failure when BTGW fails`() = runTest(testDispatcher) {
+        coEvery { autoLinkTokenizeUseCase(any()) } throws BraintreeException("BTGW 422")
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Failure)
+        assertNull(pendingPaymentStore.pendingSession)
+        verify { braintreeClient.sendAnalyticsEvent(eq(PayPalAnalytics.AUTO_LINK_TOKENIZE_FAILED), any()) }
+    }
+
+    @Test
+    fun `tokenize with autoLinkPending returns Failure when no session`() = runTest(testDispatcher) {
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        val result = sut.tokenize(PayPalPaymentAuthResult.Success(autoLinkPending = true))
+
+        assertTrue(result is PayPalResult.Failure)
+    }
+
+    @Test
+    fun `createPaymentAuthRequest re-click delivers nonce via tokenizeCallback`() = runTest(testDispatcher) {
+        every { getAppSwitchUseCase() } returns true
+        val nonce = mockk<PayPalAccountNonce>(relaxed = true)
+        coEvery { autoLinkTokenizeUseCase(any()) } returns nonce
+        pendingPaymentStore.pendingSession = autoLinkSession()
+        val braintreeClient = MockkBraintreeClientBuilder().build()
+        val sut = testPaypalClient(braintreeClient, mockk(relaxed = true), testDispatcher, this)
+
+        sut.createPaymentAuthRequest(activity, PayPalVaultRequest(true), paymentAuthCallback, payPalTokenizeCallback)
+        advanceUntilIdle()
+
+        verify { payPalTokenizeCallback.onPayPalResult(any<PayPalResult.Success>()) }
+        verify(exactly = 0) { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+        assertNull(pendingPaymentStore.pendingSession)
+    }
+
+    @Test
+    fun `createPaymentAuthRequest re-click falls through to normal flow when no session`() =
+        runTest(testDispatcher) {
+            every { getAppSwitchUseCase() } returns true
+            val payPalVaultRequest = PayPalVaultRequest(true)
+            val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+                payPalVaultRequest, null, "https://example.com/approval/url",
+                "sample-client-metadata-id", null, "https://example.com/success/url"
+            )
+            val payPalInternalClient =
+                MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest).build()
+            val braintreeClient =
+                MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+            val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this)
+
+            sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback, payPalTokenizeCallback)
+            advanceUntilIdle()
+
+            verify { paymentAuthCallback.onPayPalPaymentAuthRequest(any()) }
+            verify(exactly = 0) { payPalTokenizeCallback.onPayPalResult(any()) }
+        }
+
+    @Test
+    fun `createPaymentAuthRequest stores pending session for app-switch vault flow`() =
+        runTest(testDispatcher) {
+            every { getAppSwitchUseCase() } returns true
+            every { getReturnLinkUseCase.invoke(any()) } returns AppLink("www.example.com".toUri())
+            val payPalVaultRequest = PayPalVaultRequest(true)
+            val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+                payPalVaultRequest, null, "https://example.com/approval/url?ba_token=BA-STORED",
+                "sample-client-metadata-id", null, "https://example.com/success/url"
+            )
+            val payPalInternalClient =
+                MockkPayPalInternalClientBuilder().sendRequestSuccess(paymentAuthRequest).build()
+            val braintreeClient =
+                MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+            val sut = testPaypalClient(braintreeClient, payPalInternalClient, testDispatcher, this)
+
+            sut.createPaymentAuthRequest(activity, payPalVaultRequest, paymentAuthCallback)
+            advanceUntilIdle()
+
+            assertEquals("BA-STORED", pendingPaymentStore.pendingSession?.baToken)
+        }
+
+    // endregion auto-link
+
     private fun testPaypalClient(
         braintreeClient: BraintreeClient,
         payPalInternalClient: PayPalInternalClient,
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
         scope: CoroutineScope = CoroutineScope(dispatcher)
     ): PayPalClient = PayPalClient(
-        braintreeClient,
-        payPalInternalClient,
-        merchantRepository,
-        getDefaultAppUseCase,
-        getAppLinksCompatibleBrowserUseCase,
-        getReturnLinkTypeUseCase,
-        getReturnLinkUseCase,
-        analyticsParamRepository,
-        dispatcher,
-        scope
+        braintreeClient = braintreeClient,
+        internalPayPalClient = payPalInternalClient,
+        merchantRepository = merchantRepository,
+        getDefaultAppUseCase = getDefaultAppUseCase,
+        getAppLinksCompatibleBrowserUseCase = getAppLinksCompatibleBrowserUseCase,
+        getReturnLinkTypeUseCase = getReturnLinkTypeUseCase,
+        getReturnLinkUseCase = getReturnLinkUseCase,
+        analyticsParamRepository = analyticsParamRepository,
+        appSwitchRepository = appSwitchRepository,
+        getAppSwitchUseCase = getAppSwitchUseCase,
+        pendingPaymentStore = pendingPaymentStore,
+        autoLinkTokenizeUseCase = autoLinkTokenizeUseCase,
+        dispatcher = dispatcher,
+        coroutineScope = scope
     )
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.json.JSONException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -44,6 +45,8 @@ class PayPalLauncherUnitTest {
     private val isPurchase = true
     private val recurringBillingPlanType = PayPalRecurringBillingPlanType.RECURRING.name
 
+    private val pendingPaymentStore = PendingPaymentStore()
+
     private lateinit var sut: PayPalLauncher
 
     @Before
@@ -63,9 +66,18 @@ class PayPalLauncherUnitTest {
             getAppSwitchUseCase = getAppSwitchUseCase,
             resolvePayPalUseCase = resolvePayPalUseCase,
             lazyAnalyticsClient = lazy { analyticsClient },
-            analyticsParamRepository = analyticsParamRepository
+            analyticsParamRepository = analyticsParamRepository,
+            pendingPaymentStore = pendingPaymentStore
         )
     }
+
+    private fun pendingSession() = PendingPaymentStore.PendingSession(
+        baToken = paymentToken,
+        clientMetadataId = "cmid",
+        merchantAccountId = null,
+        intent = "authorize",
+        paymentType = "billing-agreement"
+    )
 
     @Test
     fun `launch starts browser switch and returns pending request`() {
@@ -539,6 +551,61 @@ class PayPalLauncherUnitTest {
 
         assertSame(PayPalAnalytics.HANDLE_RETURN_NO_RESULT, slot1.captured)
         assertEquals(paymentToken, slot2.captured.contextId)
+    }
+
+    @Test
+    fun `handleReturnToApp when URL return succeeds clears pending auto-link session`() {
+        pendingPaymentStore.pendingSession = pendingSession()
+        val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns browserSwitchFinalResult
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.Success)
+        assertNull(pendingPaymentStore.pendingSession)
+    }
+
+    @Test
+    fun `handleReturnToApp NoResult with valid pending session returns auto-link pending`() {
+        pendingPaymentStore.pendingSession = pendingSession()
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns BrowserSwitchFinalResult.NoResult
+
+        val slot1 = CapturingSlot<String>()
+        every { analyticsClient.sendEvent(capture(slot1), any()) } returns Unit
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.Success)
+        assertTrue((paymentAuthResult as PayPalPaymentAuthResult.Success).autoLinkPending)
+        assertSame(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_PENDING, slot1.captured)
+    }
+
+    @Test
+    fun `handleReturnToApp NoResult with expired pending session returns NoResult`() {
+        pendingPaymentStore.pendingSession = pendingSession().copy(
+            timestampMs = 0L,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns BrowserSwitchFinalResult.NoResult
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.NoResult)
     }
 
     @Test

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -591,6 +591,27 @@ class PayPalLauncherUnitTest {
     }
 
     @Test
+    fun `handleReturnToApp NoResult with resolved auto-link nonce returns Success with nonce`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        pendingPaymentStore.autoLinkNonce = nonce
+        every {
+            browserSwitchClient.completeRequest(intent, pendingRequestString)
+        } returns BrowserSwitchFinalResult.NoResult
+
+        val slot1 = CapturingSlot<String>()
+        every { analyticsClient.sendEvent(capture(slot1), any()) } returns Unit
+
+        val paymentAuthResult = sut.handleReturnToApp(
+            PayPalPendingRequest.Started(pendingRequestString),
+            intent
+        )
+
+        assertTrue(paymentAuthResult is PayPalPaymentAuthResult.Success)
+        assertSame(nonce, (paymentAuthResult as PayPalPaymentAuthResult.Success).autoLinkNonce)
+        assertSame(PayPalAnalytics.AUTO_LINK_HANDLE_RETURN_SUCCEEDED, slot1.captured)
+    }
+
+    @Test
     fun `handleReturnToApp NoResult with expired pending session returns NoResult`() {
         pendingPaymentStore.pendingSession = pendingSession().copy(
             timestampMs = 0L,

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -2,6 +2,7 @@ package com.braintreepayments.api.paypal
 
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -16,6 +17,11 @@ class PendingPaymentStoreUnitTest {
     @Before
     fun setup() {
         sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial state is IDLE`() {
+        assertEquals(PendingPaymentStore.State.IDLE, sut.state)
     }
 
     @Test
@@ -76,6 +82,7 @@ class PendingPaymentStoreUnitTest {
     @Test
     fun `clear resets all state`() {
         val nonce = mockk<PayPalAccountNonce>()
+        sut.state = PendingPaymentStore.State.AWAITING_RETURN
         sut.pendingSession = PendingPaymentStore.PendingSession(
             baToken = "BA-123",
             clientMetadataId = null,
@@ -88,6 +95,7 @@ class PendingPaymentStoreUnitTest {
 
         sut.clear()
 
+        assertEquals(PendingPaymentStore.State.IDLE, sut.state)
         assertNull(sut.pendingSession)
         assertNull(sut.tokenizeDeferred)
         assertNull(sut.autoLinkNonce)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PendingPaymentStoreUnitTest.kt
@@ -1,0 +1,115 @@
+package com.braintreepayments.api.paypal
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PendingPaymentStoreUnitTest {
+
+    private lateinit var sut: PendingPaymentStore
+
+    @Before
+    fun setup() {
+        sut = PendingPaymentStore()
+    }
+
+    @Test
+    fun `initial pendingSession is null`() {
+        assertNull(sut.pendingSession)
+    }
+
+    @Test
+    fun `initial autoLinkNonce is null`() {
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `PendingSession isExpired returns false when within TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = "metadata-id",
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis(),
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertFalse(session.isExpired())
+    }
+
+    @Test
+    fun `PendingSession isExpired returns true when past TTL`() {
+        val session = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement",
+            timestampMs = System.currentTimeMillis() - PendingPaymentStore.TTL_MS - 1,
+            ttlMs = PendingPaymentStore.TTL_MS
+        )
+        assertTrue(session.isExpired())
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates new deferred on first call`() {
+        val (deferred, isInitiator) = sut.getOrCreateDeferred()
+        assertTrue(isInitiator)
+        assertSame(deferred, sut.tokenizeDeferred)
+    }
+
+    @Test
+    fun `getOrCreateDeferred returns existing deferred on second call`() {
+        val (first, isFirstInitiator) = sut.getOrCreateDeferred()
+        val (second, isSecondInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isFirstInitiator)
+        assertFalse(isSecondInitiator)
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val nonce = mockk<PayPalAccountNonce>()
+        sut.pendingSession = PendingPaymentStore.PendingSession(
+            baToken = "BA-123",
+            clientMetadataId = null,
+            merchantAccountId = null,
+            intent = null,
+            paymentType = "billing-agreement"
+        )
+        sut.tokenizeDeferred = CompletableDeferred()
+        sut.autoLinkNonce = nonce
+
+        sut.clear()
+
+        assertNull(sut.pendingSession)
+        assertNull(sut.tokenizeDeferred)
+        assertNull(sut.autoLinkNonce)
+    }
+
+    @Test
+    fun `clear cancels active deferred`() {
+        val deferred = CompletableDeferred<PayPalAccountNonce>()
+        sut.tokenizeDeferred = deferred
+
+        sut.clear()
+
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun `getOrCreateDeferred creates fresh deferred after clear`() {
+        val (first, _) = sut.getOrCreateDeferred()
+        sut.clear()
+        val (second, isInitiator) = sut.getOrCreateDeferred()
+
+        assertTrue(isInitiator)
+        assertFalse(first === second)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.13.2"
+gradle = "8.9.1"
 kotlinGradlePlugin = "1.8.0"
 gradleNexusPublish = "1.1.0"
 kotlin = "1.9.10"
@@ -57,6 +57,7 @@ androidx-annotation = { group = "androidx.annotation", name = "annotation", vers
 androidx-autofill = { group = "androidx.autofill", name = "autofill", version.ref = "androidxAutofill" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidxLifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-navigation-safe-args-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigationSafeArgsGradlePlugin" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "androidxWork" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidxWork" }
@@ -75,7 +76,7 @@ kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", vers
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
-gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
 cardinal = { group = "org.jfrog.cardinalcommerce.gradle", name = "cardinalmobilesdk", version.ref = "cardinal" }
 paypal-messages = { module = "com.paypal.messages:paypal-messages", version.ref = "paypalMessages" }
@@ -123,8 +124,8 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 google-pay-button = { module = "com.google.pay.button:compose-pay-button", version.ref = "googlePayButton" }
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
-android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+android-application = { id = "com.android.application", version.ref = "gradle" }
+android-library = { id = "com.android.library", version.ref = "gradle" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary of changes

Adds `AppForegroundDetector`, a merchant-independent foreground trigger for auto-link tokenization, closing the gap left by PR 3/PR 4: integrations where `handleReturnToApp` is never invoked on a manual return (e.g. `onNewIntent`/`singleTop` activities that receive no new intent) still get auto-linked once the app returns to the foreground. With this PR merged, the full original PR #1634 feature set is complete.

> **Note:** This PR is stacked on the PR 4 branch (not yet opened separately) — the diff includes all of PRs 1-4's commits plus this PR's new commit. Please review/merge #1640, #1641, PR 3, and PR 4 first; once merged, this PR's diff shrinks to just the new commit.

### Background

PR 3 covered `handleReturnToApp` being called with `NoResult`. Some integrations never call it at all on a manual return (e.g. `singleTop` with no redelivered intent) — the BA is approved on PayPal's side but the SDK has no signal to act on.

This PR adds `AppForegroundDetector`, a `DefaultLifecycleObserver` registered once via `ProcessLifecycleOwner` from `PendingPaymentStore.instance` (guarded by a try/catch that silently disables the feature if unavailable — flagged in code review CR-22, Warning #6, as an intentionally broad catch to avoid breaking unrelated flows).

`PendingPaymentStore` gains a state machine: `SWITCH_LAUNCHED` on launch, `AWAITING_RETURN` on `onStop`, and on `onStart` the detector attempts auto-link tokenization. Race resolution is timer-free: the foreground attempt re-checks state inside the coroutine, and a real URL return's `Success` clears the store first (-> `IDLE`), winning the race. The nonce is delivered via `handleReturnToApp` (pre-resolved) or a re-click; the `CompletableDeferred` from PR 1 still guarantees exactly one BTGW call.

**Dependency:** adds `androidx-lifecycle-process`.
**Analytics added:** `paypal:tokenize:auto-link:handle-return:succeeded`.

**Changes:** `AppForegroundDetector.kt` (new); `PendingPaymentStore.kt` (state machine + registration); `PayPalClient.kt`/`PayPalLauncher.kt`/`PayPalPaymentAuthResult.kt` (pre-resolved-nonce interop); `PayPalAnalytics.kt` (new event); `PayPal/build.gradle`/`gradle/libs.versions.toml` (dependency); `AppForegroundDetectorUnitTest.kt` (new) plus added coverage in `PayPalClientUnitTest.kt`, `PayPalLauncherUnitTest.kt`, `PendingPaymentStoreUnitTest.kt`.

### Steps to Test

**Unit tests:**
1. `./gradlew :PayPal:testDebugUnitTest --tests "*.AppForegroundDetectorUnitTest"`
2. `./gradlew :PayPal:testDebugUnitTest --tests "*.PendingPaymentStoreUnitTest"`
3. Confirm state transitions and race resolution (a `Success` return wins over foreground-trigger) pass.

**Manual (Demo app):**
1. Build/run the Demo app with an activity config that doesn't re-invoke `handleReturnToApp` on manual return.
2. Start a PayPal vault checkout, approve the BA, manually switch back before any redirect fires.
3. Confirm a nonce resolves automatically on foreground (no re-click needed), and a later delayed `handleReturnToApp` receives the already-resolved nonce (no duplicate BTGW call).

### AI Usage

**Which AI Agent Was Used?**
- [x] Claude

**How was AI used?**
Code generation and unit test authoring for `AppForegroundDetector` and the `PendingPaymentStore` state machine, based on an existing HLD/LLD design and a prior reference implementation.

**Estimated AI Code Contribution**
- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected (manually verified the foreground auto-link path in the Demo app, plus unit tests)

### Authors
- @pedrofsn

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

1. Comment `/inner source` — adds labels, opens as draft.
2. Reviewed/approved by your team's technical lead (no LGTM-only reviews).
3. Comment `/ready` once done.
4. PR comments addressed within 24 hours, or move back to draft.

### Inner Source Checklist
- [x] Added all labels to the PR
- [x] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable — recommended since this completes the merchant-independent auto-link path; can be added during review
- [ ] All upstream dependencies are merged in and this PR can be released at any time — **this is PR 5 of 5 in a stacked series, based on PR 4 (not yet opened, branch `paypal-autolink-launcher-wiring`); all target `feature/paypal-autolink-manual-return`**
- [x] Unit tests and builds have been run locally and pass/compile as expected

## PR series

Part of a 5-PR series re-splitting the original "auto-link on manual return" feature (previously opened as #1633 and #1634, closed for being too large to review):

1. `PendingPaymentStore` (session persistence) - [#1640](https://github.com/braintree/braintree_android/pull/1640)
2. `AutoLinkTokenizeUseCase` (tokenization logic) - [#1641](https://github.com/braintree/braintree_android/pull/1641) - stacked on PR 1
3. `PayPalClient` wiring (handleReturnToApp + re-click) - stacked on PR 2
4. `PayPalLauncher`/`PayPalPaymentAuthResult`/Demo wiring - stacked on PR 3
5. **This PR** - `AppForegroundDetector` merchant-independent foreground trigger - stacked on PR 4

Please review/merge in order 1 -> 5.
