### PR TITLE
Unify unit test names

### DIFF
--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressAnalyticsUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class AmericanExpressAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics constants match expected amex rewards balance event names`() {
         assertEquals(
             "amex:rewards-balance:started",
             AmericanExpressAnalytics.REWARDS_BALANCE_STARTED

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
@@ -37,7 +37,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_sendsGETRequestForAmexAwardsBalance() = runTest {
+    fun `when getRewardsBalance is called, GET request includes nonce and currency code in query params`() = runTest {
         val braintreeClient = mockk<BraintreeClient>(relaxed = true)
         coEvery { braintreeClient.sendGET(any()) } returns """
         {
@@ -67,7 +67,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_callsListenerWithRewardsBalanceOnSuccess() = runTest {
+    fun `when getRewardsBalance receives a successful response, callback receives success result with rewards balance`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_SUCCESS).build()
 
@@ -95,7 +95,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_callsListenerWithRewardsBalanceWithErrorCode_OnIneligibleCard() = runTest {
+    fun `when getRewardsBalance is called and card is ineligible, callback receives success result with error code`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_INELIGIBLE_CARD).build()
         val testDispatcher = StandardTestDispatcher(testScheduler)
@@ -122,7 +122,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_callsListenerWithRewardsBalanceWithErrorCode_OnInsufficientPoints() = runTest {
+    fun `when getRewardsBalance is called and points are insufficient, callback receives success result with error code`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_INSUFFICIENT_POINTS).build()
         val testDispatcher = StandardTestDispatcher(testScheduler)
@@ -149,7 +149,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_callsBackFailure_OnHttpError() = runTest {
+    fun `when getRewardsBalance http request errors, callback receives failure result`() = runTest {
         val expectedError = IOException("error")
         val braintreeClient = MockkBraintreeClientBuilder().sendGetErrorResponse(
             expectedError).build()
@@ -169,7 +169,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_sendsAnalyticsEventOnSuccess() = runTest {
+    fun `when getRewardsBalance succeeds, started and succeeded analytics events are sent`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(
             Fixtures.AMEX_REWARDS_BALANCE_SUCCESS).build()
         val testDispatcher = StandardTestDispatcher(testScheduler)
@@ -185,7 +185,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_sendsAnalyticsEventOnFailure() = runTest {
+    fun `when getRewardsBalance http request fails, started and failed analytics events are sent with error description`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder().sendGetErrorResponse(
             AuthorizationException("Bad fingerprint")).build()
         val testDispatcher = StandardTestDispatcher(testScheduler)
@@ -203,7 +203,7 @@ class AmericanExpressClientUnitTest {
     }
 
     @Test
-    fun getRewardsBalance_sendsAnalyticsEventOnParseError() = runTest {
+    fun `when getRewardsBalance response has a json parse error, started and failed analytics events are sent with error description`() = runTest {
         val notJson = "Big blob that is not a valid JSON object"
         val braintreeClient = MockkBraintreeClientBuilder().sendGetSuccessfulResponse(notJson).build()
         val testDispatcher = StandardTestDispatcher(testScheduler)

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressClientUnitTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class AmericanExpressClientUnitTest {
 
     private lateinit var amexRewardsCallback: AmericanExpressGetRewardsBalanceCallback

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalanceUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalanceUnitTest.kt
@@ -43,21 +43,6 @@ class AmericanExpressRewardsBalanceUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `fromJson parses successful rewards balance response with points`() {
-        val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_SUCCESS)
-
-        assertEquals("0.0070", rewardsBalance.conversionRate)
-        assertEquals("316795.03", rewardsBalance.currencyAmount)
-        assertEquals("USD", rewardsBalance.currencyIsoCode)
-        assertEquals("715f4712-8690-49ed-8cc5-d7fb1c2d", rewardsBalance.requestId)
-        assertEquals("45256433", rewardsBalance.rewardsAmount)
-        assertEquals("Points", rewardsBalance.rewardsUnit)
-        assertNull(rewardsBalance.errorMessage)
-        assertNull(rewardsBalance.errorCode)
-    }
-
-    @Test
-    @Throws(JSONException::class)
     fun `fromJson parses response with error code for insufficient points`() {
         val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_INSUFFICIENT_POINTS)
 

--- a/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalanceUnitTest.kt
+++ b/AmericanExpress/src/test/java/com/braintreepayments/api/americanexpress/AmericanExpressRewardsBalanceUnitTest.kt
@@ -13,7 +13,7 @@ import org.robolectric.RobolectricTestRunner
 class AmericanExpressRewardsBalanceUnitTest {
     @Test
     @Throws(JSONException::class)
-    fun fromJson_parsesResponse() {
+    fun `fromJson parses successful rewards balance response`() {
         val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_SUCCESS)
 
         assertEquals("0.0070", rewardsBalance.conversionRate)
@@ -28,7 +28,7 @@ class AmericanExpressRewardsBalanceUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun fromJson_parsesResponseForIneligibleCard() {
+    fun `fromJson parses response with error code for ineligible card`() {
         val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_INELIGIBLE_CARD)
 
         assertNull(rewardsBalance.conversionRate)
@@ -43,7 +43,7 @@ class AmericanExpressRewardsBalanceUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun parcelsCorrectly() {
+    fun `fromJson parses successful rewards balance response with points`() {
         val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_SUCCESS)
 
         assertEquals("0.0070", rewardsBalance.conversionRate)
@@ -58,7 +58,7 @@ class AmericanExpressRewardsBalanceUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun parcelsCorrectly_forErrorResponse() {
+    fun `fromJson parses response with error code for insufficient points`() {
         val rewardsBalance = fromJson(Fixtures.AMEX_REWARDS_BALANCE_INSUFFICIENT_POINTS)
 
         assertNull(rewardsBalance.conversionRate)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ApiClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ApiClientUnitTest.kt
@@ -36,7 +36,7 @@ class ApiClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenizeREST_setsSessionIdBeforeTokenizing() = runTest(testDispatcher) {
+    fun `when tokenizeREST is called, session id is set on card before sending POST`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLDisabledConfig)
             .sendPostSuccessfulResponse("{}")
@@ -76,7 +76,7 @@ class ApiClientUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     @Throws(BraintreeException::class, InvalidArgumentException::class, JSONException::class)
-    fun tokenizeGraphQL_tokenizesCardsWithGraphQL() = runTest(testDispatcher) {
+    fun `when tokenizeGraphQL is called, card is tokenized via sendGraphQLPOST and not sendPOST`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -98,7 +98,7 @@ class ApiClientUnitTest {
     }
 
     @Test
-    fun tokenizeREST_tokenizesPaymentMethodsWithREST() = runTest(testDispatcher) {
+    fun `when tokenizeREST is called, payment method is tokenized via REST and not GraphQL`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .sendPostSuccessfulResponse("{}")
@@ -134,7 +134,7 @@ class ApiClientUnitTest {
     }
 
     @Test
-    fun versionedPath_returnsv1Path() {
+    fun `when versionedPath is called, the given path is prefixed with v1`() {
         assertEquals("/v1/test/path", ApiClient.versionedPath("test/path"))
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ApiClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ApiClientUnitTest.kt
@@ -17,6 +17,7 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class ApiClientUnitTest {
 
     private lateinit var analyticsParamRepository: AnalyticsParamRepository

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/AuthorizationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/AuthorizationUnitTest.kt
@@ -10,43 +10,43 @@ import org.junit.runner.RunWith
 @RunWith(RobolectricTestRunner::class)
 class AuthorizationUnitTest {
     @Test
-    fun fromString_returnsValidClientTokenWhenBase64() {
+    fun `when given a base64 client token, fromString returns a ClientToken`() {
         val authorization = fromString(Fixtures.BASE64_CLIENT_TOKEN)
         assertTrue(authorization is ClientToken)
     }
 
     @Test
-    fun fromString_returnsValidClientTokenWhenBase64IncludesSpaces() {
+    fun `when given a base64 client token with spaces, fromString returns a ClientToken`() {
         val authorization = fromString(Fixtures.BASE64_CLIENT_TOKEN_WITH_SPACES)
         assertTrue(authorization is ClientToken)
     }
 
     @Test
-    fun fromString_returnsValidTokenizationKey() {
+    fun `when given a tokenization key, fromString returns a TokenizationKey`() {
         val authorization = fromString(Fixtures.TOKENIZATION_KEY)
         assertTrue(authorization is TokenizationKey)
     }
 
     @Test
-    fun fromString_returnsValidTokenizationKeyIncludesSpaces() {
+    fun `when given a tokenization key with spaces, fromString returns a TokenizationKey`() {
         val authorization = fromString(Fixtures.TOKENIZATION_KEY_WITH_SPACES)
         assertTrue(authorization is TokenizationKey)
     }
 
     @Test
-    fun fromString_whenPassedNull_returnsInvalidToken() {
+    fun `when passed null, fromString returns InvalidAuthorization`() {
         val result = fromString(null)
         assertTrue(result is InvalidAuthorization)
     }
 
     @Test
-    fun fromString_whenPassedAnEmptyString_returnsInvalidToken() {
+    fun `when passed an empty string, fromString returns InvalidAuthorization`() {
         val result = fromString("")
         assertTrue(result is InvalidAuthorization)
     }
 
     @Test
-    fun fromString_whenPassedJunk_returnsInvalidToken() {
+    fun `when passed a junk string, fromString returns InvalidAuthorization`() {
         val result = fromString("not authorization")
         assertTrue(result is InvalidAuthorization)
     }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
@@ -33,6 +33,7 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class BraintreeClientUnitTest {
 
     private lateinit var authorization: Authorization

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeClientUnitTest.kt
@@ -77,7 +77,7 @@ class BraintreeClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun configuration_onAuthorizationAndConfigurationLoadSuccess_forwardsResult() = runTest(testDispatcher) {
+    fun `when configuration load succeeds, getConfiguration returns the loaded configuration`() = runTest(testDispatcher) {
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -95,7 +95,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun configuration_forwardsConfigurationLoaderError() = runTest(testDispatcher) {
+    fun `when configuration load fails, getConfiguration throws the configuration loader error`() = runTest(testDispatcher) {
         val configFetchError = Exception("config fetch error")
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(configFetchError)
@@ -116,7 +116,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun prefetchConfiguration_whenConfigurationLoaderThrowsJSONException_doesNotCrash() = runTest(testDispatcher) {
+    fun `when configuration loader throws JSONException during prefetch, BraintreeClient does not crash`() = runTest(testDispatcher) {
         val jsonException = JSONException("malformed JSON")
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(jsonException)
@@ -132,7 +132,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun configuration_whenInvalidAuth_callsBackAuthError() = runTest(testDispatcher) {
+    fun `when authorization is invalid, getConfiguration throws the auth error`() = runTest(testDispatcher) {
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(expectedAuthException)
             .build()
@@ -153,7 +153,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGET_onGetConfigurationSuccess_forwardsRequestToHttpClient() = runTest(testDispatcher) {
+    fun `when getConfiguration succeeds, sendGET forwards the request to httpClient`() = runTest(testDispatcher) {
         val configuration = mockk<Configuration>(relaxed = true)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -179,7 +179,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGET_onGetConfigurationFailure_forwardsErrorToCallback() = runTest(testDispatcher) {
+    fun `when getConfiguration fails, sendGET throws the configuration error`() = runTest(testDispatcher) {
         val configError = Exception("configuration error")
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(configError)
@@ -200,7 +200,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGET_whenInvalidAuth_callsBackAuthError() = runTest(testDispatcher) {
+    fun `when authorization is invalid, sendGET throws the auth error`() = runTest(testDispatcher) {
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(expectedAuthException)
             .build()
@@ -221,7 +221,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendPOST_onGetConfigurationSuccess_forwardsRequestToHttpClient() = runTest(testDispatcher) {
+    fun `when getConfiguration succeeds, sendPOST forwards the request to httpClient`() = runTest(testDispatcher) {
         val configuration = mockk<Configuration>(relaxed = true)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -259,7 +259,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendPOST_onGetConfigurationFailure_throwsException() = runTest(testDispatcher) {
+    fun `when getConfiguration fails, sendPOST throws the configuration error`() = runTest(testDispatcher) {
         val exception = Exception("configuration error")
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(exception)
@@ -280,7 +280,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun `sendPOST defaults additionalHeaders to an empty map`() = runTest(testDispatcher) {
+    fun `when sendPOST is called without additionalHeaders, an empty map is used`() = runTest(testDispatcher) {
         val configuration = mockk<Configuration>(relaxed = true)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -322,7 +322,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun `sendPOST sends additionalHeaders to httpClient post`() = runTest(testDispatcher) {
+    fun `when sendPOST is called with additionalHeaders, they are forwarded to httpClient post`() = runTest(testDispatcher) {
         val configuration = mockk<Configuration>(relaxed = true)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -366,7 +366,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendPOST_whenInvalidAuth_callsBackAuthError() = runTest(testDispatcher) {
+    fun `when authorization is invalid, sendPOST throws the auth error`() = runTest(testDispatcher) {
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(expectedAuthException)
             .build()
@@ -387,7 +387,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGraphQLPOST_onGetConfigurationSuccess_forwardsRequestToHttpClient() = runTest(testDispatcher) {
+    fun `when getConfiguration succeeds, sendGraphQLPOST forwards the request to graphQLClient`() = runTest(testDispatcher) {
         val configuration = mockk<Configuration>(relaxed = true)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -422,7 +422,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGraphQLPOST_onGetConfigurationFailure_forwardsErrorToCallback() = runTest(testDispatcher) {
+    fun `when getConfiguration fails, sendGraphQLPOST throws the configuration error`() = runTest(testDispatcher) {
         val exception = Exception("configuration error")
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(exception)
@@ -444,7 +444,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun sendGraphQLPOST_whenInvalidAuth_callsBackAuthError() = runTest(testDispatcher) {
+    fun `when authorization is invalid, sendGraphQLPOST throws the auth error`() = runTest(testDispatcher) {
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configurationError(expectedAuthException)
             .build()
@@ -466,7 +466,7 @@ class BraintreeClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendAnalyticsEvent_sendsEventToAnalyticsClient() {
+    fun `when sendAnalyticsEvent is called, event is sent to analyticsClient`() {
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -481,7 +481,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun manifestActivityInfo_forwardsInvocationToManifestValidator() {
+    fun `when getManifestActivityInfo is called, invocation is forwarded to manifestValidator`() {
         val activityInfo = ActivityInfo()
         every {
             manifestValidator.getActivityInfo(applicationContext, FragmentActivity::class.java)
@@ -492,14 +492,14 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun returnUrlScheme_returnsUrlSchemeBasedOnApplicationIdByDefault() {
+    fun `when no returnUrlScheme is provided in constructor, getReturnUrlScheme is based on application id`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val sut = BraintreeClient(context, authorization.toString())
         assertEquals("com.braintreepayments.api.core.test.braintree", sut.getReturnUrlScheme())
     }
 
     @Test
-    fun returnUrlScheme_returnsUrlSchemeDefinedInConstructor() {
+    fun `when a returnUrlScheme is provided in constructor, getReturnUrlScheme returns it`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val returnUrlScheme = "custom-url-scheme"
         val sut = BraintreeClient(
@@ -512,7 +512,7 @@ class BraintreeClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun reportCrash_reportsCrashViaAnalyticsClient() = runTest(testDispatcher) {
+    fun `when reportCrash is called, crash is reported via analyticsClient`() = runTest(testDispatcher) {
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)
@@ -534,7 +534,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun reportCrash_whenConfigurationLoaderThrowsCancellationException_doesNotCrash() =
+    fun `when configuration loader throws CancellationException, reportCrash does not crash`() =
     runTest(testDispatcher) {
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         val configurationLoader = MockkConfigurationLoaderBuilder()
@@ -570,7 +570,7 @@ class BraintreeClientUnitTest {
     }
 
     @Test
-    fun `when BraintreeClient is initialized and appLinkReturnUri is null, it is not set on the MerchantRepository`() {
+    fun `when BraintreeClient is initialized and appLinkReturnUri is null, appLinkReturnUri is not set on the MerchantRepository`() {
         val configuration = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         val configurationLoader = MockkConfigurationLoaderBuilder()
             .configuration(configuration)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeErrorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeErrorUnitTest.kt
@@ -15,7 +15,7 @@ class BraintreeErrorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun parcelsCorrectly() {
+    fun `when BraintreeError is parceled from a field error response, fields survive parceling`() {
         val errorResponse = JSONObject(Fixtures.ERRORS_CREDIT_CARD_ERROR_RESPONSE)
         val errors: List<BraintreeError> =
             BraintreeError.fromJsonArray(errorResponse.getJSONArray("fieldErrors"))
@@ -34,7 +34,7 @@ class BraintreeErrorUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun graphQLErrors_parcelCorrectly() {
+    fun `when BraintreeError is parceled from a GraphQL error response, fields survive parceling`() {
         val errorResponse = JSONObject(Fixtures.ERRORS_GRAPHQL_CREDIT_CARD_ERROR)
         val errors = BraintreeError.fromGraphQLJsonArray(errorResponse.getJSONArray("errors"))
         assertEquals(1, errors.size)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeRequestCodesUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/BraintreeRequestCodesUnitTest.kt
@@ -9,37 +9,37 @@ import org.junit.runners.JUnit4
 class BraintreeRequestCodesUnitTest {
 
     @Test
-    fun threeDSecure() {
+    fun `THREE_D_SECURE request code is 13487`() {
         assertEquals(13487, BraintreeRequestCodes.THREE_D_SECURE.code)
     }
 
     @Test
-    fun venmo() {
+    fun `VENMO request code is 13488`() {
         assertEquals(13488, BraintreeRequestCodes.VENMO.code)
     }
 
     @Test
-    fun paypal() {
+    fun `PAYPAL request code is 13591`() {
         assertEquals(13591, BraintreeRequestCodes.PAYPAL.code)
     }
 
     @Test
-    fun visaCheckout() {
+    fun `VISA_CHECKOUT request code is 13592`() {
         assertEquals(13592, BraintreeRequestCodes.VISA_CHECKOUT.code)
     }
 
     @Test
-    fun googlePay() {
+    fun `GOOGLE_PAY request code is 13593`() {
         assertEquals(13593, BraintreeRequestCodes.GOOGLE_PAY.code)
     }
 
     @Test
-    fun localPayment() {
+    fun `LOCAL_PAYMENT request code is 13596`() {
         assertEquals(13596, BraintreeRequestCodes.LOCAL_PAYMENT.code)
     }
 
     @Test
-    fun sepDebit() {
+    fun `SEPA_DEBIT request code is 13597`() {
         assertEquals(13597, BraintreeRequestCodes.SEPA_DEBIT.code)
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/CardConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/CardConfigurationUnitTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 @RunWith(RobolectricTestRunner::class)
 class CardConfigurationUnitTest {
     @Test
-    fun fromJson_parsesFullInput() {
+    fun `when input contains full card configuration data, all fields are parsed`() {
         val input = JSONObject()
             .put("collectDeviceData", true)
             .put(
@@ -32,14 +32,14 @@ class CardConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputNull_returnsConfigWithDefaultValues() {
+    fun `when input is null, CardConfiguration uses default values`() {
         val (supportedCardTypes, isFraudDataCollectionEnabled) = CardConfiguration(null)
         assertFalse(isFraudDataCollectionEnabled)
         assertEquals(0, supportedCardTypes.size)
     }
 
     @Test
-    fun fromJson_whenInputEmpty_returnsConfigWithDefaultValues() {
+    fun `when input is empty, CardConfiguration uses default values`() {
         val (supportedCardTypes, isFraudDataCollectionEnabled) = CardConfiguration(JSONObject())
         assertFalse(isFraudDataCollectionEnabled)
         assertEquals(0, supportedCardTypes.size)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ClientTokenUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ClientTokenUnitTest.kt
@@ -11,7 +11,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ClientTokenUnitTest {
     @Test
-    fun fromString_deserializesClientToken() {
+    fun `when given a base64-encoded CLIENT_TOKEN fixture, fromString deserializes it into a ClientToken`() {
         val clientToken =
             fromString(FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)) as ClientToken
         assertEquals("client_api_configuration_url", clientToken.configUrl)
@@ -19,27 +19,27 @@ class ClientTokenUnitTest {
     }
 
     @Test
-    fun fromString_canDeserializeFromBase64String() {
+    fun `when given the BASE64_CLIENT_TOKEN fixture, fromString deserializes the encoded fields`() {
         val clientToken = fromString(Fixtures.BASE64_CLIENT_TOKEN) as ClientToken
         assertEquals("encoded_capi_configuration_url", clientToken.configUrl)
         assertEquals("encoded_auth_fingerprint", clientToken.authorizationFingerprint)
     }
 
     @Test
-    fun fromString_returnsInvalidTokenWhenGivenRandomJson() {
+    fun `when given random json, fromString returns InvalidAuthorization`() {
         val result = fromString(Fixtures.RANDOM_JSON)
         assertTrue(result is InvalidAuthorization)
     }
 
     @Test
-    fun getBearer_returnsAuthorizationFingerprint() {
+    fun `when clientToken is decoded, bearer returns the authorization fingerprint`() {
         val clientToken =
             fromString(FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)) as ClientToken
         assertEquals(clientToken.authorizationFingerprint, clientToken.bearer)
     }
 
     @Test
-    fun getCustomerId_returnsNull_whenCustomerIdNotPresent() {
+    fun `when customer id is not present in authorization fingerprint options, customerId returns null`() {
         val clientToken =
             fromString(
                 FixturesHelper.base64Encode(
@@ -50,7 +50,7 @@ class ClientTokenUnitTest {
     }
 
     @Test
-    fun getCustomerId_returnsCustomerId() {
+    fun `when customer id is present in authorization fingerprint, customerId returns it`() {
         val clientToken =
             fromString(
                 FixturesHelper.base64Encode(

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationCacheUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationCacheUnitTest.kt
@@ -17,7 +17,7 @@ class ConfigurationCacheUnitTest {
     private var braintreeSharedPreferences: BraintreeSharedPreferences = mockk(relaxed = true)
 
     @Test
-    fun saveConfiguration_savesConfigurationInSharedPrefs() {
+    fun `when saveConfiguration is called, configuration is saved to shared preferences`() {
         val configuration = fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         val sut = ConfigurationCache(braintreeSharedPreferences)
         sut.saveConfiguration(configuration, "cacheKey", 123L)
@@ -32,7 +32,7 @@ class ConfigurationCacheUnitTest {
     }
 
     @Test
-    fun getConfiguration_returnsConfigurationFromSharedPrefs() {
+    fun `when cache entry has not expired, getConfiguration returns the cached configuration`() {
         val configuration = fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         every { braintreeSharedPreferences.containsKey("cacheKey_timestamp") } returns true
         every { braintreeSharedPreferences.getLong("cacheKey_timestamp") } returns 0L
@@ -48,7 +48,7 @@ class ConfigurationCacheUnitTest {
     }
 
     @Test
-    fun getConfiguration_whenCacheEntryExpires_returnsNull() {
+    fun `when cache entry has expired, getConfiguration returns null`() {
         val configuration = fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         every { braintreeSharedPreferences.containsKey("cacheKey_timestamp") } returns true
         every { braintreeSharedPreferences.getLong("cacheKey_timestamp") } returns TimeUnit.MINUTES.toMillis(5)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class ConfigurationLoaderUnitTest {
     private val configurationCache: ConfigurationCache = mockk(relaxed = true)
     private val braintreeHttpClient: BraintreeHttpClient = mockk(relaxed = true)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationLoaderUnitTest.kt
@@ -36,7 +36,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_loadsConfigurationForTheCurrentEnvironment() = runTest {
+    fun `when httpClient get returns a valid config response, loadConfiguration returns Success`() = runTest {
         every { authorization.configUrl } returns "https://example.com/config"
         every { merchantRepository.authorization } returns authorization
 
@@ -56,7 +56,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_savesFetchedConfigurationToCache() = runTest {
+    fun `when loadConfiguration fetches a new configuration, the configuration is saved to the cache`() = runTest {
         every { authorization.configUrl } returns "https://example.com/config"
         every { authorization.bearer } returns "bearer"
 
@@ -83,7 +83,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_onJSONParsingError_forwardsExceptionToErrorResponseListener() = runTest {
+    fun `when response body is not valid json, loadConfiguration returns a Failure with a JSONException`() = runTest {
         every { authorization.configUrl } returns "https://example.com/config"
 
         val mockResponse = HttpResponse("not json", HttpResponseTiming(0, 0))
@@ -102,7 +102,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_onHttpError_forwardsExceptionToErrorResponseListener() = runTest {
+    fun `when httpClient get throws an IOException, loadConfiguration returns a Failure wrapping the error message`() = runTest {
         every { authorization.configUrl } returns "https://example.com/config"
 
         val httpError = IOException("http error")
@@ -124,7 +124,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_whenInvalidToken_exception_is_returned() = runTest {
+    fun `when authorization is invalid, loadConfiguration returns a Failure with the auth error message`() = runTest {
         every { merchantRepository.authorization } returns InvalidAuthorization("invalid", "token invalid")
 
         sut = createConfigurationLoader()
@@ -139,7 +139,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_whenCachedConfigurationAvailable_loadsConfigurationFromCache() = runTest {
+    fun `when a cached configuration is available, loadConfiguration loads it from the cache`() = runTest {
         val cacheKey = Base64.encodeToString(
             "https://example.com/config?configVersion=3bearer".toByteArray(),
             0
@@ -155,7 +155,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun `when loadConfiguration is called and configuration is fetched from the API, analytics event is sent`() =
+    fun `when configuration is fetched from the API, loadConfiguration sends an API_REQUEST_LATENCY analytics event`() =
         runTest {
         every { authorization.configUrl } returns "https://example.com/config"
         every { merchantRepository.authorization } returns authorization
@@ -188,7 +188,7 @@ class ConfigurationLoaderUnitTest {
     }
 
     @Test
-    fun loadConfiguration_onNullResponseBody_forwardsConfigurationExceptionToErrorResponseListener() = runTest {
+    fun `when response body is null, loadConfiguration returns a Failure with a ConfigurationException`() = runTest {
         every { authorization.configUrl } returns "https://example.com/config"
 
         val mockResponse = HttpResponse(null, HttpResponseTiming(0, 0))

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ConfigurationUnitTest.kt
@@ -26,113 +26,113 @@ class ConfigurationUnitTest {
     private val authorization: Authorization = mockk(relaxed = true)
 
     @Test(expected = JSONException::class)
-    fun fromJson_throwsForEmptyString() {
+    fun `when given an empty string, fromJson throws JSONException`() {
         Configuration.fromJson("")
     }
 
     @Test(expected = JSONException::class)
-    fun fromJson_throwsForRandomJson() {
+    fun `when given random json, fromJson throws JSONException`() {
         Configuration.fromJson(Fixtures.RANDOM_JSON)
     }
 
     @Test(expected = JSONException::class)
-    fun fromJson_throwsWhenNoClientApiUrlPresent() {
+    fun `when client api url is absent, fromJson throws JSONException`() {
         Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_CLIENT_API_URL)
     }
 
     @Test
-    fun fromJson_parsesClientApiUrl() {
+    fun `fromJson parses the client api url`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_CLIENT_API_URL)
         assertEquals("client_api_url", sut.clientApiUrl)
     }
 
     @Test
-    fun fromJson_parsesAssetsUrl() {
+    fun `fromJson parses the assets url`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ASSETS_URL)
         assertEquals("https://assets.braintreegateway.com", sut.assetsUrl)
     }
 
     @Test
-    fun fromJson_parsesCardinalAuthenticationJwt() {
+    fun `fromJson parses the cardinal authentication jwt`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_CARDINAL_AUTHENTICATION_JWT)
         assertEquals("cardinal_authentication_jwt", sut.cardinalAuthenticationJwt)
     }
 
     @Test
-    fun fromJson_handlesAbsentChallenges() {
+    fun `when challenges are absent, fromJson reports no cvv or postal code challenge`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_CHALLENGE)
         assertFalse(sut.isCvvChallengePresent)
         assertFalse(sut.isPostalCodeChallengePresent)
     }
 
     @Test
-    fun fromJson_parsesSingleChallenge() {
+    fun `when only cvv challenge is configured, fromJson reports cvv challenge present and postal code absent`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_CVV_CHALLENGE)
         assertTrue(sut.isCvvChallengePresent)
         assertFalse(sut.isPostalCodeChallengePresent)
     }
 
     @Test
-    fun fromJson_parsesAllChallenges() {
+    fun `when multiple challenges are configured, fromJson reports both cvv and postal code challenges present`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_MULTIPLE_CHALLENGES)
         assertTrue(sut.isCvvChallengePresent)
         assertTrue(sut.isPostalCodeChallengePresent)
     }
 
     @Test(expected = JSONException::class)
-    fun fromJson_throwsWhenNoMerchantIdPresent() {
+    fun `when merchant id is absent, fromJson throws JSONException`() {
         Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_MERCHANT_ID)
     }
 
     @Test(expected = JSONException::class)
-    fun fromJson_throwsWhenNoEnvironmentPresent() {
+    fun `when environment is absent, fromJson throws JSONException`() {
         Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ENVIRONMENT)
     }
 
     @Test
-    fun fromJson_parsesEnvironment() {
+    fun `fromJson parses the merchant id from a configuration with environment`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ENVIRONMENT)
         assertEquals("integration_merchant_id", sut.merchantId)
     }
 
     @Test
-    fun fromJson_parsesMerchantId() {
+    fun `fromJson parses the merchant id`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_MERCHANT_ID)
         assertEquals("integration_merchant_id", sut.merchantId)
     }
 
     @Test
-    fun fromJson_parsesMerchantAccountId() {
+    fun `fromJson parses the merchant account id`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_MERCHANT_ACCOUNT_ID)
         assertEquals("integration_merchant_account_id", sut.merchantAccountId)
     }
 
     @Test
-    fun returnsEmptyVenmoConfigurationWhenNotDefined() {
+    fun `when venmo configuration is not defined, venmoAccessToken is empty`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertTrue(TextUtils.isEmpty(sut.venmoAccessToken))
     }
 
     @Test
-    fun payWithVenmoIsEnabledWhenConfigurationExists() {
+    fun `when pay with venmo configuration exists, venmoAccessToken is not empty`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
         assertFalse(TextUtils.isEmpty(sut.venmoAccessToken))
     }
 
     @Test
-    fun reportsThreeDSecureEnabledWhenEnabled() {
+    fun `when three d secure configuration is present, isThreeDSecureEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_THREE_D_SECURE)
         assertTrue(sut.isThreeDSecureEnabled)
     }
 
     @Test
-    fun reportsThreeDSecureDisabledWhenAbsent() {
+    fun `when three d secure configuration is absent, isThreeDSecureEnabled is false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_THREE_D_SECURE)
         assertFalse(sut.isThreeDSecureEnabled)
     }
 
     @Test
-    fun returnsNewGooglePayConfigurationWhenGooglePayIsNull() {
+    fun `when google pay configuration is null, fromJson returns default google pay values`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_GOOGLE_PAY)
         assertFalse(sut.isGooglePayEnabled)
         assertEquals("", sut.googlePayDisplayName)
@@ -140,55 +140,55 @@ class ConfigurationUnitTest {
     }
 
     @Test
-    fun returnsNewCardConfigurationWhenCardConfigurationIsAbsent() {
+    fun `when card configuration is absent, fromJson returns no supported card types`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertEquals(0, sut.supportedCardTypes.size)
     }
 
     @Test
-    fun returnsVisaCheckoutConfiguration_whenVisaCheckoutConfigurationIsPresent() {
+    fun `when visa checkout configuration is present, isVisaCheckoutEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_VISA_CHECKOUT)
         assertTrue(sut.isVisaCheckoutEnabled)
     }
 
     @Test
-    fun returnsNewVisaCheckoutConfigurationWhenVisaCheckoutConfigurationIsAbsent() {
+    fun `when visa checkout configuration is absent, isVisaCheckoutEnabled is false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertFalse(sut.isVisaCheckoutEnabled)
     }
 
     @Test
-    fun returnsBraintreeApiConfigurationWhenBraintreeApiConfigurationPresent() {
+    fun `when braintree api configuration is present, isBraintreeApiEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
         assertTrue(sut.isBraintreeApiEnabled)
     }
 
     @Test
-    fun returnsNewBraintreeApiConfigurationWhenBraintreeApiConfigurationAbsent() {
+    fun `when braintree api configuration is absent, isBraintreeApiEnabled is false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertFalse(sut.isBraintreeApiEnabled)
     }
 
     @Test
-    fun returnsGraphQLConfiguration_whenGraphQLConfigurationIsPresent() {
+    fun `when graphQL configuration is present, isGraphQLEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
         assertTrue(sut.isGraphQLEnabled)
     }
 
     @Test
-    fun returnsNewGraphQLConfigurationWhenGraphQLConfigurationIsAbsent() {
+    fun `when graphQL configuration is absent, isGraphQLEnabled is false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertFalse(sut.isGraphQLEnabled)
     }
 
     @Test
-    fun isFraudDataCollectionEnabled_whenCardFraudDataCollectionEnabled_returnsTrue() {
+    fun `when card fraud data collection is enabled, isFraudDataCollectionEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_CARD_COLLECT_DEVICE_DATA)
         assertTrue(sut.isFraudDataCollectionEnabled)
     }
 
     @Test
-    fun supportedCardTypes_forwardsValuesFromConfiguration() {
+    fun `supportedCardTypes forwards values from the card configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_CARD_COLLECT_DEVICE_DATA)
         assertEquals(5, sut.supportedCardTypes.size)
         assertTrue(sut.supportedCardTypes.contains("American Express"))
@@ -199,201 +199,201 @@ class ConfigurationUnitTest {
     }
 
     @Test
-    fun isVenmoEnabled_whenVenmoAccessTokenValid_returnsTrue() {
+    fun `when venmo access token is valid, isVenmoEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
         assertTrue(sut.isVenmoEnabled)
     }
 
     @Test
-    fun venmoAccessToken_forwardsAccessTokenFromVenmoConfiguration() {
+    fun `venmoAccessToken forwards the access token from venmo configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
         assertEquals("access-token", sut.venmoAccessToken)
     }
 
     @Test
-    fun venmoAccessToken_forwardsMerchantIdFromVenmoConfiguration() {
+    fun `venmoMerchantId forwards the merchant id from venmo configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
         assertEquals("merchant-id", sut.venmoMerchantId)
     }
 
     @Test
-    fun venmoAccessToken_forwardsEnvironmentFromVenmoConfiguration() {
+    fun `venmoEnvironment forwards the environment from venmo configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_PAY_WITH_VENMO)
         assertEquals("environment", sut.venmoEnvironment)
     }
 
     @Test
-    fun isGraphQLEnabled_forwardsInvocationToGraphQLConfiguration() {
+    fun `when graphQL configuration exists, isGraphQLEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
         assertTrue(sut.isGraphQLEnabled)
     }
 
     @Test
-    fun isLocalPaymentsEnabled_whenPayPalEnabled_returnsTrue() {
+    fun `when paypal is enabled, isLocalPaymentEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertTrue(sut.isLocalPaymentEnabled)
     }
 
     @Test
-    fun isVisaCheckoutEnabled_returnsFalseWhenConfigurationApiKeyDoesNotExist() {
+    fun `when visa checkout api key does not exist, isVisaCheckoutEnabled is false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
         assertFalse(sut.isVisaCheckoutEnabled)
     }
 
     @Test
-    fun payPalDisplayName_forwardsValueFromConfiguration() {
+    fun `payPalDisplayName forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("paypal_merchant", sut.payPalDisplayName)
     }
 
     @Test
-    fun payPalClientId_forwardsValueFromConfiguration() {
+    fun `payPalClientId forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("paypal_client_id", sut.payPalClientId)
     }
 
     @Test
-    fun payPalPrivacyUrl_forwardsValueFromConfiguration() {
+    fun `payPalPrivacyUrl forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("http://www.example.com/privacy", sut.payPalPrivacyUrl)
     }
 
     @Test
-    fun payPalUserAgreementUrl_forwardsValueFromConfiguration() {
+    fun `payPalUserAgreementUrl forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("http://www.example.com/user_agreement", sut.payPalUserAgreementUrl)
     }
 
     @Test
-    fun payPalDirectBaseUrl_forwardsVersionedUrlFromConfiguration() {
+    fun `payPalDirectBaseUrl forwards the versioned url from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("https://www.paypal.com/v1/", sut.payPalDirectBaseUrl)
     }
 
     @Test
-    fun payPalEnvironment_forwardsValueFromConfiguration() {
+    fun `payPalEnvironment forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("live", sut.payPalEnvironment)
     }
 
     @Test
-    fun isPayPalTouchDisabled_forwardsValueFromConfiguration() {
+    fun `isPayPalTouchDisabled forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertTrue(sut.isPayPalTouchDisabled)
     }
 
     @Test
-    fun payPalCurrencyIsoCode_forwardsValueFromConfiguration() {
+    fun `payPalCurrencyIsoCode forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
         assertEquals("USD", sut.payPalCurrencyIsoCode)
     }
 
     @Test
-    fun isVisaCheckoutEnabled_returnsTrueWhenConfigurationApiKeyExists() {
+    fun `when visa checkout api key exists, isVisaCheckoutEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_VISA_CHECKOUT)
         assertTrue(sut.isVisaCheckoutEnabled)
     }
 
     @Test
-    fun visaCheckoutSupportedNetworks_forwardsInvocationToVisaCheckoutConfiguration() {
+    fun `visaCheckoutSupportedNetworks forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_VISA_CHECKOUT)
         val expected = listOf("AMEX", "DISCOVER", "MASTERCARD", "VISA")
         assertEquals(expected, sut.visaCheckoutSupportedNetworks)
     }
 
     @Test
-    fun visaCheckoutApiKey_forwardsInvocationToVisaCheckoutConfiguration() {
+    fun `visaCheckoutApiKey forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_VISA_CHECKOUT)
         assertEquals("gwApikey", sut.visaCheckoutApiKey)
     }
 
     @Test
-    fun visaCheckoutExternalClientId_forwardsInvocationToVisaCheckoutConfiguration() {
+    fun `visaCheckoutExternalClientId forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_VISA_CHECKOUT)
         assertEquals("gwExternalClientId", sut.visaCheckoutExternalClientId)
     }
 
     @Test
-    fun isGooglePayEnabled_whenGooglePayEnabledInConfig_returnsTrue() {
+    fun `when google pay is enabled in configuration, isGooglePayEnabled is true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         assertTrue(sut.isGooglePayEnabled)
     }
 
     @Test
-    fun googlePayAuthorizationFingerprint_forwardsValueFromConfiguration() {
+    fun `googlePayAuthorizationFingerprint forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         assertEquals("google-auth-fingerprint", sut.googlePayAuthorizationFingerprint)
     }
 
     @Test
-    fun googlePayEnvironment_forwardsValueFromConfiguration() {
+    fun `googlePayEnvironment forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         assertEquals("sandbox", sut.googlePayEnvironment)
     }
 
     @Test
-    fun googlePayDisplayName_forwardsValueFromConfiguration() {
+    fun `googlePayDisplayName forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         assertEquals("Google Pay Merchant", sut.googlePayDisplayName)
     }
 
     @Test
-    fun googlePaySupportedNetworks_forwardsValuesFromConfiguration() {
+    fun `googlePaySupportedNetworks forwards the values from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         val expected = listOf("visa", "mastercard", "amex", "discover")
         assertEquals(expected, sut.googlePaySupportedNetworks)
     }
 
     @Test
-    fun googlePayPayPalClientId_forwardsValuesFromConfiguration() {
+    fun `googlePayPayPalClientId forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY)
         assertEquals("pay-pal-client-id", sut.googlePayPayPalClientId)
     }
 
     @Test
-    fun isBraintreeApiEnabled_returnsTrueWhenAccessTokenPresent() {
+    fun `when access token is present, isBraintreeApiEnabled returns true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
         assertTrue(sut.isBraintreeApiEnabled)
     }
 
     @Test
-    fun isBraintreeApiEnabled_returnsFalseWhenAccessTokenNotPresent() {
+    fun `when access token is not present, isBraintreeApiEnabled returns false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITHOUT_ACCESS_TOKEN)
         assertFalse(sut.isBraintreeApiEnabled)
     }
 
     @Test
-    fun braintreeApiAccessToken_forwardsValueFromConfiguration() {
+    fun `braintreeApiAccessToken forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
         assertEquals("access-token-example", sut.braintreeApiAccessToken)
     }
 
     @Test
-    fun braintreeApiUrl_forwardsValueFromConfiguration() {
+    fun `braintreeApiUrl forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_ACCESS_TOKEN)
         assertEquals("https://braintree-api.com", sut.braintreeApiUrl)
     }
 
     @Test
-    fun isGraphQLFeatureEnabled_returnsTrue_whenFeatureEnabled() {
+    fun `when the feature is enabled, isGraphQLFeatureEnabled returns true`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
         assertTrue(sut.isGraphQLFeatureEnabled(GraphQLConstants.Features.TOKENIZE_CREDIT_CARDS))
     }
 
     @Test
-    fun isGraphQLFeatureEnabled_returnsFalse_whenFeatureNotEnabled() {
+    fun `when the feature is not enabled, isGraphQLFeatureEnabled returns false`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
         assertFalse(sut.isGraphQLFeatureEnabled("a_different_feature"))
     }
 
     @Test
-    fun graphQLUrl_forwardsValueFromConfiguration() {
+    fun `graphQLUrl forwards the value from configuration`() {
         val sut = Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GRAPHQL)
         assertEquals("https://example-graphql.com/graphql", sut.graphQLUrl)
     }
 
     @Test
-    fun `fetch on success calls back with configuration`() = runTest {
+    fun `when loadConfiguration succeeds, fetch calls back with configuration`() = runTest {
         val expectedConfiguration: Configuration = mockk()
         coEvery {
             configurationLoader.loadConfiguration(authorization)
@@ -420,7 +420,7 @@ class ConfigurationUnitTest {
     }
 
     @Test
-    fun `fetch on failure calls back with error`() = runTest {
+    fun `when loadConfiguration fails, fetch calls back with error`() = runTest {
         val expectedError = ConfigurationException("configuration fetch failed")
         coEvery {
             configurationLoader.loadConfiguration(authorization)
@@ -447,7 +447,7 @@ class ConfigurationUnitTest {
     }
 
     @Test
-    fun `fetch on cancellation does not call back`() = runTest {
+    fun `when loadConfiguration is cancelled, fetch does not call back`() = runTest {
         coEvery {
             configurationLoader.loadConfiguration(authorization)
         } throws CancellationException()

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/CrashReporterUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/CrashReporterUnitTest.kt
@@ -22,14 +22,14 @@ class CrashReporterUnitTest {
     }
 
     @Test
-    fun start_setsSelfAsThreadDefaultExceptionHandler() {
+    fun `when start is called, CrashReporter sets itself as the thread default exception handler`() {
         val sut = CrashReporter(braintreeClient)
         sut.start()
         assertSame(sut, Thread.getDefaultUncaughtExceptionHandler())
     }
 
     @Test
-    fun uncaughtExceptionHandler_whenClientReferenceNull_forwardsToExceptionHandler() {
+    fun `when braintreeClient weak reference is null, uncaughtException forwards to the default handler`() {
         Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler)
         val thread = mockk<Thread>()
         val exception = Exception("error")
@@ -41,7 +41,7 @@ class CrashReporterUnitTest {
     }
 
     @Test
-    fun uncaughtExceptionHandler_whenClientReferenceNull_restoresOriginalDefaultExceptionHandler() {
+    fun `when braintreeClient weak reference is null, uncaughtException restores the original default handler`() {
         Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler)
         val sut = CrashReporter(WeakReference(null))
         sut.start()
@@ -50,7 +50,7 @@ class CrashReporterUnitTest {
     }
 
     @Test
-    fun uncaughtExceptionHandler_whenCauseUnknown_forwardsInvocationToDefaultExceptionHandler() {
+    fun `when stack trace has no known braintree or paypal cause, uncaughtException forwards to the default handler without reporting`() {
         Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler)
         val thread = mockk<Thread>()
         val exception = Exception()
@@ -67,7 +67,7 @@ class CrashReporterUnitTest {
     }
 
     @Test
-    fun uncaughtExceptionHandler_whenBraintreeInStackTrace_reportsCrashToExceptionHandler() {
+    fun `when stack trace contains a braintree class, uncaughtException reports the crash and forwards to the default handler`() {
         Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler)
         val thread = mockk<Thread>()
         val exception = Exception()
@@ -86,7 +86,7 @@ class CrashReporterUnitTest {
     }
 
     @Test
-    fun uncaughtExceptionHandler_whenPayPalInStackTrace_reportsCrashToExceptionHandler() {
+    fun `when stack trace contains a paypal class, uncaughtException reports the crash and forwards to the default handler`() {
         Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler)
         val thread = mockk<Thread>()
         val exception = Exception()

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/CrashReporterUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/CrashReporterUnitTest.kt
@@ -10,6 +10,7 @@ import org.robolectric.RobolectricTestRunner
 import java.lang.ref.WeakReference
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class CrashReporterUnitTest {
 
     private lateinit var braintreeClient: BraintreeClient

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
@@ -29,6 +29,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.util.ReflectionHelpers
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class DeviceInspectorUnitTest {
 
     private var context: Context = mockk(relaxed = true)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/DeviceInspectorUnitTest.kt
@@ -61,7 +61,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsPlatform() {
+    fun `getDeviceMetadata returns metadata with platform set to Android`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("Android", metadata.platform)
@@ -69,7 +69,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsEventSource() {
+    fun `getDeviceMetadata returns metadata with eventSource set to mobile-native`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("mobile-native", metadata.eventSource)
@@ -77,7 +77,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsComponent() {
+    fun `getDeviceMetadata returns metadata with component set to braintreeclientsdk`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("braintreeclientsdk", metadata.component)
@@ -85,7 +85,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsPlatformVersion() {
+    fun `getDeviceMetadata returns metadata with clientOs based on Build VERSION SDK_INT`() {
         ReflectionHelpers.setStaticField(VERSION::class.java, "SDK_INT", 123)
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -94,7 +94,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsSDKVersion() {
+    fun `getDeviceMetadata returns metadata with clientSDKVersion set to BuildConfig VERSION_NAME`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals(BuildConfig.VERSION_NAME, metadata.clientSDKVersion)
@@ -102,7 +102,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsAppId() {
+    fun `getDeviceMetadata returns metadata with appId set to context package name`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("com.sample.app", metadata.appId)
@@ -110,7 +110,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(PackageManager.NameNotFoundException::class, JSONException::class)
-    fun getDeviceMetadata_whenApplicationInfoUnavailable_returnsApplicationNameUnknown() {
+    fun `when packageManager throws NameNotFoundException for application info, getDeviceMetadata returns metadata with appName set to ApplicationNameUnknown`() {
         every {
             packageManager.getApplicationInfo("com.sample.app", 0)
         } throws PackageManager.NameNotFoundException()
@@ -121,7 +121,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(PackageManager.NameNotFoundException::class, JSONException::class)
-    fun getDeviceMetadata_returnsAppNameFromPackageManager() {
+    fun `getDeviceMetadata returns metadata with appName from packageManager application label`() {
         val applicationInfo = ApplicationInfo()
         every { packageManager.getApplicationInfo("com.sample.app", 0) } returns applicationInfo
         every { packageManager.getApplicationLabel(applicationInfo) } returns "SampleAppName"
@@ -132,7 +132,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsDeviceManufacturer() {
+    fun `getDeviceMetadata returns metadata with deviceManufacturer from Build MANUFACTURER`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "device-manufacturer")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -141,7 +141,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_returnsDeviceModel() {
+    fun `getDeviceMetadata returns metadata with deviceModel from Build MODEL`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "device-model")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -150,7 +150,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductManufacturerAndFingerprintAreValid_returnsFalseForIsSimulator() {
+    fun `when Build PRODUCT, MANUFACTURER and FINGERPRINT are all valid device values, getDeviceMetadata returns metadata with isSimulator set to false`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "randomBuildProduct")
         ReflectionHelpers.setStaticField(
             Build::class.java,
@@ -165,7 +165,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildFingerpintContainsGeneric_returnsTrueForIsSimulator() {
+    fun `when Build FINGERPRINT contains generic, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "FINGERPRINT", "generic")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -174,7 +174,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildFingerpintContainsUnknown_returnsTrueForIsSimulator() {
+    fun `when Build FINGERPRINT contains unknown, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "FINGERPRINT", "unknown")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -183,7 +183,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenHardwareContainsGoldfish_returnsTrueForIsSimulator() {
+    fun `when Build HARDWARE is goldfish, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "HARDWARE", "goldfish")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -192,7 +192,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenHardwareContainsRanchu_returnsTrueForIsSimulator() {
+    fun `when Build HARDWARE is ranchu, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "HARDWARE", "ranchu")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -201,7 +201,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenHardwareModelGoogleSDK_returnsTrueForIsSimulator() {
+    fun `when Build MODEL is google_sdk, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "google_sdk")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -210,7 +210,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenHardwareModelEmulator_returnsTrueForIsSimulator() {
+    fun `when Build MODEL is Emulator, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Emulator")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -219,7 +219,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenHardwareModelAndroidSDKBuiltForX86_returnsTrueForIsSimulator() {
+    fun `when Build MODEL is Android SDK built for x86, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Android SDK built for x86")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -228,7 +228,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildManufacturerIsGenymotion_returnsTrueForIsSimulator() {
+    fun `when Build MANUFACTURER is Genymotion, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Genymotion")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -237,7 +237,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsSdkGoogle_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is sdk_google, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "sdk_google")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -246,7 +246,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsGoogleSdk_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is google_sdk, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "google_sdk")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -255,7 +255,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsSdk_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is sdk, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "sdk")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -264,7 +264,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIssdkx86_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is sdk_x86, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "sdk_x86")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -273,7 +273,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsVbox86p_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is vbox86p, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "vbox86p")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -282,7 +282,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsEmulator_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is emulator, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "emulator")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -291,7 +291,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_whenBuildProductIsSimulator_returnsTrueForIsSimulator() {
+    fun `when Build PRODUCT is simulator, getDeviceMetadata returns metadata with isSimulator set to true`() {
         ReflectionHelpers.setStaticField(Build::class.java, "PRODUCT", "simulator")
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
@@ -300,7 +300,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_forwardsSessionId() {
+    fun `getDeviceMetadata forwards sessionId argument to result`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("session-id", metadata.sessionId)
@@ -308,7 +308,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_forwardsIntegrationType() {
+    fun `getDeviceMetadata forwards integrationType argument to result`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals(IntegrationType.CUSTOM, metadata.integrationType)
@@ -316,7 +316,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class, PackageManager.NameNotFoundException::class)
-    fun getDeviceMetadata_returnsAppVersion() {
+    fun `getDeviceMetadata returns metadata with merchantAppVersion from packageManager package info`() {
         val packageInfo = PackageInfo()
         packageInfo.versionName = "AppVersion"
         every { packageManager.getPackageInfo("com.sample.app", 0) } returns packageInfo
@@ -327,7 +327,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class, PackageManager.NameNotFoundException::class)
-    fun getDeviceMetadata_whenAppVersionUnavailable_returnsVersionUnknownByDefault() {
+    fun `when packageManager throws NameNotFoundException for package info, getDeviceMetadata returns metadata with merchantAppVersion set to VersionUnknown`() {
         every {
             packageManager.getPackageInfo("com.sample.app", 0)
         } throws PackageManager.NameNotFoundException()
@@ -338,7 +338,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getDeviceMetadata_forwardsDropInVersionFromClassHelper() {
+    fun `getDeviceMetadata returns metadata with dropInSDKVersion from DeviceInspector getDropInVersion`() {
         mockkObject(DeviceInspector) {
             every { DeviceInspector.getDropInVersion() } returns "fake-drop-in-version"
             val metadata = sut.getDeviceMetadata(
@@ -353,7 +353,7 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getSDKEnvironment_forwardsEnvironmentFromConfig() {
+    fun `getDeviceMetadata returns metadata with environment from configuration`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("test", metadata.environment)
@@ -361,26 +361,26 @@ class DeviceInspectorUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun getMerchantID_forwardsMerchantIdFromConfig() {
+    fun `getDeviceMetadata returns metadata with merchantId from configuration`() {
         val metadata =
             sut.getDeviceMetadata(context, btConfiguration, "session-id", IntegrationType.CUSTOM)
         assertEquals("integration_merchant_id", metadata.merchantId)
     }
 
     @Test
-    fun isPayPalInstalled_forwardsIsPayPalInstalledResultFromAppHelper() {
+    fun `isPayPalInstalled returns true when appHelper reports PayPal app installed`() {
         every { appHelper.isAppInstalled(context, "com.paypal.android.p2pmobile") } returns true
         assertTrue(sut.isPayPalInstalled())
     }
 
     @Test
-    fun isVenmoInstalled_forwardsIsVenmoInstalledResultFromAppHelper() {
+    fun `isVenmoInstalled returns true when appHelper reports Venmo app installed`() {
         every { appHelper.isAppInstalled(context, "com.venmo") } returns true
         assertTrue(sut.isVenmoInstalled(context))
     }
 
     @Test
-    fun isVenmoAppSwitchAvailable_checksForVenmoIntentAvailability() {
+    fun `isVenmoAppSwitchAvailable checks appHelper with intent targeting Venmo SetupMerchantActivity`() {
         sut.isVenmoAppSwitchAvailable(context)
         val intentSlot = slot<Intent>()
         verify { appHelper.isIntentAvailable(context, capture(intentSlot)) }
@@ -392,13 +392,13 @@ class DeviceInspectorUnitTest {
     }
 
     @Test
-    fun isVenmoAppSwitchAvailable_whenVenmoIsNotInstalled_returnsFalse() {
+    fun `when appHelper reports Venmo intent unavailable, isVenmoAppSwitchAvailable returns false`() {
         every { appHelper.isIntentAvailable(context, ofType(Intent::class)) } returns false
         assertFalse(sut.isVenmoAppSwitchAvailable(context))
     }
 
     @Test
-    fun isVenmoAppSwitchAvailable_whenVenmoIsInstalledSignatureIsNotValid_returnsFalse() {
+    fun `when Venmo intent is available but signature is not valid, isVenmoAppSwitchAvailable returns false`() {
         every { appHelper.isIntentAvailable(context, ofType(Intent::class)) } returns true
 
         every {
@@ -413,7 +413,7 @@ class DeviceInspectorUnitTest {
     }
 
     @Test
-    fun isVenmoAppSwitchAvailable_whenVenmoIsInstalledSignatureIsValid_returnsTrue() {
+    fun `when Venmo intent is available and signature is valid, isVenmoAppSwitchAvailable returns true`() {
         every { appHelper.isIntentAvailable(context, ofType(Intent::class)) } returns true
 
         every {

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ErrorsWithResponseUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ErrorsWithResponseUnitTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 class ErrorsWithResponseUnitTest {
 
     @Test
-    fun constructor_parsesErrorsCorrectly() {
+    fun `constructor parses field and message errors from credit card error response`() {
         val response = Fixtures.ERRORS_CREDIT_CARD_ERROR_RESPONSE
         val errorWithResponse = ErrorWithResponse(422, response)
         assertEquals("Credit card is invalid", errorWithResponse.message)
@@ -56,7 +56,7 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun constructor_handlesTopLevelErrors() {
+    fun `constructor parses top level error message and single field error`() {
         val topLevelError = Fixtures.ERRORS_AUTH_FINGERPRINT_ERROR
         val errorWithResponse = ErrorWithResponse(422, topLevelError)
         assertEquals("Authorization fingerprint is invalid", errorWithResponse.message)
@@ -64,7 +64,7 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun constructor_canHandleMultipleCategories() {
+    fun `constructor parses errors across multiple field categories`() {
         val errors = Fixtures.ERRORS_COMPLEX_ERROR_RESPONSE
         val errorWithResponse = ErrorWithResponse(422, errors)
         assertEquals(3, errorWithResponse.errorFor("creditCard")?.fieldErrors?.size)
@@ -73,7 +73,7 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun constructor_doesNotBlowUpParsingBadJson() {
+    fun `when response is invalid json, constructor sets message to parsing error failed`() {
         val badJson = Fixtures.RANDOM_JSON
         val errorWithResponse = ErrorWithResponse(422, badJson)
         assertEquals("Parsing error response failed", errorWithResponse.message)
@@ -81,7 +81,7 @@ class ErrorsWithResponseUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun fromJson_parsesErrorsCorrectly() {
+    fun `fromJson parses field and message errors from credit card error response`() {
         val response = Fixtures.ERRORS_CREDIT_CARD_ERROR_RESPONSE
         val errorWithResponse = ErrorWithResponse.fromJson(response)
         assertEquals("Credit card is invalid", errorWithResponse.message)
@@ -102,12 +102,12 @@ class ErrorsWithResponseUnitTest {
 
     @Test(expected = JSONException::class)
     @Throws(JSONException::class)
-    fun fromJson_throwsExceptionIfJsonParsingFails() {
+    fun `when json parsing fails, fromJson throws JSONException`() {
         ErrorWithResponse.fromJson(Fixtures.RANDOM_JSON)
     }
 
     @Test
-    fun fromGraphQLJson_parsesErrorsCorrectly() {
+    fun `fromGraphQLJson parses field and message errors from credit card error response`() {
         val response = Fixtures.ERRORS_GRAPHQL_CREDIT_CARD_ERROR
         val errorWithResponse = ErrorWithResponse.fromGraphQLJson(response)
         assertEquals("Input is invalid.", errorWithResponse.message)
@@ -127,7 +127,7 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun fromGraphQLJson_parsesGraphQLCoercionErrorsCorrectly() {
+    fun `fromGraphQLJson parses coercion error message`() {
         val response = Fixtures.ERRORS_GRAPHQL_COERCION_ERROR
         val errorWithResponse = ErrorWithResponse.fromGraphQLJson(response)
         assertEquals(
@@ -138,14 +138,14 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun fromGraphQLJson_doesNotBlowUpParsingBadJson() {
+    fun `when response is invalid json, fromGraphQLJson sets message to parsing error failed`() {
         val badJson = Fixtures.RANDOM_JSON
         val errorWithResponse = ErrorWithResponse.fromGraphQLJson(badJson)
         assertEquals("Parsing error response failed", errorWithResponse.message)
     }
 
     @Test
-    fun REST_tokenizeCardDuplicate() {
+    fun `constructor parses duplicate card error code from REST error response`() {
         val errorWithResponse = ErrorWithResponse(422, Fixtures.ERRORS_CREDIT_CARD_DUPLICATE)
         assertEquals(
             81724, errorWithResponse.errorFor("creditCard")?.errorFor("number")?.code
@@ -153,7 +153,7 @@ class ErrorsWithResponseUnitTest {
     }
 
     @Test
-    fun GraphQL_tokenizeCardDuplicate() {
+    fun `fromGraphQLJson parses duplicate card error code from GraphQL error response`() {
         val errorWithResponse =
             ErrorWithResponse.fromGraphQLJson(Fixtures.ERRORS_GRAPHQL_CREDIT_CARD_DUPLICATE_ERROR)
         assertEquals(
@@ -163,7 +163,7 @@ class ErrorsWithResponseUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun parcelsCorrectly() {
+    fun `writeToParcel and createFromParcel preserve statusCode, message, errorResponse and fieldErrors`() {
         val error = ErrorWithResponse.fromJson(Fixtures.ERRORS_CREDIT_CARD_ERROR_RESPONSE)
         val parcel = Parcel.obtain()
         error.writeToParcel(parcel, 0)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/GraphQLConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/GraphQLConfigurationUnitTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 @RunWith(RobolectricTestRunner::class)
 class GraphQLConfigurationUnitTest {
     @Test
-    fun fromJson_parsesFullInput() {
+    fun `when json contains url and features, GraphQLConfiguration is enabled with feature and url parsed`() {
         val input = JSONObject()
             .put("url", "https://example.com/graphql")
             .put(
@@ -24,7 +24,7 @@ class GraphQLConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputNull_returnsConfigWithDefaultValues() {
+    fun `when input json is null, GraphQLConfiguration is disabled with default values`() {
         val sut = GraphQLConfiguration(null)
         assertFalse(sut.isEnabled)
         assertFalse(sut.isFeatureEnabled(GraphQLConstants.Features.TOKENIZE_CREDIT_CARDS))
@@ -32,7 +32,7 @@ class GraphQLConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputEmpty_returnsConfigWithDefaultValues() {
+    fun `when input json is empty, GraphQLConfiguration is disabled with default values`() {
         val sut = GraphQLConfiguration(JSONObject())
         assertFalse(sut.isEnabled)
         assertFalse(sut.isFeatureEnabled(GraphQLConstants.Features.TOKENIZE_CREDIT_CARDS))

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/MetadataBuilderUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/MetadataBuilderUnitTest.kt
@@ -11,7 +11,7 @@ class MetadataBuilderUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun build_correctlyBuildsMetadata() {
+    fun `build assembles integration, platform, version, sessionId and source into json`() {
         val json = MetadataBuilder()
             .integration(IntegrationType.CUSTOM)
             .version()

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/PayPalConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/PayPalConfigurationUnitTest.kt
@@ -14,7 +14,7 @@ class PayPalConfigurationUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun fromJson_parsesFullInput() {
+    fun `when json contains all fields, PayPalConfiguration parses all values`() {
         val input = JSONObject()
             .put("displayName", "sample display name")
             .put("clientId", "sample-client-id")
@@ -37,7 +37,7 @@ class PayPalConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputNull_returnsConfigWithDefaultValues() {
+    fun `when input json is null, PayPalConfiguration has null fields and touch disabled is true`() {
         val sut = PayPalConfiguration(null)
         assertNull(sut.displayName)
         assertNull(sut.clientId)
@@ -49,7 +49,7 @@ class PayPalConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputEmpty_returnsConfigWithDefaultValues() {
+    fun `when input json is empty, PayPalConfiguration has null fields and touch disabled is true`() {
         val sut = PayPalConfiguration(JSONObject())
         assertNull(sut.displayName)
         assertNull(sut.clientId)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/PostalAddressUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/PostalAddressUnitTest.kt
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith
 @RunWith(RobolectricTestRunner::class)
 class PostalAddressUnitTest {
     @Test
-    fun constructsCorrectly() {
+    fun `PostalAddress property assignments are readable back correctly`() {
         val postalAddress = PostalAddress().apply {
             streetAddress = "123 Fake St."
             extendedAddress = "Apt. 3"
@@ -35,7 +35,7 @@ class PostalAddressUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun testCanCreatePostalAddress_fromStandardJson() {
+    fun `PostalAddressParser fromJson parses standard address json`() {
         val accountAddressJson = Fixtures.PAYMENT_METHODS_PAYPAL_ADDRESS
         val postalAddress = PostalAddressParser.fromJson(JSONObject(accountAddressJson))
         assertEquals("123 Fake St.", postalAddress.streetAddress)
@@ -49,7 +49,7 @@ class PostalAddressUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun testCanCreatePostalAddress_fromAlternateJson() {
+    fun `PostalAddressParser fromJson parses alternate address json`() {
         val accountAddressJson = Fixtures.PAYMENT_METHODS_PAYPAL_ADDRESS_ALTERNATE
         val postalAddress = PostalAddressParser.fromJson(JSONObject(accountAddressJson))
         assertEquals("123 Fake St.", postalAddress.streetAddress)
@@ -63,7 +63,7 @@ class PostalAddressUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun testCanPostalAddressHandleMissingFieldsInJson() {
+    fun `when json is missing address fields, PostalAddressParser fromJson leaves fields null`() {
         val accountAddressJson = Fixtures.RANDOM_JSON
         val postalAddress = PostalAddressParser.fromJson(JSONObject(accountAddressJson))
         assertNull(postalAddress.streetAddress)
@@ -76,7 +76,7 @@ class PostalAddressUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun testWriteToParcel_serializesCorrectly() {
+    fun `PostalAddress survives Parcel serialization round trip`() {
         val accountAddressJson = Fixtures.PAYMENT_METHODS_PAYPAL_ADDRESS
         val preSerialized = PostalAddressParser.fromJson(JSONObject(accountAddressJson))
 
@@ -95,7 +95,7 @@ class PostalAddressUnitTest {
     }
 
     @Test
-    fun isEmpty_returnsTrueIfCountryCodeIsNotSet() {
+    fun `when countryCodeAlpha2 is not set, isEmpty returns true`() {
         val postalAddress = PostalAddress().apply {
             streetAddress = "123 Fake St."
             extendedAddress = "Apt. 3"
@@ -108,7 +108,7 @@ class PostalAddressUnitTest {
     }
 
     @Test
-    fun isEmpty_returnsFalseIfCountryCodeIsSet() {
+    fun `when countryCodeAlpha2 is set, isEmpty returns false`() {
         val postalAddress = PostalAddress()
         postalAddress.countryCodeAlpha2 = "US"
         assertFalse(postalAddress.isEmpty)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/TokenizationKeyUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/TokenizationKeyUnitTest.kt
@@ -15,31 +15,31 @@ class TokenizationKeyUnitTest {
     }
 
     @Test
-    fun fromString_acceptsATokenizationKey() {
+    fun `fromString parses a valid tokenization key`() {
         val tokenizationKey = fromString(TOKENIZATION_KEY)
         assertEquals(TOKENIZATION_KEY, tokenizationKey.bearer)
     }
 
     @Test
-    fun fromString_returnsInvalidTokenForNonTokenizationKeys() {
+    fun `when input is not a tokenization key, fromString returns InvalidAuthorization`() {
         val result = fromString("{}")
         assertTrue(result is InvalidAuthorization)
     }
 
     @Test
-    fun fromString_parsesEnvironment() {
+    fun `fromString parses environment from tokenization key`() {
         val tokenizationKey = fromString(TOKENIZATION_KEY) as TokenizationKey
         assertEquals("development", tokenizationKey.environment)
     }
 
     @Test
-    fun fromString_parsesMerchantId() {
+    fun `fromString parses merchantId from tokenization key`() {
         val tokenizationKey = fromString(TOKENIZATION_KEY) as TokenizationKey
         assertEquals("integration_merchant_id", tokenizationKey.merchantId)
     }
 
     @Test
-    fun fromString_setsUrlForDevelopment() {
+    fun `when environment is development, fromString sets url and configUrl to development endpoints`() {
         val tokenizationKey = fromString(TOKENIZATION_KEY) as TokenizationKey
         assertEquals(
             BuildConfig.DEVELOPMENT_URL + "merchants/integration_merchant_id/client_api/",
@@ -52,7 +52,7 @@ class TokenizationKeyUnitTest {
     }
 
     @Test
-    fun fromString_setsUrlForSandbox() {
+    fun `when environment is sandbox, fromString sets url and configUrl to sandbox endpoints`() {
         val tokenizationKey = fromString(
             "sandbox_fjajdkd_integration_merchant_id"
         ) as TokenizationKey
@@ -67,7 +67,7 @@ class TokenizationKeyUnitTest {
     }
 
     @Test
-    fun fromString_setsUrlForProduction() {
+    fun `when environment is production, fromString sets url and configUrl to production endpoints`() {
         val tokenizationKey = fromString(
             "production_fjajdkd_integration_merchant_id"
         ) as TokenizationKey
@@ -82,13 +82,13 @@ class TokenizationKeyUnitTest {
     }
 
     @Test
-    fun fromString_returnsInvalidTokenForInvalidEnvironments() {
+    fun `when environment is invalid, fromString returns InvalidAuthorization`() {
         val result = fromString("test_fjajdkd_integration_merchant_id")
         assertTrue(result is InvalidAuthorization)
     }
 
     @Test
-    fun getBearer_returnsTokenizationKey() {
+    fun `bearer returns the original tokenization key string`() {
         assertEquals(TOKENIZATION_KEY, fromString(TOKENIZATION_KEY).bearer)
     }
 }

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/UUIDHelperUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/UUIDHelperUnitTest.kt
@@ -14,7 +14,7 @@ class UUIDHelperUnitTest {
     private var braintreeSharedPreferences: BraintreeSharedPreferences = mockk(relaxed = true)
 
     @Test
-    fun getInstallationGUID_returnsNewGUIDWhenOneDoesNotExistAndPersistsIt() {
+    fun `when no GUID exists in shared preferences, getInstallationGUID generates and persists a new one`() {
         every {
             braintreeSharedPreferences.getString("InstallationGUID", null)
         } returns null
@@ -26,7 +26,7 @@ class UUIDHelperUnitTest {
     }
 
     @Test
-    fun getInstallationGUID_returnsExistingGUIDWhenOneExist() {
+    fun `when a GUID already exists in shared preferences, getInstallationGUID returns the existing one`() {
         val uuid = UUID.randomUUID().toString()
         every {
             braintreeSharedPreferences.getString("InstallationGUID", null)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/VenmoConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/VenmoConfigurationUnitTest.kt
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith
 class VenmoConfigurationUnitTest {
     @Test
     @Throws(JSONException::class)
-    fun fromJson_parsesFullInput() {
+    fun `when json contains all fields, VenmoConfiguration parses all values and isAccessTokenValid is true`() {
         val input = JSONObject()
             .put("accessToken", "sample-access-token")
             .put("environment", "sample-environment")
@@ -24,7 +24,7 @@ class VenmoConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputNull_returnsConfigWithDefaultValues() {
+    fun `when input json is null, VenmoConfiguration has empty fields and isAccessTokenValid is false`() {
         val sut = VenmoConfiguration(null)
         assertEquals("", sut.accessToken)
         assertEquals("", sut.environment)
@@ -33,7 +33,7 @@ class VenmoConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputEmpty_returnsConfigWithDefaultValues() {
+    fun `when input json is empty, VenmoConfiguration has empty fields and isAccessTokenValid is false`() {
         val sut = VenmoConfiguration(JSONObject())
         assertEquals("", sut.accessToken)
         assertEquals("", sut.environment)

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/VisaCheckoutConfigurationUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/VisaCheckoutConfigurationUnitTest.kt
@@ -13,7 +13,7 @@ import org.robolectric.RobolectricTestRunner
 class VisaCheckoutConfigurationUnitTest {
 
     @Test
-    fun fromJson_parsesFullInput() {
+    fun `when json contains all fields, VisaCheckoutConfiguration is enabled with values and mapped card brands`() {
         val input = JSONObject()
             .put("apikey", "sample-api-key")
             .put("externalClientId", "sample-external-client-id")
@@ -33,7 +33,7 @@ class VisaCheckoutConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputNull_returnsConfigWithDefaultValues() {
+    fun `when input json is null, VisaCheckoutConfiguration is disabled with default values`() {
         val sut = VisaCheckoutConfiguration(null)
         assertFalse(sut.isEnabled)
         assertEquals("", sut.apiKey)
@@ -42,7 +42,7 @@ class VisaCheckoutConfigurationUnitTest {
     }
 
     @Test
-    fun fromJson_whenInputEmpty_returnsConfigWithDefaultValues() {
+    fun `when input json is empty, VisaCheckoutConfiguration is disabled with default values`() {
         val sut = VisaCheckoutConfiguration(JSONObject())
         assertFalse(sut.isEnabled)
         assertEquals("", sut.apiKey)

--- a/Card/src/test/java/com/braintreepayments/api/card/CardAnalyticsUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class CardAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants match expected event names`() {
         assertEquals("card:tokenize:started", CardAnalytics.CARD_TOKENIZE_STARTED)
         assertEquals("card:tokenize:failed", CardAnalytics.CARD_TOKENIZE_FAILED)
         assertEquals("card:tokenize:succeeded", CardAnalytics.CARD_TOKENIZE_SUCCEEDED)

--- a/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class CardClientUnitTest {
     private val card: Card = Card()
     private val cardTokenizeCallback: CardTokenizeCallback = mockk(relaxed = true)

--- a/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardClientUnitTest.kt
@@ -53,7 +53,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_resetsSessionId() = runTest(testDispatcher) {
+    fun `tokenize resets the analytics session id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         apiClient = MockkApiClientBuilder().build()
 
@@ -71,7 +71,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_sendsTokenizeStartedAnalytics() = runTest(testDispatcher) {
+    fun `tokenize sends card tokenize started analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         apiClient = MockkApiClientBuilder().build()
 
@@ -89,7 +89,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLEnabled_setsSessionIdOnCardBeforeTokenizing() = runTest(testDispatcher) {
+    fun `when GraphQL is enabled, session id is set on card before tokenizing`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -114,7 +114,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLEnabled_tokenizesWithGraphQL() = runTest(testDispatcher) {
+    fun `when GraphQL is enabled, tokenize returns success result from GraphQL response`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -144,7 +144,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLDisabled_tokenizesWithREST() = runTest(testDispatcher) {
+    fun `when GraphQL is disabled, tokenize returns success result from REST response`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLDisabledConfig)
             .build()
@@ -174,7 +174,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLEnabled_sendsAnalyticsEventOnSuccess() = runTest(testDispatcher) {
+    fun `when GraphQL is enabled and tokenize succeeds, sends card tokenize succeeded analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -197,7 +197,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLDisabled_sendsAnalyticsEventOnSuccess() = runTest(testDispatcher) {
+    fun `when GraphQL is disabled and tokenize succeeds, sends card tokenize succeeded analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLDisabledConfig)
             .build()
@@ -220,7 +220,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLEnabled_callsListenerWithErrorOnFailure() = runTest(testDispatcher) {
+    fun `when GraphQL is enabled and tokenize fails, callback receives failure result with the error`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -250,7 +250,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLDisabled_callsListenerWithErrorOnFailure() = runTest(testDispatcher) {
+    fun `when GraphQL is disabled and tokenize fails, callback receives failure result with the error`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLDisabledConfig)
             .build()
@@ -280,7 +280,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLEnabled_sendsAnalyticsEventOnFailure() = runTest(testDispatcher) {
+    fun `when GraphQL is enabled and tokenize fails, sends card tokenize failed analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -304,7 +304,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenGraphQLDisabled_sendsAnalyticsEventOnFailure() = runTest(testDispatcher) {
+    fun `when GraphQL is disabled and tokenize fails, sends card tokenize failed analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLDisabledConfig)
             .build()
@@ -328,7 +328,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_propagatesConfigurationFetchError() = runTest(testDispatcher) {
+    fun `when configuration fetch fails, tokenize callback receives failure result with configuration error`() = runTest(testDispatcher) {
         val configError = Exception("Configuration error.")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(configError)
@@ -354,7 +354,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenizeException_analyticsEventIsSentWithErrorDescription() = runTest(testDispatcher) {
+    fun `when configuration fetch fails, sends card tokenize failed analytics event with error description`() = runTest(testDispatcher) {
         val errorDescription = "Configuration error."
         val configError = IOException(errorDescription)
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -378,7 +378,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenResponseHasErrorsArray_callsListenerWithErrorOnFailure() = runTest(testDispatcher) {
+    fun `when GraphQL response contains an errors array, callback receives failure result`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -414,7 +414,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenApiClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when apiClient tokenizeGraphQL throws CancellationException, callback is not invoked`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()
@@ -438,7 +438,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenResponseHasEmptyErrorsArray_proceedsWithNormalProcessing() = runTest(testDispatcher) {
+    fun `when GraphQL response contains an empty errors array, tokenize proceeds and returns success`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(graphQLEnabledConfig)
             .build()

--- a/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
@@ -189,17 +189,6 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `when buildJSON is called with a different source value, includes source in meta object`() {
-        val card = Card(source = "form")
-
-        val jsonObject = card.buildJSON()
-
-        assertEquals("form",
-            jsonObject.getJSONObject("_meta").getString("source"))
-    }
-
-    @Test
-    @Throws(JSONException::class)
     fun `when buildJSON is called with integration set, sets integration field in metadata`() {
         val card = Card(integration = IntegrationType.CUSTOM)
 
@@ -373,17 +362,6 @@ class CardUnitTest {
 
         val json = card.buildJSONForGraphQL()
         assertEquals("form",
-            json.getJSONObject("clientSdkMetadata").getString("source"))
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun `when buildJSONForGraphQL is called with a different source value, includes source in clientSdkMetadata`() {
-        val card = Card(source = "test-source")
-
-        val json = card.buildJSONForGraphQL()
-
-        assertEquals("test-source",
             json.getJSONObject("clientSdkMetadata").getString("source"))
     }
 

--- a/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
@@ -17,6 +17,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class CardUnitTest {
 
     private val CREDIT_CARD_KEY = "creditCard"

--- a/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
+++ b/Card/src/test/java/com/braintreepayments/api/card/CardUnitTest.kt
@@ -79,7 +79,7 @@ class CardUnitTest {
             "}"
 
     @Test
-    fun buildJSON_correctlyBuildsACardTokenizationPayload() {
+    fun `when buildJSON is called with all card and billing address fields set, builds full tokenization payload`() {
         val card = Card(
             number = VISA,
             expirationMonth = "01",
@@ -138,7 +138,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_nestsAddressCorrectly() {
+    fun `when buildJSON is called with only postal code set, omits other billing address fields`() {
         val card = Card()
         card.postalCode = "60606"
 
@@ -165,7 +165,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_usesDefaultInfoForMetadata() {
+    fun `when buildJSON is called with integration and source set, includes them in metadata`() {
         val card = Card(integration = IntegrationType.CUSTOM, source = "form")
 
         val metadata = card.buildJSON()
@@ -179,7 +179,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_usesDefaultCardSource() {
+    fun `when buildJSON is called with source set, includes source in meta object`() {
         val card = Card(source = "form")
         val jsonObject = card.buildJSON()
 
@@ -189,7 +189,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_setsCardSource() {
+    fun `when buildJSON is called with a different source value, includes source in meta object`() {
         val card = Card(source = "form")
 
         val jsonObject = card.buildJSON()
@@ -200,7 +200,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_setsIntegrationMethod() {
+    fun `when buildJSON is called with integration set, sets integration field in metadata`() {
         val card = Card(integration = IntegrationType.CUSTOM)
 
         val metadata = card.buildJSON().getJSONObject(MetadataBuilder.META_KEY)
@@ -210,7 +210,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_whenValidateIsNotSet_defaultsToFalse() {
+    fun `when buildJSON is called and shouldValidate is not set, validate option defaults to false`() {
         val card = Card()
         val json = card.buildJSON().getJSONObject(CREDIT_CARD_KEY)
 
@@ -219,7 +219,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_includesValidateOptionWhenSetToTrue() {
+    fun `when buildJSON is called and shouldValidate is true, validate option is true`() {
         val card = Card(shouldValidate = true)
 
         val json = card.buildJSON().getJSONObject(CREDIT_CARD_KEY)
@@ -229,7 +229,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_includesValidateOptionWhenSetToFalse() {
+    fun `when buildJSON is called and shouldValidate is false, validate option is false`() {
         val card = Card(shouldValidate = false)
 
         val builtCard = card.buildJSON().getJSONObject(CREDIT_CARD_KEY)
@@ -239,7 +239,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_doesNotIncludeEmptyStrings() {
+    fun `when buildJSON is called with an empty card, omits empty string fields, keeps options object, and excludes billing address`() {
         val card = Card()
 
         assertEquals(1, card.buildJSON().getJSONObject(CREDIT_CARD_KEY).length())
@@ -249,7 +249,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_whenAuthenticationInsightRequestedIsTrue_requestsAuthenticationInsight() {
+    fun `when buildJSON is called and isAuthenticationInsightRequested is true with merchant account id, includes authenticationInsight and merchantAccountId`() {
         val card = Card()
         card.isAuthenticationInsightRequested = true
         card.merchantAccountId = "merchant_account_id"
@@ -262,7 +262,7 @@ class CardUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildJSON_whenAuthenticationInsightRequestedIsFalse_doesNotRequestsAuthenticationInsight() {
+    fun `when buildJSON is called and isAuthenticationInsightRequested is false, omits authenticationInsight field`() {
         val card = Card(isAuthenticationInsightRequested = false)
 
         val json = card.buildJSON()
@@ -272,7 +272,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_correctlyBuildsACardTokenization() {
+    fun `when buildJSONForGraphQL is called with all card and billing address fields set, builds full graphQL tokenization payload`() {
         val card = Card(
             number = VISA,
             expirationMonth = "01",
@@ -330,7 +330,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_nestsAddressCorrectly() {
+    fun `when buildJSONForGraphQL is called with only postal code set, omits other billing address fields`() {
         val card = Card(postalCode = "60606")
 
         val json = card.buildJSONForGraphQL()
@@ -356,7 +356,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_usesDefaultInfoForMetadata() {
+    fun `when buildJSONForGraphQL is called with integration and source set, includes them in clientSdkMetadata`() {
         val card = Card(integration = IntegrationType.CUSTOM, source = "form")
 
         val json = card.buildJSONForGraphQL()
@@ -368,7 +368,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_usesDefaultCardSource() {
+    fun `when buildJSONForGraphQL is called with source set, includes source in clientSdkMetadata`() {
         val card = Card(source = "form")
 
         val json = card.buildJSONForGraphQL()
@@ -378,7 +378,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_setsCardSource() {
+    fun `when buildJSONForGraphQL is called with a different source value, includes source in clientSdkMetadata`() {
         val card = Card(source = "test-source")
 
         val json = card.buildJSONForGraphQL()
@@ -389,7 +389,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_setsIntegrationMethod() {
+    fun `when buildJSONForGraphQL is called with integration set, sets integration field in clientSdkMetadata`() {
         val card = Card(integration = IntegrationType.CUSTOM)
 
         val json = card.buildJSONForGraphQL()
@@ -400,7 +400,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_whenValidateNotSet_defaultsToFalse() {
+    fun `when buildJSONForGraphQL is called and shouldValidate is not set, validate option defaults to false`() {
         val card = Card()
 
         val json = card.buildJSONForGraphQL()
@@ -413,7 +413,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_whenValidateSetToTrue_includesValidationOptionTrue() {
+    fun `when buildJSONForGraphQL is called and shouldValidate is true, validate option is true`() {
         val card = Card(shouldValidate = true)
 
         val json = card.buildJSONForGraphQL()
@@ -426,7 +426,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_whenValidateSetToFalse_includesValidationOptionFalse() {
+    fun `when buildJSONForGraphQL is called and shouldValidate is false, validate option is false`() {
         val card = Card(shouldValidate = false)
 
         val json = card.buildJSONForGraphQL()
@@ -439,7 +439,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_doesNotIncludeEmptyStrings() {
+    fun `when buildJSONForGraphQL is called with an empty card, produces empty credit card object`() {
         val card = Card()
 
         val json = card.buildJSONForGraphQL()
@@ -452,7 +452,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_withMerchantAccountId_andAuthInsightRequested_requestsAuthInsight() {
+    fun `when buildJSONForGraphQL is called and merchant account id is set and isAuthenticationInsightRequested is true, includes authenticationInsightInput and auth insight query`() {
         val card = Card(merchantAccountId = "merchant-account-id", isAuthenticationInsightRequested = true)
 
         val json = card.buildJSONForGraphQL()
@@ -467,7 +467,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_withMerchantAccountId_andNoAuthInsightRequested_doesNotRequestInsight() {
+    fun `when buildJSONForGraphQL is called and merchant account id is set and isAuthenticationInsightRequested is false, omits authenticationInsightInput and uses base query`() {
         val card = Card()
         card.merchantAccountId = "merchant-account-id"
         card.isAuthenticationInsightRequested = false
@@ -481,7 +481,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_whenMerchantAccountIdIsNull_andAuthInsightRequested_throwsException() {
+    fun `when buildJSONForGraphQL is called and merchant account id is null and isAuthenticationInsightRequested is true, throws BraintreeException`() {
         val card = Card()
         card.merchantAccountId = null
         card.isAuthenticationInsightRequested = true
@@ -496,7 +496,7 @@ class CardUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun buildJSONForGraphQL_withNullMerchantAccountId_andNoInsightRequested_doesNotRequestInsight() {
+    fun `when buildJSONForGraphQL is called and merchant account id is null and isAuthenticationInsightRequested is false, omits authenticationInsightInput and uses base query`() {
         val card = Card()
         card.merchantAccountId = null
         card.isAuthenticationInsightRequested = false

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorInternalRequestUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorInternalRequestUnitTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class DataCollectorInternalRequestUnitTest {
     @Test
-    fun setClientMetadataId_trimsId_to_32characters() {
+    fun `when clientMetadataId is set with a value longer than 32 characters, it is trimmed to 32 characters`() {
         val request = DataCollectorInternalRequest(true)
         request.clientMetadataId = "pairing-id-pairing-id-pairing-idXXX"
 

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
@@ -83,7 +83,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun payPalInstallationGUID_returnsInstallationIdentifier() {
+    fun `when getPayPalInstallationGUID is called, the installation GUID is returned from UUIDHelper`() {
 
         val sut = DataCollector(braintreeClient, magnesInternalClient, uuidHelper)
 
@@ -91,7 +91,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun getClientMetadataId_configuresMagnesWithDefaultRequest() {
+    fun `when getClientMetadataId is called with a boolean consent flag, a request with the installation guid and consent flag is forwarded to magnes`() {
         val hasUserLocationConsent = true
 
         val sut = DataCollector(braintreeClient, magnesInternalClient, uuidHelper)
@@ -113,7 +113,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun getClientMetadataId_configuresMagnesWithCustomRequestAndForwardsClientMetadataIdFromMagnesResult() {
+    fun `when getClientMetadataId is called with a custom request, the custom request is forwarded to magnes`() {
 
         val customRequest =
             DataCollectorInternalRequest(true)
@@ -137,7 +137,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun getClientMetadataId_forwardsClientMetadataIdFromMagnesResult() {
+    fun `when getClientMetadataId is called, the client metadata id from magnes is returned`() {
 
         val sut = DataCollector(braintreeClient, magnesInternalClient, uuidHelper)
         val result = sut.getClientMetadataId(context, configuration, true)
@@ -146,7 +146,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_forwardsConfigurationFetchErrors() = runTest(testDispatcher) {
+    fun `when collectDeviceData is called and configuration fetch fails, callback receives a failure result with the configuration error`() = runTest(testDispatcher) {
         val configError = IOException("configuration error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(configError)
@@ -166,7 +166,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_configuresMagnesWithDefaultRequest() = runTest(testDispatcher) {
+    fun `when collectDeviceData is called, the installation guid is forwarded to magnes and user location consent defaults to false`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -191,7 +191,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_with_request_configuresMagnesWithDefaultRequest() = runTest(testDispatcher) {
+    fun `when collectDeviceData is called with a request containing a risk correlation id, the risk correlation id is forwarded to magnes as the client metadata id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -217,7 +217,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_configuresMagnesWithClientId() = runTest(testDispatcher) {
+    fun `when collectDeviceData is called with a risk correlation id, the resulting magnes request includes the correlation id as the client metadata id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -244,7 +244,7 @@ class DataCollectorUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun collectDeviceData_getsDeviceDataJSONWithCorrelationIdFromPayPal() = runTest(testDispatcher) {
+    fun `when collectDeviceData succeeds, callback receives a success result containing device data json with the correlation id from magnes`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -265,7 +265,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_without_DataCollectorRequest_sets_hasUserLocationConsent_to_false() =
+    fun `when collectDeviceData is called with a request that has no user location consent, the resulting magnes request has user location consent set to false`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
@@ -291,7 +291,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_with_DataCollectorRequest_sets_correct_values_for_getClientMetadataId() =
+    fun `when collectDeviceData is called with a request that has user location consent true, the resulting magnes request has user location consent set to true`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
@@ -318,7 +318,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceData_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when collectDeviceData configuration fetch throws a CancellationException, the callback is never invoked`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
@@ -335,7 +335,7 @@ class DataCollectorUnitTest {
     // Tests for collectDeviceDataOnSuccess
 
     @Test
-    fun collectDeviceDataOnSuccess_forwardsConfigurationFetchErrors() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess is called and configuration fetch fails, callback receives a failure result with the configuration error`() = runTest(testDispatcher) {
         val configError = IOException("configuration error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(configError)
@@ -355,7 +355,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_configuresMagnesWithDefaultRequest() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess is called, the installation guid is forwarded to magnes and user location consent defaults to false`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -381,7 +381,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_withRequest_configuresMagnesWithRiskCorrelationId() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess is called with a request containing a risk correlation id, the risk correlation id is forwarded to magnes as the client metadata id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -409,7 +409,7 @@ class DataCollectorUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun collectDeviceDataOnSuccess_whenMagnesReturnsSuccess_callsCallbackWithDeviceData() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess succeeds, callback receives a success result containing device data json with the correlation id from magnes`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
             .build()
@@ -430,7 +430,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_whenMagnesReturnsSubmitError_callsCallbackWithFailure() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess magnes callback returns a submit error, callback receives a failure result with the submit error`() = runTest(testDispatcher) {
         val submitError = CallbackSubmitException.SubmitError
         every {
             magnesInternalClient.getClientMetadataIdWithCallback(
@@ -462,7 +462,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_whenMagnesReturnsSubmitTimeout_callsCallbackWithFailure() = runTest(testDispatcher) {
+    fun `when collectDeviceDataOnSuccess magnes callback returns a submit timeout, callback receives a failure result with the submit timeout error`() = runTest(testDispatcher) {
         val submitTimeout = CallbackSubmitException.SubmitTimeout
         every {
             magnesInternalClient.getClientMetadataIdWithCallback(
@@ -494,7 +494,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_withDataCollectorRequest_setsCorrectValuesForGetClientMetadataIdWithCallback() =
+    fun `when collectDeviceDataOnSuccess is called with a request that has user location consent true, the resulting magnes request has user location consent set to true`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(configuration)
@@ -522,7 +522,7 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun collectDeviceDataOnSuccess_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when collectDeviceDataOnSuccess configuration fetch throws a CancellationException, the callback is never invoked`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
@@ -27,6 +27,7 @@ import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class DataCollectorUnitTest {
 
     private val testDispatcher = StandardTestDispatcher()

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/DataCollectorUnitTest.kt
@@ -217,32 +217,6 @@ class DataCollectorUnitTest {
     }
 
     @Test
-    fun `when collectDeviceData is called with a risk correlation id, the resulting magnes request includes the correlation id as the client metadata id`() = runTest(testDispatcher) {
-        val braintreeClient = MockkBraintreeClientBuilder()
-            .configurationSuccess(configuration)
-            .build()
-
-        val testScope = TestScope(testDispatcher)
-        val sut = DataCollector(braintreeClient, magnesInternalClient, uuidHelper, testDispatcher, testScope)
-        sut.collectDeviceData(context, dataCollectorRequest, callback)
-        advanceUntilIdle()
-
-        val captor = slot<DataCollectorInternalRequest>()
-        verify {
-            magnesInternalClient.getClientMetadataId(
-                context,
-                configuration,
-                capture(captor)
-            )
-        }
-
-        val request = captor.captured
-        Assert.assertEquals(sampleInstallationGUID, request.applicationGuid)
-        Assert.assertEquals("risk_correlation_id", request.clientMetadataId)
-        Assert.assertFalse(request.hasUserLocationConsent)
-    }
-
-    @Test
     @Throws(Exception::class)
     fun `when collectDeviceData succeeds, callback receives a success result containing device data json with the correlation id from magnes`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/MagnesInternalClientUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/MagnesInternalClientUnitTest.kt
@@ -74,7 +74,7 @@ class MagnesInternalClientUnitTest {
     }
 
     @Test
-    fun getClientMetaDataId_returnsEmptyStringWhenContextIsNull() {
+    fun `when getClientMetadataId is called with a null context, an empty string is returned`() {
         val sut = MagnesInternalClient(magnesSDK)
         val result = sut.getClientMetadataId(
             null, sandboxConfiguration,
@@ -86,7 +86,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_configuresMagnesSourceAsBraintree() {
+    fun `when getClientMetadataId is called, magnes is set up with magnes source set to braintree`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, sandboxConfiguration, dataCollectorInternalRequest)
@@ -103,7 +103,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_whenBraintreeEnvironmentIsSandbox_configuresMagnesEnvironmentToSandbox() {
+    fun `when getClientMetadataId is called with a sandbox configuration, magnes is set up with the sandbox environment`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, sandboxConfiguration, dataCollectorInternalRequest)
@@ -117,7 +117,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_whenBraintreeEnvironmentIsProd_configuresMagnesEnvironmentToLive() {
+    fun `when getClientMetadataId is called with a production configuration, magnes is set up with the live environment`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, prodConfiguration, dataCollectorInternalRequest)
@@ -131,7 +131,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_forwardsDisableBeaconOptionToMagnes() {
+    fun `when getClientMetadataId is called with disable beacon set to true on the request, magnes is set up with disable beacon true`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, prodConfiguration, dataCollectorInternalRequest)
@@ -145,7 +145,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_forwardsApplicationGUIDOptionToMagnes() {
+    fun `when getClientMetadataId is called with an application guid on the request, magnes is set up with that app guid`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, prodConfiguration, dataCollectorInternalRequest)
@@ -159,7 +159,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_setsHasUserLocationConsent() {
+    fun `when getClientMetadataId is called with user location consent on the request, magnes is set up with matching user location consent`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataId(context, prodConfiguration, dataCollectorInternalRequest)
@@ -172,7 +172,7 @@ class MagnesInternalClientUnitTest {
     }
 
     @Test
-    fun getClientMetaDataId_returnsAnEmptyStringWhenApplicationGUIDIsInvalid() {
+    fun `when getClientMetadataId is called with an invalid application guid, an empty string is returned`() {
 
         val requestWithInvalidGUID =
             DataCollectorInternalRequest(hasUserLocationConsent, null, null, false)
@@ -186,7 +186,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_forwardsClientMetadataIdFromMagnesStart() {
+    fun `when getClientMetadataId is called, the client metadata id produced by magnes collectAndSubmit is returned`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         val result = sut.getClientMetadataId(
@@ -199,7 +199,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetaDataId_returnsAnEmptyStringWhenCollectAndSubmitThrows() {
+    fun `when magnes collectAndSubmit throws InvalidInputException, getClientMetadataId returns an empty string`() {
 
         every {
             magnesSDK.collectAndSubmit(
@@ -220,7 +220,7 @@ class MagnesInternalClientUnitTest {
     // Tests for getClientMetadataIdWithCallback
 
     @Test
-    fun getClientMetadataIdWithCallback_returnsEmptyStringWhenContextIsNull() {
+    fun `when getClientMetadataIdWithCallback is called with a null context, the callback receives an empty client metadata id`() {
         val sut = MagnesInternalClient(magnesSDK)
         var receivedClientMetadataId = "non-empty"
 
@@ -235,7 +235,7 @@ class MagnesInternalClientUnitTest {
     }
 
     @Test
-    fun getClientMetadataIdWithCallback_returnsEmptyStringWhenConfigurationIsNull() {
+    fun `when getClientMetadataIdWithCallback is called with a null configuration, the callback receives an empty client metadata id`() {
         val sut = MagnesInternalClient(magnesSDK)
         var receivedClientMetadataId = "non-empty"
 
@@ -250,7 +250,7 @@ class MagnesInternalClientUnitTest {
     }
 
     @Test
-    fun getClientMetadataIdWithCallback_returnEmptyStringWhenRequestIsNull() {
+    fun `when getClientMetadataIdWithCallback is called with a null request, the callback receives an empty client metadata id`() {
         val sut = MagnesInternalClient(magnesSDK)
         var receivedClientMetadataId = "non-empty"
 
@@ -266,7 +266,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_configuresMagnesSourceAsBraintree() {
+    fun `when getClientMetadataIdWithCallback is called, magnes is set up with magnes source set to braintree`() {
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, sandboxConfiguration, dataCollectorInternalRequest) { _, _ -> }
 
@@ -282,7 +282,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenBraintreeEnvironmentIsSandbox_configuresMagnesEnvironmentToSandbox() {
+    fun `when getClientMetadataIdWithCallback is called with a sandbox configuration, magnes is set up with the sandbox environment`() {
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, sandboxConfiguration, dataCollectorInternalRequest) { _, _ -> }
 
@@ -295,7 +295,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenBraintreeEnvironmentIsProd_configuresMagnesEnvironmentToLive() {
+    fun `when getClientMetadataIdWithCallback is called with a production configuration, magnes is set up with the live environment`() {
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, prodConfiguration, dataCollectorInternalRequest) { _, _ -> }
 
@@ -308,7 +308,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_forwardsDisableBeaconOptionToMagnes() {
+    fun `when getClientMetadataIdWithCallback is called with disable beacon set to true on the request, magnes is set up with disable beacon true`() {
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, prodConfiguration, dataCollectorInternalRequest) { _, _ -> }
 
@@ -321,7 +321,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_forwardsApplicationGUIDOptionToMagnes() {
+    fun `when getClientMetadataIdWithCallback is called with an application guid on the request, magnes is set up with that app guid`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, prodConfiguration, dataCollectorInternalRequest) { _, _ -> }
@@ -335,7 +335,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_setsHasUserLocationConsent() {
+    fun `when getClientMetadataIdWithCallback is called with user location consent on the request, magnes is set up with matching user location consent`() {
 
         val sut = MagnesInternalClient(magnesSDK)
         sut.getClientMetadataIdWithCallback(context, prodConfiguration, dataCollectorInternalRequest) { _, _ -> }
@@ -349,7 +349,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenMagnesCallbackReturnsSuccess_forwardsCMIDToCallback() {
+    fun `when the magnes submit listener reports success, the callback receives the client metadata id and no error`() {
         var storedListener: MagnesSubmitListener? = null
 
         every {
@@ -385,7 +385,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenMagnesCallbackReturnsError_returnsSubmitErrorException() {
+    fun `when the magnes submit listener reports an error, the callback receives a null client metadata id and a SubmitError exception`() {
         every {
             magnesSDK.collectAndSubmit(
                 context,
@@ -418,7 +418,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenMagnesCallbackReturnsTimeout_returnsSubmitTimeoutException() {
+    fun `when the magnes submit listener reports a timeout, the callback receives a null client metadata id and a SubmitTimeout exception`() {
         every {
             magnesSDK.collectAndSubmit(
                 context,
@@ -451,7 +451,7 @@ class MagnesInternalClientUnitTest {
 
     @Throws(InvalidInputException::class)
     @Test
-    fun getClientMetadataIdWithCallback_whenCollectAndSubmitThrows_callsCallbackWithException() {
+    fun `when magnes collectAndSubmit throws InvalidInputException, the callback receives a null client metadata id and the thrown exception`() {
         every {
             magnesSDK.collectAndSubmit(
                 context,

--- a/DataCollector/src/test/java/com/braintreepayments/api/datacollector/MagnesInternalClientUnitTest.kt
+++ b/DataCollector/src/test/java/com/braintreepayments/api/datacollector/MagnesInternalClientUnitTest.kt
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class MagnesInternalClientUnitTest {
 
     @MockK

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayAnalyticsUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class GooglePayAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants match expected event names`() {
         assertEquals(
             "google-pay:payment-request:started",
             GooglePayAnalytics.PAYMENT_REQUEST_STARTED

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.kt
@@ -1,3 +1,5 @@
+ @file:Suppress("MaxLineLength")
+
 package com.braintreepayments.api.googlepay
 
 import androidx.fragment.app.FragmentActivity

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayClientUnitTest.kt
@@ -70,7 +70,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun isReadyToPay_sendsReadyToPayRequest() = runTest(testDispatcher) {
+    fun `when isReadyToPay is called, internal client is invoked with expected ready to pay request`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -114,7 +115,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun isReadyToPay_whenExistingPaymentMethodRequired_sendsIsReadyToPayRequestWithExistingPaymentRequired() =
+    fun `when isReadyToPay is called with existing payment method required, request reflects that flag`() =
         runTest(testDispatcher) {
         val readyForGooglePayRequest = ReadyForGooglePayRequest().apply {
             isExistingPaymentMethodRequired = true
@@ -163,7 +164,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun isReadyToPay_returnsFalseWhenGooglePayIsNotEnabled() = runTest(testDispatcher) {
+    fun `when isReadyToPay is called and Google Pay is not enabled, callback receives not ready to pay result`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -197,7 +199,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun isReadyToPay_whenInternalClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when isReadyToPay internal client throws cancellation exception, callback is not invoked`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -230,7 +233,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_resetsSessionId() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, analytics param repository session id is reset`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -266,7 +270,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_callsBackIntentData() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, callback receives payment data request with expected fields`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -406,7 +411,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_includesATokenizationKeyWhenPresent() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with tokenization key authorization, client key is included`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -457,7 +463,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_doesNotIncludeATokenizationKeyWhenNotPresent() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with client token authorization, client key is omitted`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -508,7 +515,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest succeeds, started and succeeded analytics events are sent in order`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -549,7 +557,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenMerchantNotConfigured_returnsExceptionToFragment() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called and Google Pay is not configured, callback receives failure and analytics are sent`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder().build())
 
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -591,7 +600,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenSandbox_setsTestEnvironment() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with sandbox configuration, test environment is set`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -638,7 +648,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenProduction_setsProductionEnvironment() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with production configuration, production environment is set`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -685,7 +696,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_withGoogleMerchantName_sendGoogleMerchantName() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with google merchant name override, merchant name is included in request`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -733,7 +745,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_withMerchantInfo_sendSoftwareInfo() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, merchant info includes software info`() = runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -779,7 +791,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenGooglePayCanProcessPayPal_tokenizationPropertiesIncludePayPal() =
+    fun `when createPaymentAuthRequest is called and PayPal is enabled and configured, allowed payment methods include PayPal and card`() =
         runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
@@ -830,7 +842,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenPayPalDisabledByRequest_tokenizationPropertiesLackPayPal() =
+    fun `when createPaymentAuthRequest is called with PayPal disabled on request, allowed payment methods only include card`() =
         runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
@@ -881,7 +893,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenPayPalDisabledAndGooglePayHasPayPalClientId_tokenizationPropsContainPayPal() =
+    fun `when createPaymentAuthRequest is called with merchant PayPal disabled but Google Pay has a PayPal client id, allowed payment methods include PayPal and card`() =
         runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
@@ -934,7 +946,8 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_usesGooglePayConfigurationClientId() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called and both PayPal and Google Pay configs have client ids, Google Pay client id is used for PayPal payment method`() =
+        runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -1002,7 +1015,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenGooglePayConfigurationLacksClientId_tokenizationPropertiesLackPayPal() =
+    fun `when createPaymentAuthRequest is called and Google Pay configuration lacks a PayPal client id, allowed payment methods only include card`() =
         runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
@@ -1052,7 +1065,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenConfigurationContainsElo_addsEloAndEloDebitToAllowedPaymentMethods() =
+    fun `when createPaymentAuthRequest is called with elo supported network, allowed card networks include elo and elo debit`() =
         runTest(testDispatcher) {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
@@ -1106,7 +1119,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun tokenize_withCardToken_returnsGooglePayNonce() {
+    fun `when tokenize is called with card payment data, callback receives a GooglePayCardNonce`() {
         val paymentDataJson = Fixtures.RESPONSE_GOOGLE_PAY_CARD
 
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
@@ -1148,7 +1161,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPayPalToken_returnsPayPalAccountNonce() {
+    fun `when tokenize is called with PayPal payment data, callback receives a PayPalAccountNonce`() {
         val paymentDataJson = Fixtures.REPSONSE_GOOGLE_PAY_PAYPAL_ACCOUNT
 
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
@@ -1190,7 +1203,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenPaymentDataExists_returnsResultToListener_andSendsAnalytics() {
+    fun `when tokenize is called with GooglePayPaymentAuthResult containing payment data, callback receives success and analytics are sent`() {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         val internalGooglePayClient = MockkGooglePayInternalClientBuilder().build()
 
@@ -1220,7 +1233,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenErrorExists_returnsErrorToListener_andSendsAnalytics() {
+    fun `when tokenize is called with GooglePayPaymentAuthResult containing an error, callback receives failure and analytics are sent`() {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         val internalGooglePayClient = MockkGooglePayInternalClientBuilder().build()
 
@@ -1252,7 +1265,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenUserCanceledErrorExists_returnsErrorToListener_andSendsAnalytics() {
+    fun `when tokenize is called with GooglePayPaymentAuthResult containing a user canceled error, callback receives cancel and analytics are sent`() {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         val internalGooglePayClient = MockkGooglePayInternalClientBuilder().build()
 
@@ -1277,7 +1290,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getAllowedCardNetworks_returnsSupportedNetworks() {
+    fun `when getAllowedCardNetworks is called, wallet constants for each supported network are returned`() {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -1311,7 +1324,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getTokenizationParameters_returnsCorrectParameters() {
+    fun `when getTokenizationParameters is called with configuration and authorization, expected parameters are returned`() {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -1352,7 +1365,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getTokenizationParameters_doesNotIncludeATokenizationKeyWhenNotPresent() {
+    fun `when getTokenizationParameters is called with client token authorization, client key parameter is not included`() {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -1382,7 +1395,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getTokenizationParameters_includesATokenizationKeyWhenPresent() {
+    fun `when getTokenizationParameters is called with tokenization key authorization, client key parameter is included`() {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()
@@ -1412,7 +1425,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getTokenizationParameters_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when getTokenizationParameters configuration lookup throws cancellation exception, callback is not invoked`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
@@ -1436,7 +1449,7 @@ class GooglePayClientUnitTest {
     }
 
     @Test
-    fun getTokenizationParameters_forwardsParametersAndAllowedCardsToCallback() {
+    fun `when getTokenizationParameters callback overload is called, callback receives parameters and allowed card networks`() {
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .googlePay(
                 TestConfigurationBuilder.TestGooglePayConfigurationBuilder()

--- a/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayLauncherUnitTest.kt
+++ b/GooglePay/src/test/java/com/braintreepayments/api/googlepay/GooglePayLauncherUnitTest.kt
@@ -46,7 +46,7 @@ class GooglePayLauncherUnitTest {
     }
 
     @Test
-    fun constructor_createsActivityLauncher() {
+    fun `when GooglePayLauncher is constructed, activity result launcher is registered`() {
         val expectedKey = "com.braintreepayments.api.GooglePay.RESULT"
         val lifecycleOwner = FragmentActivity()
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -64,7 +64,7 @@ class GooglePayLauncherUnitTest {
     }
 
     @Test
-    fun launch_launchesTask() {
+    fun `when launch is called with ready to launch request, activity result launcher launches task`() {
         val lifecycleOwner = FragmentActivity()
         val context = ApplicationProvider.getApplicationContext<Context>()
         val mockTask = mockk<Task<PaymentData>>(relaxed = true)
@@ -85,7 +85,7 @@ class GooglePayLauncherUnitTest {
     }
 
     @Test
-    fun `callback_whenSuccess_passesPaymentDataToCallback`() {
+    fun `when activity result callback receives a successful status, payment data is passed to callback`() {
         val callbackSlot = slot<ActivityResultCallback<ApiTaskResult<PaymentData>>>()
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
         every {
@@ -111,7 +111,7 @@ class GooglePayLauncherUnitTest {
     }
 
     @Test
-    fun `callback_whenCanceled_passesUserCanceledExceptionToCallback`() {
+    fun `when activity result callback receives a canceled status, UserCanceledException is passed to callback`() {
         val callbackSlot = slot<ActivityResultCallback<ApiTaskResult<PaymentData>>>()
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
         every {
@@ -137,7 +137,7 @@ class GooglePayLauncherUnitTest {
     }
 
     @Test
-    fun `callback_whenError_passesGooglePayExceptionToCallback`() {
+    fun `when activity result callback receives an error status, GooglePayException is passed to callback`() {
         val callbackSlot = slot<ActivityResultCallback<ApiTaskResult<PaymentData>>>()
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
         every {

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentAnalyticsUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class LocalPaymentAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants match expected event name strings`() {
         assertEquals(
             "local-payment:start-payment:started",
             LocalPaymentAnalytics.PAYMENT_STARTED

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
@@ -28,6 +28,7 @@ import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class LocalPaymentApiUnitTest {
     private val testDispatcher = StandardTestDispatcher()
 

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentApiUnitTest.kt
@@ -44,7 +44,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun createPaymentMethod_sendsCorrectPostParams() = runTest(testDispatcher) {
+    fun `when createPaymentMethod is called, sends expected POST body params`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .returnUrlScheme("sample-scheme")
             .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_CREATE_RESPONSE)
@@ -95,7 +95,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun createPaymentMethod_onPOSTError_throwsException() = runTest(testDispatcher) {
+    fun `when sendPOST fails with an IOException, createPaymentMethod throws that exception`() = runTest(testDispatcher) {
         val error = IOException("error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostErrorResponse(error)
@@ -117,7 +117,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun createPaymentMethod_onJSONError_throwsException() = runTest(testDispatcher) {
+    fun `when sendPOST returns an error response body, createPaymentMethod throws an exception`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.ERROR_RESPONSE)
             .build()
@@ -137,7 +137,8 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun createPaymentMethod_onPOSTSuccess_returnsResultWithOriginalRequest() = runTest(testDispatcher) {
+    fun `when createPaymentMethod succeeds, returns result containing the original request and approval data`() =
+        runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_CREATE_RESPONSE)
             .build()
@@ -162,7 +163,7 @@ class LocalPaymentApiUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_sendsCorrectPostParams() = runTest(testDispatcher) {
+    fun `when tokenize is called, sends expected POST body params`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_RESPONSE)
             .build()
@@ -206,7 +207,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun tokenize_onPOSTError_throwsException() = runTest(testDispatcher) {
+    fun `when sendPOST fails with an IOException, tokenize throws that exception`() = runTest(testDispatcher) {
         val error = IOException("error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostErrorResponse(error)
@@ -229,7 +230,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun tokenize_onJSONError_throwsException() = runTest(testDispatcher) {
+    fun `when sendPOST returns invalid JSON, tokenize throws a JSONException`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse("not-json")
             .build()
@@ -251,7 +252,7 @@ class LocalPaymentApiUnitTest {
     }
 
     @Test
-    fun tokenize_onPOSTSuccess_returnsResult() = runTest(testDispatcher) {
+    fun `when tokenize succeeds, returns a nonce parsed from the response`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.PAYMENT_METHODS_LOCAL_PAYMENT_RESPONSE)
             .build()

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.kt
@@ -40,6 +40,7 @@ import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class LocalPaymentClientUnitTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var activity: FragmentActivity

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentClientUnitTest.kt
@@ -121,7 +121,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_resetsSessionId() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, resets the analytics session id`() = runTest(testDispatcher) {
         sut.createPaymentAuthRequest(createLocalPaymentRequest(), localPaymentAuthCallback)
         advanceUntilIdle()
 
@@ -129,7 +129,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsPaymentStartedEvent() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, sends a payment started analytics event`() = runTest(testDispatcher) {
         sut.createPaymentAuthRequest(createLocalPaymentRequest(), localPaymentAuthCallback)
         advanceUntilIdle()
 
@@ -143,7 +143,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsPaymentFailedEvent_forNullGetPaymentType() = runTest(testDispatcher) {
+    fun `when paymentType is null, createPaymentAuthRequest sends a payment failed analytics event`() = runTest(testDispatcher) {
         val request = createLocalPaymentRequest()
         request.paymentType = null
         sut.createPaymentAuthRequest(request, localPaymentAuthCallback)
@@ -161,7 +161,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_createsPaymentMethodWithLocalPaymentApi() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, creates payment method via localPaymentApi`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -182,7 +182,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_success_forwardsResultToCallback() = runTest(testDispatcher) {
+    fun `when createPaymentMethod succeeds, createPaymentAuthRequest forwards result params to callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -210,7 +210,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_success_sendsAnalyticsEvents() = runTest(testDispatcher) {
+    fun `when createPaymentMethod succeeds, createPaymentAuthRequest sends a browser switch succeeded analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -237,7 +237,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_configurationFetchError_forwardsErrorToCallback() = runTest(testDispatcher) {
+    fun `when configuration fetch fails, createPaymentAuthRequest forwards the error to callback`() = runTest(testDispatcher) {
         val configException = IOException("Configuration not fetched")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(configException)
@@ -262,7 +262,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_onLocalPaymentApiError_sendsAnalyticsEvents() = runTest(testDispatcher) {
+    fun `when localPaymentApi createPaymentMethod fails, createPaymentAuthRequest sends a payment failed analytics event`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -291,7 +291,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenPayPalDisabled_returnsErrorToCallback() = runTest(testDispatcher) {
+    fun `when PayPal is disabled in configuration, createPaymentAuthRequest returns a ConfigurationException to callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalDisabledConfig)
             .build()
@@ -316,7 +316,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenAmountIsNull_returnsErrorToCallback() = runTest(testDispatcher) {
+    fun `when request amount is null, createPaymentAuthRequest returns a validation error to callback`() = runTest(testDispatcher) {
         val request = createLocalPaymentRequest()
         request.amount = null
 
@@ -337,7 +337,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenPaymentTypeIsNull_returnsErrorToCallback() = runTest(testDispatcher) {
+    fun `when request paymentType is null, createPaymentAuthRequest returns a validation error to callback`() = runTest(testDispatcher) {
         val request = createLocalPaymentRequest()
         request.paymentType = null
 
@@ -358,7 +358,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCreatePaymentMethodError_returnsErrorToCallback() = runTest(testDispatcher) {
+    fun `when createPaymentMethod fails, createPaymentAuthRequest returns a wrapped BraintreeException to callback`() = runTest(testDispatcher) {
         val localPaymentApi = MockkLocalPaymentApiBuilder()
             .createPaymentMethodError(Exception("error"))
             .build()
@@ -388,7 +388,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCreatePaymentMethodSuccess_returnsLocalPaymentResultToCallback() =
+    fun `when createPaymentMethod succeeds, createPaymentAuthRequest returns ReadyToLaunch params to callback`() =
         runTest(testDispatcher) {
         val localPaymentApi = MockkLocalPaymentApiBuilder()
             .createPaymentMethodSuccess(localPaymentAuthRequestParams)
@@ -413,7 +413,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_success_withEmptyPaymentId_sendsAnalyticsEvents() = runTest(testDispatcher) {
+    fun `when payment id is empty, createPaymentAuthRequest sends analytics events without a payment id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -450,7 +450,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_success_withPaymentId_sendsAnalyticsEvents() = runTest(testDispatcher) {
+    fun `when payment id is present, createPaymentAuthRequest sends analytics events with that payment id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
             .build()
@@ -489,7 +489,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun buildBrowserSwitchOptions_returnsLocalPaymentResultWithBrowserSwitchOptions() = runTest(testDispatcher) {
+    fun `when buildBrowserSwitchOptions is called, returns ReadyToLaunch params with expected browser switch options`() = runTest(testDispatcher) {
         val request = createLocalPaymentRequest()
         val approvalUrl = "https://sample.com/approval?token=sample-token"
         val transaction = LocalPaymentAuthRequestParams(request, approvalUrl, "payment-id")
@@ -513,7 +513,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun testBrowserSwitchOptions_NewTask_RequestCode() = runTest(testDispatcher) {
+    fun `when buildBrowserSwitchOptions is called, isLaunchAsNewTask defaults to false`() = runTest(testDispatcher) {
         every { braintreeClient.launchesBrowserSwitchAsNewTask() } returns true
 
         val request = createLocalPaymentRequest()
@@ -530,7 +530,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun buildBrowserSwitchOptions_sendsAnalyticsEvents() = runTest(testDispatcher) {
+    fun `when buildBrowserSwitchOptions is called, sends a browser switch succeeded analytics event`() = runTest(testDispatcher) {
         val request = createLocalPaymentRequest()
         val approvalUrl = "https://sample.com/approval?token=sample-token"
         val transaction = createLocalPaymentAuthRequestParams(request, approvalUrl, "payment-id")
@@ -548,7 +548,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenPostFailure_notifiesCallbackOfErrorAlongWithAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when tokenize POST fails, notifies callback of the error and sends a payment failed analytics event`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -606,7 +606,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenResultOKAndSuccessful_tokenizesWithLocalPaymentApi() = runTest(testDispatcher) {
+    fun `when browser switch result is success, tokenize calls localPaymentApi tokenize with expected params`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -649,7 +649,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenResultOKAndTokenizationSucceeds_sendsResultToCallback() = runTest(testDispatcher) {
+    fun `when tokenization succeeds, tokenize sends the nonce result to callback`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -693,7 +693,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenResultOKAndTokenizationSuccess_sendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when tokenization succeeds, tokenize sends a payment succeeded analytics event`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -738,7 +738,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenResultOK_onConfigurationError_returnsError() = runTest(testDispatcher) {
+    fun `when configuration fetch fails during tokenize, returns the configuration error to callback`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -782,7 +782,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenResultOKAndUserCancels_notifiesCallbackAndSendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when the return url indicates a user cancellation, tokenize notifies callback and sends a payment canceled analytics event`() = runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
             .put("payment-type", "ideal")
@@ -816,7 +816,7 @@ class LocalPaymentClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun onBrowserSwitchResult_sends_the_correct_value_of_hasUserLocationConsent_to_getClientMetadataId() =
+    fun `when request has-user-location-consent metadata is true, tokenize passes that value to getClientMetadataId`() =
     runTest(testDispatcher) {
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)
         every { browserSwitchResult.requestMetadata } returns JSONObject()
@@ -868,7 +868,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when braintreeClient throws CancellationException, createPaymentAuthRequest never invokes the callback`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
@@ -890,7 +890,7 @@ class LocalPaymentClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when braintreeClient throws CancellationException, tokenize never invokes the callback`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))

--- a/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentRequestUnitTest.kt
+++ b/LocalPayment/src/test/java/com/braintreepayments/api/localpayment/LocalPaymentRequestUnitTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 class LocalPaymentRequestUnitTest {
     @Test
     @Throws(JSONException::class)
-    fun build_setsAllParams() {
+    fun `when build is called, generates JSON payload with all request params set`() {
         val address = PostalAddress()
         address.streetAddress = "836486 of 22321 Park Lake"
         address.extendedAddress = "Apt 2"

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAnalyticsUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class PayPalAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `PayPalAnalytics constants match expected event names`() {
         assertEquals("paypal:tokenize:started", PayPalAnalytics.TOKENIZATION_STARTED)
         assertEquals("paypal:tokenize:failed", PayPalAnalytics.TOKENIZATION_FAILED)
         assertEquals("paypal:tokenize:succeeded", PayPalAnalytics.TOKENIZATION_SUCCEEDED)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -52,6 +52,7 @@ import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class PayPalClientUnitTest {
     private val testDispatcher = StandardTestDispatcher()
     private val activity = mockk<FragmentActivity>(relaxed = true)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -78,7 +78,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun initialization_sets_app_link_in_analyticsParamRepository() {
+    fun `when return link type is app link, analyticsParamRepository linkType is set to APP_LINK`() {
         val payPalVaultRequest = PayPalVaultRequest(true)
         val paymentAuthRequest = PayPalPaymentAuthRequestParams(
             payPalVaultRequest,
@@ -105,7 +105,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun initialization_sets_deep_link_in_analyticsParamRepository() {
+    fun `when return link type is deep link, analyticsParamRepository linkType is set to DEEP_LINK`() {
         every { getReturnLinkTypeUseCase.invoke() } returns ReturnLinkTypeResult.DEEP_LINK
         val payPalVaultRequest = PayPalVaultRequest(true)
         val paymentAuthRequest = PayPalPaymentAuthRequestParams(
@@ -135,7 +135,7 @@ class PayPalClientUnitTest {
     @OptIn(ExperimentalBetaApi::class)
     @Test
     @Throws(JSONException::class)
-    fun createPaymentAuthRequest_callsBackPayPalResponse_sendsStartedAnalytics() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest succeeds for vault request, callback receives ready to launch request and started analytics are sent`() = runTest(testDispatcher) {
         val payPalVaultRequest = PayPalVaultRequest(true)
         payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
         payPalVaultRequest.shopperSessionId = "test-shopper-session-id"
@@ -203,7 +203,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_launchesBrowserSwitchWith_ACTIVITY_CLEAR_TOP() = runTest(testDispatcher) {
+    fun `when braintreeClient launches browser switch as new task, browserSwitchOptions launchType is ACTIVITY_CLEAR_TOP`() = runTest(testDispatcher) {
         val payPalVaultRequest = PayPalVaultRequest(true)
         payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
 
@@ -245,7 +245,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_setsAppLinkReturnUrl() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns an app link, browserSwitchOptions appLinkUri is set`() = runTest(testDispatcher) {
         every { getReturnLinkUseCase.invoke(any()) } returns AppLink("www.example.com".toUri())
         val payPalVaultRequest = PayPalVaultRequest(true)
         payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
@@ -289,7 +289,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_setsDeepLinkReturnUrlScheme() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns a deep link, browserSwitchOptions returnUrlScheme is set`() = runTest(testDispatcher) {
         every { getReturnLinkUseCase.invoke(any()) } returns DeepLink("com.braintreepayments.demo")
         val payPalVaultRequest = PayPalVaultRequest(true)
         payPalVaultRequest.merchantAccountId = "sample-merchant-account-id"
@@ -331,7 +331,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_returnsAnErrorWhen_getReturnLinkUseCase_returnsAFailure() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns a failure, callback receives failure with that error`() = runTest(testDispatcher) {
         val exception = BraintreeException()
         every { getReturnLinkUseCase.invoke(any()) } returns ReturnLinkResult.Failure(exception)
 
@@ -372,7 +372,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenPayPalNotEnabled_returnsError() = runTest(testDispatcher) {
+    fun `when PayPal is not enabled in configuration, callback receives failure and failed analytics are sent`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val braintreeClient =
@@ -409,7 +409,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCheckoutRequest_whenConfigError_forwardsErrorToListener() =
+    fun `when configuration fetch fails for a checkout request, callback receives failure with that error`() =
         runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
@@ -447,7 +447,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun requestBillingAgreement_whenConfigError_forwardsErrorToListener() = runTest(testDispatcher) {
+    fun `when configuration fetch fails for a vault request, callback receives failure with that error`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val errorMessage = "Error fetching auth"
@@ -480,7 +480,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sets_analyticsParamRepository_didEnablePayPalAppSwitch() = runTest(testDispatcher) {
+    fun `when payPalRequest enables app switch, analyticsParamRepository didEnablePayPalAppSwitch is set to true`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val braintreeClient =
@@ -507,7 +507,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenVaultRequest_sendsPayPalRequestViaInternalClient() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with a vault request, internal client sendRequest is invoked with that request`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val braintreeClient =
@@ -534,7 +534,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCheckoutRequest_sendsPayPalRequestViaInternalClient() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called with a checkout request, internal client sendRequest is invoked with that request`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val braintreeClient =
@@ -562,7 +562,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_withBillingAgreement_tokenizesResponseOnSuccess() = runTest(testDispatcher) {
+    fun `when tokenize is called with a billing agreement approval url, internal client tokenizes with expected payload`() = runTest(testDispatcher) {
         val payPalAccountNonce = mockk<PayPalAccountNonce>(relaxed = true)
         val payPalInternalClient =
             MockkPayPalInternalClientBuilder().tokenizeSuccess(payPalAccountNonce).build()
@@ -612,7 +612,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_withOneTimePayment_tokenizesResponseOnSuccess() = runTest(testDispatcher) {
+    fun `when tokenize is called with a one-time payment approval url, internal client tokenizes with expected payload`() = runTest(testDispatcher) {
         val payPalAccountNonce = mockk<PayPalAccountNonce>(relaxed = true)
         val payPalInternalClient =
             MockkPayPalInternalClientBuilder().tokenizeSuccess(payPalAccountNonce).build()
@@ -664,7 +664,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenCancelUriReceived_notifiesCancellationAndSendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when tokenize receives an onetouch cancel url, callback receives Cancel and browser login canceled analytics are sent`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val approvalUrl = "sample-scheme://onetouch/v1/cancel"
@@ -705,7 +705,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenPayPalInternalClientTokenizeResult_callsBackResult() = runTest(testDispatcher) {
+    fun `when internal client tokenize succeeds, callback receives Success and succeeded analytics are sent`() = runTest(testDispatcher) {
         val payPalAccountNonce = mockk<PayPalAccountNonce>(relaxed = true)
         val payPalInternalClient =
             MockkPayPalInternalClientBuilder().tokenizeSuccess(payPalAccountNonce).build()
@@ -753,7 +753,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenCancelUriReceived_sendsAppSwitchCanceledEvent() = runTest(testDispatcher) {
+    fun `when tokenize receives a cancel url with switch_initiated_time, callback receives Cancel and app switch canceled analytics are sent`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val approvalUrl = "https://some-scheme/cancel?switch_initiated_time=17166111926211"
@@ -789,7 +789,7 @@ class PayPalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenCancelUriReceived_sendsBrowserLoginCanceledEvent() = runTest(testDispatcher) {
+    fun `when tokenize receives a cancel url without switch_initiated_time, callback receives Cancel and browser login canceled analytics are sent`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val approvalUrl = "https://some-scheme/cancel"
@@ -824,7 +824,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenInternalClientSendRequestThrows_callsBackFailure() = runTest(testDispatcher) {
+    fun `when internal client sendRequest throws, callback receives failure and failed analytics are sent`() = runTest(testDispatcher) {
         val error = BraintreeException("sendRequest failed")
         val payPalInternalClient = MockkPayPalInternalClientBuilder()
             .sendRequestError(error)
@@ -853,7 +853,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenInternalClientTokenizeThrows_callsBackFailure() = runTest(testDispatcher) {
+    fun `when internal client tokenize throws IllegalStateException, callback receives failure and failed analytics are sent`() = runTest(testDispatcher) {
         val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
 
         val approvalUrl =
@@ -892,7 +892,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenInternalClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when internal client sendRequest throws CancellationException, callback is not invoked`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(payPalEnabledConfig)
@@ -910,7 +910,7 @@ class PayPalClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenInternalClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when internal client tokenize throws CancellationException, callback is not invoked`() = runTest(testDispatcher) {
         val approvalUrl = "sample-scheme://onetouch/v1/success?token=EC-HERMES-SANDBOX-EC-TOKEN"
 
         val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>(relaxed = true)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
@@ -278,7 +278,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequest_sendsAllParameters() = runTest(testDispatcher) {
+    fun `when sendRequest is called with a vault request with shipping, request body includes all expected parameters`() = runTest(testDispatcher) {
 
         every { clientToken.bearer } returns "client-token-bearer"
         every { merchantRepository.authorization } returns clientToken
@@ -323,7 +323,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequest_sendsAllParameters_with_deep_link() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns a deep link, request body uses deep link return and cancel urls`() = runTest(testDispatcher) {
         every { getReturnLinkUseCase.invoke() } returns DeepLink("com.braintreepayments.demo")
 
         every { clientToken.bearer } returns "client-token-bearer"
@@ -369,7 +369,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalCheckoutRequest_sendsAllParameters() = runTest(testDispatcher) {
+    fun `when sendRequest is called with a checkout request with all params, request body includes all expected parameters`() = runTest(testDispatcher) {
         every { clientToken.bearer } returns "client-token-bearer"
         every { merchantRepository.authorization } returns clientToken
 
@@ -387,7 +387,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withTokenizationKey_sendsClientKeyParam() = runTest(testDispatcher) {
+    fun `when authorization is a tokenization key, request body includes client_key instead of authorization_fingerprint`() = runTest(testDispatcher) {
         every { tokenizationKey.bearer } returns "tokenization-key-bearer"
 
         val slot = slot<String>()
@@ -406,7 +406,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withEmptyDisplayName_fallsBackToPayPalConfigurationDisplayName() = runTest(testDispatcher) {
+    fun `when displayName is empty, request body brand_name falls back to configuration display name`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns tokenizationKey
 
         val slot = slot<String>()
@@ -426,7 +426,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withLocaleNotSpecified_omitsLocale() = runTest(testDispatcher) {
+    fun `when localeCode is null, request body omits locale_code`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns tokenizationKey
 
         val slot = slot<String>()
@@ -442,7 +442,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withMerchantAccountIdNotSpecified_omitsMerchantAccountId() = runTest(testDispatcher) {
+    fun `when merchantAccountId is null, request body omits merchant_account_id`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns tokenizationKey
 
         val slot = slot<String>()
@@ -459,7 +459,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withShippingAddressOverrideNotSpecified_sendsAddressOverrideFalse() = runTest(testDispatcher) {
+    fun `when shippingAddressOverride is null, request body address_override is false`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns tokenizationKey
 
         val slot = slot<String>()
@@ -479,7 +479,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withShippingAddressSpecified_sendsAddressOverrideBasedOnShippingAddressEditability() =
+    fun `when shippingAddressOverride is set and not editable, request body address_override is true`() =
         runTest(testDispatcher) {
         every { clientToken.bearer } returns "client-token-bearer"
         every { merchantRepository.authorization } returns tokenizationKey
@@ -503,7 +503,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withPayPalVaultRequest_omitsEmptyBillingAgreementDescription() = runTest(testDispatcher) {
+    fun `when billingAgreementDescription is empty, request body omits description`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns tokenizationKey
 
         val slot = slot<String>()
@@ -520,7 +520,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withPayPalCheckoutRequest_fallsBackToPayPalConfigurationCurrencyCode() = runTest(testDispatcher) {
+    fun `when checkout request has no currencyCode, request body currency_iso_code falls back to configuration currency`() = runTest(testDispatcher) {
         val configuration = fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL_INR)
         every { merchantRepository.authorization } returns tokenizationKey
 
@@ -537,7 +537,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun sendRequest_withPayPalCheckoutRequest_omitsEmptyLineItems() = runTest(testDispatcher) {
+    fun `when lineItems is empty, request body omits line_items`() = runTest(testDispatcher) {
 
         every { merchantRepository.authorization } returns tokenizationKey
 
@@ -553,7 +553,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenRiskCorrelationIdNotNull_setsClientMetadataIdToRiskCorrelationId() = runTest(testDispatcher) {
+    fun `when riskCorrelationId is set, clientMetadataId is set to riskCorrelationId`() = runTest(testDispatcher) {
         every {
             dataCollector.getClientMetadataId(
                 eq(context),
@@ -574,7 +574,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenRiskCorrelationIdNull_setsClientMetadataIdFromPayPalDataCollector() = runTest(testDispatcher) {
+    fun `when riskCorrelationId is null, clientMetadataId is set from dataCollector`() = runTest(testDispatcher) {
         every {
             dataCollector.getClientMetadataId(
                 eq(context),
@@ -594,7 +594,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequest_callsBackPayPalResponseOnSuccess() = runTest(testDispatcher) {
+    fun `when sendRequest succeeds for a vault request, result contains expected contextId and approvalUrl`() = runTest(testDispatcher) {
         every {
             dataCollector.getClientMetadataId(
                 eq(context),
@@ -626,7 +626,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenServerReturnsNonAppSwitchFlow_setsDidPayPalServerAttemptAppSwitchToFalse() =
+    fun `when server response does not indicate app switch, analyticsParamRepository didPayPalServerAttemptAppSwitch is set to false`() =
         runTest(testDispatcher) {
         every {
             dataCollector.getClientMetadataId(
@@ -650,7 +650,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequest_callsBackPayPalResponseOnSuccess_returnsPayPalURL() =
+    fun `when server response contains a paypal redirect url, sendRequest returns that url as approvalUrl`() =
         runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
@@ -686,7 +686,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequest_callsBackPayPalResponseOnSuccess_returnsApprovalURL() =
+    fun `when server response contains an approval url, sendRequest returns that url and contextId as-is`() =
         runTest(testDispatcher) {
 
         every { merchantRepository.authorization } returns clientToken
@@ -707,7 +707,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalCheckoutRequest_callsBackPayPalResponseOnSuccess() = runTest(testDispatcher) {
+    fun `when sendRequest succeeds for a checkout request, result contains expected contextId and approvalUrl`() = runTest(testDispatcher) {
         every {
             dataCollector.getClientMetadataId(eq(context), eq(configuration), eq(true))
         } returns "sample-client-metadata-id"
@@ -734,7 +734,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_propagatesHttpErrors() = runTest(testDispatcher) {
+    fun `when braintreeClient sendPOST fails with IOException, sendRequest propagates that exception`() = runTest(testDispatcher) {
         val httpError = IOException("http error")
         every { getReturnLinkUseCase.invoke() } returns ReturnLinkResult.AppLink(Uri.parse("https://example.com"))
         every { merchantRepository.authorization } returns clientToken
@@ -748,7 +748,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_propagatesMalformedJSONResponseErrors() = runTest(testDispatcher) {
+    fun `when server response is malformed JSON, sendRequest propagates JSONException`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         val sut = createSutWithMocks(fixture = "{bad:")
 
@@ -759,7 +759,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_returnLinkResultFailure_forwardsError() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns a failure, sendRequest propagates that error`() = runTest(testDispatcher) {
         val exception = BraintreeException()
         every { getReturnLinkUseCase.invoke() } returns ReturnLinkResult.Failure(exception)
         every { merchantRepository.authorization } returns clientToken
@@ -774,7 +774,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun tokenize_tokenizesWithApiClient() = runTest(testDispatcher) {
+    fun `when tokenize is called, apiClient tokenizeREST is invoked with the payPalAccount`() = runTest(testDispatcher) {
         val payPalAccount = mockk<PayPalAccount>(relaxed = true)
         val apiClient = mockk<ApiClient>(relaxed = true)
         coEvery { apiClient.tokenizeREST(any()) } returns
@@ -789,7 +789,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_returnsAccountNonce() = runTest(testDispatcher) {
+    fun `when apiClient tokenizeREST succeeds, tokenize returns the expected account nonce`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTSuccess(
                 JSONObject(Fixtures.PAYMENT_METHODS_PAYPAL_ACCOUNT_RESPONSE)
@@ -806,7 +806,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenApiClientThrows_propagatesError() = runTest(testDispatcher) {
+    fun `when apiClient tokenizeREST throws, tokenize propagates that error`() = runTest(testDispatcher) {
         val error = IOException("error")
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTError(error)
@@ -823,7 +823,7 @@ class PayPalInternalClientUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun payPalDataCollector_passes_correct_arguments_to_getClientMetadataId() = runTest(testDispatcher) {
+    fun `when sendRequest is called, dataCollector getClientMetadataId is invoked with hasUserLocationConsent true`() = runTest(testDispatcher) {
         val configuration = fromJson(Fixtures.CONFIGURATION_WITH_LIVE_PAYPAL)
 
         every { merchantRepository.authorization } returns clientToken
@@ -848,7 +848,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalVaultRequestAndAppSwitchEnabled_addsAppSwitchParameters() = runTest(testDispatcher) {
+    fun `when vault request enables app switch, approvalUrl includes app switch query parameters`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { getAppSwitchUseCase.invoke() } returns true
@@ -873,7 +873,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_withPayPalCheckoutRequestAndAppSwitchEnabled_addsAppSwitchParameters() = runTest(testDispatcher) {
+    fun `when checkout request enables app switch, approvalUrl includes app switch query parameters`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { getAppSwitchUseCase.invoke() } returns true
@@ -899,7 +899,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenShouldOfferCredit_addsCreditQueryParameter() = runTest(testDispatcher) {
+    fun `when shouldOfferCredit is true, approvalUrl funding_source is credit`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { getAppSwitchUseCase.invoke() } returns true
@@ -921,7 +921,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenShouldOfferPayLater_addsPayLaterQueryParameter() = runTest(testDispatcher) {
+    fun `when shouldOfferPayLater is true, approvalUrl funding_source is pay later`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { getAppSwitchUseCase.invoke() } returns true
@@ -943,7 +943,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenPayPalAppNotInstalled_disablesAppSwitch() = runTest(testDispatcher) {
+    fun `when PayPal app is not installed, setAppSwitchUseCase is invoked with merchantEnabledAppSwitch false`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { deviceInspector.isPayPalInstalled() } returns false
@@ -964,7 +964,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenPayPalAppCannotHandleURL_disablesAppSwitch() = runTest(testDispatcher) {
+    fun `when resolvePayPalUseCase returns false, setAppSwitchUseCase is invoked with merchantEnabledAppSwitch false`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { deviceInspector.isPayPalInstalled() } returns true
@@ -985,7 +985,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenPayPalInstalledAndCanHandleURL_enablesAppSwitch() = runTest(testDispatcher) {
+    fun `when PayPal is installed and resolvePayPalUseCase returns true, setAppSwitchUseCase is invoked with merchantEnabledAppSwitch true`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
         every { deviceInspector.isPayPalInstalled() } returns true
@@ -1006,7 +1006,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenEnablePayPalAppSwitchFalse_doesNotCheckPayPalInstallation() = runTest(testDispatcher) {
+    fun `when enablePayPalAppSwitch is false, PayPal installation is not checked`() = runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
 
@@ -1027,7 +1027,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenServerReturnsAppSwitchFlow_setsDidPayPalServerAttemptAppSwitchToTrue() =
+    fun `when server response indicates app switch, analyticsParamRepository didPayPalServerAttemptAppSwitch is set to true`() =
         runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")
@@ -1052,7 +1052,7 @@ class PayPalInternalClientUnitTest {
     }
 
     @Test
-    fun sendRequest_whenMerchantEnablesAppSwitchButServerReturnsAppSwitchFalse_setsBothCorrectly() =
+    fun `when merchant enables app switch but server does not indicate app switch, merchantEnabledAppSwitch is true and appSwitchFlowFromPayPalResponse is false`() =
         runTest(testDispatcher) {
         every { merchantRepository.authorization } returns clientToken
         every { merchantRepository.appLinkReturnUri } returns Uri.parse("https://example.com")

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalInternalClientUnitTest.kt
@@ -50,6 +50,7 @@ import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class PayPalInternalClientUnitTest {
     private val testDispatcher = StandardTestDispatcher()
 

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalLauncherUnitTest.kt
@@ -68,7 +68,7 @@ class PayPalLauncherUnitTest {
     }
 
     @Test
-    fun `launch starts browser switch and returns pending request`() {
+    fun `when launch is called, browser switch is started and pending request is returned`() {
         val startedPendingRequest = BrowserSwitchStartResult.Started(pendingRequestString)
         every { browserSwitchClient.start(activity, options, any()) } returns startedPendingRequest
 
@@ -83,7 +83,7 @@ class PayPalLauncherUnitTest {
     }
 
     @Test
-    fun `launch on error returns pending request failure`() {
+    fun `when browser switch start fails, launch returns pending request failure`() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
         val exception = BrowserSwitchException("error")
         every { browserSwitchClient.start(eq(activity), eq(options), any()) } returns
@@ -98,7 +98,7 @@ class PayPalLauncherUnitTest {
 
     @Test
     @Throws(BrowserSwitchException::class)
-    fun `launch when device cant perform browser switch returns pending request failure`() {
+    fun `when device can't perform browser switch, launch returns pending request failure`() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
         val exception = BrowserSwitchException("browser switch error")
         every {
@@ -363,7 +363,7 @@ class PayPalLauncherUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `handleReturnToApp when result exists returns result`() {
+    fun `when a browser switch result exists, handleReturnToApp returns result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         every {
             browserSwitchClient.completeRequest(
@@ -520,7 +520,7 @@ class PayPalLauncherUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun `handleReturnToApp when result does not exist returns null`() {
+    fun `when no browser switch result exists, handleReturnToApp returns NoResult`() {
         every {
             browserSwitchClient.completeRequest(intent, pendingRequestString)
         } returns BrowserSwitchFinalResult.NoResult

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalyticsUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class SEPADirectDebitAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants have expected event name values`() {
         assertEquals(
             "sepa:tokenize:started",
             SEPADirectDebitAnalytics.TOKENIZE_STARTED

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
@@ -30,6 +30,7 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class SEPADirectDebitClientUnitTest {
 
     private lateinit var braintreeClient: BraintreeClient

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
@@ -45,7 +45,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun createPaymentAuthRequest_onCreateMandateRequestSuccess_callsBackSEPAResponse_andSendsAnalytics() =
+    fun `when create mandate succeeds with approval url, createPaymentAuthRequest returns ReadyToLaunch with browser switch options and sends analytics`() =
         runTest(testDispatcher) {
         val createMandateResult = CreateMandateResult(
             approvalUrl = "http://www.example.com",
@@ -96,7 +96,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun createPaymentAuthRequest_whenMandateApproved_onTokenizeSuccess_callsBackWithNonce_andSendsAnalytics() =
+    fun `when mandate already approved and tokenize succeeds, createPaymentAuthRequest returns LaunchNotRequired with nonce and sends analytics`() =
         runTest(testDispatcher) {
         val createMandateResult = CreateMandateResult(
             approvalUrl = "null",
@@ -133,7 +133,7 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_onCreateMandateRequestSuccess_whenApprovalURLInvalid_callsBackError() =
+    fun `when create mandate succeeds but approval url is empty, createPaymentAuthRequest returns Failure and sends failure analytics`() =
         runTest(testDispatcher) {
         val createMandateResult = CreateMandateResult(
             approvalUrl = "",
@@ -180,7 +180,7 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenMandateApproved_callsTokenizeAndSendsAnalytics() =
+    fun `when mandate already approved, createPaymentAuthRequest calls tokenize with mandate details and sends analytics`() =
         runTest(testDispatcher) {
         val createMandateResult = CreateMandateResult(
             approvalUrl = "null",
@@ -215,7 +215,7 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_onCreateMandateError_returnsErrorToListener_andSendsAnalytics() =
+    fun `when create mandate fails with error, createPaymentAuthRequest returns Failure with that error and sends failure analytics`() =
         runTest(testDispatcher) {
         val error = Exception("error")
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
@@ -254,7 +254,7 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenApiThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when create mandate throws CancellationException, createPaymentAuthRequest callback is not invoked`() = runTest(testDispatcher) {
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
             .createMandateError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
             .build()
@@ -270,7 +270,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenDeepLinkContainsSuccess_callsTokenize_andSendsAnalytics() =
+    fun `when browser switch return url indicates success, tokenize calls api tokenize with metadata and sends challenge succeeded analytics`() =
         runTest(testDispatcher) {
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder().build()
 
@@ -309,7 +309,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_onTokenizeSuccess_callsBackNonce_andSendsAnalytics() =
+    fun `when api tokenize succeeds, tokenize returns Success with nonce and sends tokenize succeeded analytics`() =
         runTest(testDispatcher) {
         val nonce = fromJSON(JSONObject(Fixtures.SEPA_DEBIT_TOKENIZE_RESPONSE))
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
@@ -345,7 +345,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_onTokenizeFailure_callsBackError_andSendsAnalytics() =
+    fun `when api tokenize fails, tokenize returns Failure with that error and sends tokenize failed analytics`() =
         runTest(testDispatcher) {
         val exception = Exception("tokenize error")
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
@@ -397,7 +397,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_onTokenizeSuccess_callsBackResult() =
+    fun `when api tokenize succeeds, tokenize returns Success result with nonce`() =
         runTest(testDispatcher) {
         val nonce = fromJSON(JSONObject(Fixtures.SEPA_DEBIT_TOKENIZE_RESPONSE))
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
@@ -430,7 +430,7 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenDeepLinkContainsCancel_callsBackError_andSendsAnalytics() =
+    fun `when browser switch return url indicates cancel, tokenize returns Cancel and sends challenge canceled analytics`() =
         runTest(testDispatcher) {
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder().build()
 
@@ -462,7 +462,7 @@ class SEPADirectDebitClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenApiThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when api tokenize throws CancellationException, tokenize callback is not invoked`() = runTest(testDispatcher) {
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
             .tokenizeError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
             .build()

--- a/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
+++ b/SEPADirectDebit/src/test/java/com/braintreepayments/api/sepadirectdebit/SEPADirectDebitClientUnitTest.kt
@@ -396,40 +396,6 @@ class SEPADirectDebitClientUnitTest {
     }
 
     @Test
-    @Throws(JSONException::class)
-    fun `when api tokenize succeeds, tokenize returns Success result with nonce`() =
-        runTest(testDispatcher) {
-        val nonce = fromJSON(JSONObject(Fixtures.SEPA_DEBIT_TOKENIZE_RESPONSE))
-        val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder()
-            .tokenizeSuccess(nonce)
-            .build()
-
-        val metadata = JSONObject()
-            .put("ibanLastFour", "1234")
-            .put("customerId", "customer-id")
-            .put("bankReferenceToken", "bank-reference-token")
-            .put("mandateType", "ONE_OFF")
-
-        val browserSwitchResult = mockk<BrowserSwitchFinalResult.Success>()
-        val returnUri = Uri.parse("com.braintreepayments.demo.braintree://sepa/success?success=true")
-        every { browserSwitchResult.returnUrl } returns returnUri
-        every { browserSwitchResult.requestMetadata } returns metadata
-
-        braintreeClient = MockkBraintreeClientBuilder().build()
-
-        val sut = SEPADirectDebitClient(braintreeClient, sepaDirectDebitApi, testDispatcher)
-        val sepaBrowserSwitchResult = SEPADirectDebitPaymentAuthResult.Success(browserSwitchResult)
-
-        var result: SEPADirectDebitResult? = null
-        sut.tokenize(sepaBrowserSwitchResult) { result = it }
-
-        advanceUntilIdle()
-
-        assertTrue(result is SEPADirectDebitResult.Success)
-        assertEquals(nonce, (result as SEPADirectDebitResult.Success).nonce)
-    }
-
-    @Test
     fun `when browser switch return url indicates cancel, tokenize returns Cancel and sends challenge canceled analytics`() =
         runTest(testDispatcher) {
         val sepaDirectDebitApi = MockkSEPADirectDebitApiBuilder().build()

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/EligiblePaymentsApiResultUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/EligiblePaymentsApiResultUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class EligiblePaymentsApiResultUnitTest {
 
     @Test
-    fun testVenmoFromJson() {
+    fun `when fromJson is called with venmo eligibility fields, canBeVaulted, eligibleInPayPalNetwork, and recommended are parsed and recommendedPriority defaults to 0`() {
         // Sample JSON string
         val jsonString = """
             {
@@ -33,7 +33,7 @@ class EligiblePaymentsApiResultUnitTest {
     }
 
     @Test
-    fun testPayPalFromJson() {
+    fun `when fromJson is called with paypal eligibility fields, canBeVaulted, eligibleInPayPalNetwork, recommended, and recommendedPriority are parsed`() {
         // Sample JSON string
         val jsonString = """
             {

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/EligiblePaymentsApiResultUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/EligiblePaymentsApiResultUnitTest.kt
@@ -3,6 +3,7 @@ package com.braintreepayments.api.shopperinsights
 import org.junit.Assert.*
 import org.junit.Test
 
+@Suppress("MaxLineLength")
 class EligiblePaymentsApiResultUnitTest {
 
     @Test

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
@@ -47,7 +47,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_configuresDefaultCardinalConfigurationParameters() = runTest {
+    fun `when initialize is called, configures default cardinal configuration parameters`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { cardinalInstance.init(any(), any()) } answers {
             secondArg<CardinalInitService>().onSetupCompleted("session-id")
@@ -68,7 +68,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_whenV2UiCustomizationNotNull_setsCardinalConfigurationParameters() = runTest {
+    fun `when initialize is called with v2UiCustomization set, sets toolbar customization on cardinal configuration parameters`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { cardinalInstance.init(any(), any()) } answers {
             secondArg<CardinalInitService>().onSetupCompleted("session-id")
@@ -92,7 +92,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_whenEnvironmentProduction_configuresCardinalEnvironmentProduction() = runTest {
+    fun `when initialize is called with production environment, configures cardinal environment as production`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { configuration.environment } returns "production"
         every { cardinalInstance.init(any(), any()) } answers {
@@ -112,7 +112,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_whenUiTypeNotNull_setsCardinalConfigurationParameters() = runTest {
+    fun `when initialize is called with uiType set, sets uiType on cardinal configuration parameters`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { cardinalInstance.init(any(), any()) } answers {
             secondArg<CardinalInitService>().onSetupCompleted("session-id")
@@ -133,7 +133,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_whenRenderTypeNotNull_setsCardinalConfigurationParameters() = runTest {
+    fun `when initialize is called with renderTypes set, sets render types on cardinal configuration parameters`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { cardinalInstance.init(any(), any()) } answers {
             secondArg<CardinalInitService>().onSetupCompleted("session-id")
@@ -160,7 +160,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_returnsConsumerSessionId() = runTest {
+    fun `when initialize completes setup, returns and stores the consumer session id`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { configuration.cardinalAuthenticationJwt } returns "token"
 
@@ -179,7 +179,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun initialize_whenConsumerSessionIdIsNull_throwsBraintreeException() = runTest {
+    fun `when initialize validation returns a null session id, throws BraintreeException`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { configuration.cardinalAuthenticationJwt } returns "token"
 
@@ -218,7 +218,7 @@ class CardinalClientUnitTest {
     }
 
     @Test
-    fun initialize_onCardinalConfigureRuntimeException_throwsError() = runTest {
+    fun `when cardinal configure throws a runtime exception, initialize throws BraintreeException wrapping it`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { configuration.cardinalAuthenticationJwt } returns "token"
 
@@ -237,7 +237,7 @@ class CardinalClientUnitTest {
     }
 
     @Test
-    fun initialize_onCardinalInitRuntimeException_throwsError() = runTest {
+    fun `when cardinal init throws a runtime exception, initialize throws BraintreeException wrapping it`() = runTest {
         every { Cardinal.getInstance() } returns cardinalInstance
         every { configuration.cardinalAuthenticationJwt } returns "token"
 
@@ -257,7 +257,7 @@ class CardinalClientUnitTest {
 
     @Test
     @Throws(BraintreeException::class)
-    fun continueLookup_continuesCardinalLookup() {
+    fun `when continueLookup is called, continues cardinal lookup with transaction id and pareq`() {
         every { Cardinal.getInstance() } returns cardinalInstance
 
         val sut = CardinalClient()
@@ -280,7 +280,7 @@ class CardinalClientUnitTest {
     }
 
     @Test
-    fun continueLookup_onCardinalRuntimeException_throwsError() {
+    fun `when cardinal cca_continue throws a runtime exception, continueLookup throws BraintreeException wrapping it`() {
         every { Cardinal.getInstance() } returns cardinalInstance
 
         val runtimeException = RuntimeException("fake message")
@@ -315,7 +315,7 @@ class CardinalClientUnitTest {
     }
 
     @Test
-    fun cleanup_cleansUpCardinalInstance() {
+    fun `when cleanup is called, cleans up cardinal instance`() {
         every { Cardinal.getInstance() } returns cardinalInstance
 
         val sut = CardinalClient()

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/CardinalClientUnitTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("MaxLineLength")
 class CardinalClientUnitTest {
 
     private lateinit var cardinalInstance: Cardinal

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
@@ -26,7 +26,7 @@ class ThreeDSecureAPIUnitTest {
     private val testDispatcher = StandardTestDispatcher()
 
     @Test
-    fun performLookup_sendsPOSTRequest() = runTest(testDispatcher) {
+    fun `when performLookup is called, sends POST request to lookup endpoint with built request data`() = runTest(testDispatcher) {
         val urlSlot = slot<String>()
         val dataSlot = slot<String>()
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -53,7 +53,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun performLookup_onSuccess_returnsThreeDSecureResult() = runTest(testDispatcher) {
+    fun `when performLookup succeeds, returns a non-null ThreeDSecureParams result`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_LOOKUP_RESPONSE)
             .build()
@@ -67,7 +67,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun performLookup_onInvalidJSONResponse_throwsJSONException() = runTest(testDispatcher) {
+    fun `when performLookup receives an invalid JSON response, throws JSONException`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse("invalid json")
             .build()
@@ -82,7 +82,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun performLookup_onPOSTFailure_throwsHTTPError() = runTest(testDispatcher) {
+    fun `when the POST request fails, performLookup throws the underlying IOException`() = runTest(testDispatcher) {
         val httpError = IOException("http error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostErrorResponse(httpError)
@@ -101,7 +101,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_sendsPOSTRequest() = runTest(testDispatcher) {
+    fun `when authenticateCardinalJWT is called, sends POST request to authenticate_from_jwt endpoint`() = runTest(testDispatcher) {
         val urlSlot = slot<String>()
         val dataSlot = slot<String>()
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -133,7 +133,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_onSuccess_returnsThreeDSecureResult() = runTest(testDispatcher) {
+    fun `when authenticateCardinalJWT succeeds, returns a non-null ThreeDSecureParams result`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE)
             .build()
@@ -147,7 +147,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_onThreeDSecureError_returnsResultWithOriginalLookupNonce() =
+    fun `when authenticateCardinalJWT response contains a three d secure error, returns result with a nonce`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(Fixtures.THREE_D_SECURE_AUTHENTICATION_RESPONSE_WITH_ERROR)
@@ -162,7 +162,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_onInvalidJSONResponse_throwsJSONException() = runTest(testDispatcher) {
+    fun `when authenticateCardinalJWT receives an invalid JSON response, throws JSONException`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse("not-json")
             .build()
@@ -177,7 +177,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_onPOSTFailure_throwsHTTPError() = runTest(testDispatcher) {
+    fun `when the POST request fails, authenticateCardinalJWT throws the underlying IOException`() = runTest(testDispatcher) {
         val postError = IOException("post-error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostErrorResponse(postError)
@@ -196,7 +196,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_whenCustomerFailsAuthentication_returnsLookupCardNonce() = runTest(testDispatcher) {
+    fun `when customer fails authentication, authenticateCardinalJWT returns lookup nonce with liability not shifted and an error message`() = runTest(testDispatcher) {
         val authResponseJson = Fixtures.THREE_D_SECURE_V2_AUTHENTICATION_RESPONSE_WITH_ERROR
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostSuccessfulResponse(authResponseJson)
@@ -223,7 +223,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_whenPostError_throwsException() = runTest(testDispatcher) {
+    fun `when the POST request errors, authenticateCardinalJWT rethrows the exception`() = runTest(testDispatcher) {
         val exception = IOException("Error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendPostErrorResponse(exception)
@@ -241,7 +241,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_whenJWTNull_throwsException() = runTest(testDispatcher) {
+    fun `when jwt is null, authenticateCardinalJWT throws BraintreeException`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
         val threeDSecureParams = ThreeDSecureParams.fromJson(Fixtures.THREE_D_SECURE_V2_LOOKUP_RESPONSE)
 
@@ -253,7 +253,7 @@ class ThreeDSecureAPIUnitTest {
     }
 
     @Test
-    fun authenticateCardinalJWT_whenThreeDSecureParamsNull_throwsException() = runTest(testDispatcher) {
+    fun `when threeDSecureParams is null, authenticateCardinalJWT throws BraintreeException`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
         val sut = ThreeDSecureAPI(braintreeClient)

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAPIUnitTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("MaxLineLength")
 class ThreeDSecureAPIUnitTest {
     private val testDispatcher = StandardTestDispatcher()
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAnalyticsUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class ThreeDSecureAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants match expected event names`() {
         assertEquals("3ds:verify:started", ThreeDSecureAnalytics.VERIFY_STARTED)
         assertEquals("3ds:verify:succeeded", ThreeDSecureAnalytics.VERIFY_SUCCEEDED)
         assertEquals("3ds:verify:failed", ThreeDSecureAnalytics.VERIFY_FAILED)

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
@@ -33,6 +33,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class ThreeDSecureClientUnitTest {
     private val testDispatcher = StandardTestDispatcher()
 

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureClientUnitTest.kt
@@ -67,7 +67,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_returnsValidLookupJSONString() = runTest(testDispatcher) {
+    fun `when prepareLookup succeeds, returns a valid lookup JSON string containing request data`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("fake-df")
             .build()
@@ -116,7 +116,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_initializesCardinal() = runTest(testDispatcher) {
+    fun `when prepareLookup is called, initializes the cardinal client`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("fake-df")
             .build()
@@ -149,7 +149,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_whenCardinalClientInitializeFails_forwardsError() = runTest(testDispatcher) {
+    fun `when cardinal client initialize fails during prepareLookup, forwards the error to the callback`() = runTest(testDispatcher) {
         val initializeRuntimeError = BraintreeException("initialize error")
         val cardinalClient = MockkCardinalClientBuilder()
             .initializeRuntimeError(initializeRuntimeError)
@@ -182,7 +182,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_whenDfReferenceIdMissing_forwardsError() = runTest(testDispatcher) {
+    fun `when dfReferenceId is missing during prepareLookup, forwards a BraintreeException to the callback`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("")
             .build()
@@ -217,7 +217,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_withoutCardinalJWT_postsException() = runTest(testDispatcher) {
+    fun `when merchant is not configured for 3D Secure version 2, prepareLookup posts a BraintreeException`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
             .threeDSecureEnabled(true)
@@ -256,7 +256,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsAnalyticEvent() {
+    fun `when createPaymentAuthRequest is called, sends verify started analytic event`() {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("sample-session-id")
             .build()
@@ -277,7 +277,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsParamsInLookupRequest() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, sends request params including exemption type in the lookup POST body`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("df-reference-id")
             .build()
@@ -324,7 +324,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_performsLookup_WhenCardinalSDKInitFails() = runTest(testDispatcher) {
+    fun `when cardinal SDK init fails, createPaymentAuthRequest still performs the lookup POST without df reference id`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .error(Exception("error"))
             .build()
@@ -374,7 +374,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_callsLookupListener() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest completes the lookup, calls back the payment auth request listener`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("sample-session-id")
             .build()
@@ -409,7 +409,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_withInvalidRequest_postsException() = runTest(testDispatcher) {
+    fun `when the request nonce and amount are null, createPaymentAuthRequest posts a Failure with a BraintreeException`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
 
         val braintreeClient = MockkBraintreeClientBuilder().build()
@@ -441,7 +441,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_initializesCardinal() = runTest(testDispatcher) {
+    fun `when createPaymentAuthRequest is called, initializes the cardinal client`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("df-reference-id")
             .build()
@@ -466,7 +466,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCardinalClientInitializeFails_forwardsError() = runTest(testDispatcher) {
+    fun `when cardinal client initialize fails during createPaymentAuthRequest, forwards the error as a Failure`() = runTest(testDispatcher) {
         val initializeRuntimeError = BraintreeException("initialize error")
         val cardinalClient = MockkCardinalClientBuilder()
             .initializeRuntimeError(initializeRuntimeError)
@@ -497,7 +497,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCardinalSetupFailed_sendsAnalyticEvent() = runTest(testDispatcher) {
+    fun `when cardinal setup fails during createPaymentAuthRequest, sends verify started and verify failed analytics events`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .initializeRuntimeError(BraintreeException("cardinal error"))
             .build()
@@ -526,7 +526,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_withoutCardinalJWT_postsException() = runTest(testDispatcher) {
+    fun `when merchant is not configured for 3D Secure version 2, createPaymentAuthRequest posts a Failure with a BraintreeException`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
 
         val configuration = Configuration.fromJson(TestConfigurationBuilder()
@@ -563,7 +563,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun sendAnalyticsAndResult_whenAuthenticatingWithCardinal_sendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when sendAnalyticsAndResult is called, sends lookup succeeded analytics event`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("reference-id")
             .build()
@@ -588,7 +588,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun sendAnalyticsAndResult_whenChallengeIsRequired_sendsAnalyticsEvent() = runTest(testDispatcher) {
+    fun `when the lookup requires a challenge, sendAnalyticsAndResult sends lookup succeeded and challenge required analytics events`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("reference-id")
             .build()
@@ -615,7 +615,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun sendAnalyticsAndResult_whenChallengeIsNotPresented_returnsResult() = runTest(testDispatcher) {
+    fun `when the lookup has no acs url, sendAnalyticsAndResult returns a LaunchNotRequired result with the nonce and lookup`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("reference-id")
             .build()
@@ -642,7 +642,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun sendAnalyticsAndResult_callsBackThreeDSecureResultForLaunch() = runTest(testDispatcher) {
+    fun `when a challenge is required, sendAnalyticsAndResult returns a ReadyToLaunch result with the request params`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("reference-id")
             .build()
@@ -668,7 +668,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenErrorExists_forwardsErrorToCallback_andSendsAnalytics() = runTest(testDispatcher) {
+    fun `when the payment auth result contains an error, tokenize forwards the error to the callback`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
@@ -694,7 +694,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenValidateResponseTimeout_returnsErrorAndSendsAnalytics() = runTest(testDispatcher) {
+    fun `when the validate response action code is timeout, tokenize returns a Failure and sends verify failed analytics with the error description`() = runTest(testDispatcher) {
         val errorMessage = "Error"
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
@@ -732,7 +732,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenValidateResponseCancel_returnsUserCanceledErrorAndSendsAnalytics() = runTest(testDispatcher) {
+    fun `when the validate response action code is cancel, tokenize returns a Cancel result and sends verify canceled analytics`() = runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
@@ -762,7 +762,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTResult_returnsResultAndSendsAnalytics() =
+    fun `when the validate response action code is success and jwt authentication succeeds, tokenize returns a Success result and sends jwt and verify succeeded analytics`() =
         runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
@@ -799,7 +799,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTResultWithError_returnsResultAndSendsAnalytics() =
+    fun `when the validate response action code is success but the jwt authentication result has an error, tokenize returns a Failure and sends jwt auth failed analytics`() =
         runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
@@ -850,7 +850,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenValidateResponseSuccess_onAuthenticateCardinalJWTError_returnsErrorAndSendsAnalytics() =
+    fun `when the validate response action code is success but authenticateCardinalJWT throws, tokenize returns a Failure and sends jwt and verify failed analytics`() =
         runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder().build()
@@ -895,7 +895,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenThreeDSecureAPIThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when the three d secure API throws a CancellationException, createPaymentAuthRequest does not invoke the callback`() =
     runTest(testDispatcher) {
         val cardinalClient = MockkCardinalClientBuilder()
             .successReferenceId("fake-df")
@@ -924,7 +924,7 @@ class ThreeDSecureClientUnitTest {
     }
 
     @Test
-    fun prepareLookup_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when the braintree client throws a CancellationException getting configuration, prepareLookup does not invoke the callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
             .build()

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureLauncherUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureLauncherUnitTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class ThreeDSecureLauncherUnitTest {
 
     private var activityResultLauncher: ActivityResultLauncher<ThreeDSecureParams?> =

--- a/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureLauncherUnitTest.kt
+++ b/ThreeDSecure/src/test/java/com/braintreepayments/api/threedsecure/ThreeDSecureLauncherUnitTest.kt
@@ -41,7 +41,7 @@ class ThreeDSecureLauncherUnitTest {
     }
 
     @Test
-    fun constructor_createsActivityLauncher() {
+    fun `when constructed, registers an activity result launcher with the expected key`() {
         val expectedKey = "com.braintreepayments.api.ThreeDSecure.RESULT"
         val lifecycleOwner = FragmentActivity()
 
@@ -58,7 +58,7 @@ class ThreeDSecureLauncherUnitTest {
     }
 
     @Test
-    fun launch_launchesAuthChallenge() {
+    fun `when launch is called with a ready to launch request, launches the auth challenge with the three d secure params`() {
         val lifecycleOwner = FragmentActivity()
         val sut = ThreeDSecureLauncher(
             activityResultRegistry!!, lifecycleOwner,
@@ -77,7 +77,7 @@ class ThreeDSecureLauncherUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun launch_whenTransactionTooLarge_callsBackError() {
+    fun `when the activity launcher throws a transaction too large error, calls back a BraintreeException`() {
         val lifecycleOwner = FragmentActivity()
         val sut = ThreeDSecureLauncher(
             activityResultRegistry!!, lifecycleOwner,

--- a/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/ExampleUnitTest.kt
+++ b/UIComponents/src/test/java/com/braintreepayments/api/uicomponents/ExampleUnitTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.*
  */
 class ExampleUnitTest {
     @Test
-    fun addition_isCorrect() {
+    fun `when two and two are added, result is four`() {
         assertEquals(4, 2 + 2)
     }
 }

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoAnalyticsUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class VenmoAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants match the expected braintree event names`() {
         assertEquals(
             "venmo:tokenize:app-switch:canceled",
             VenmoAnalytics.APP_SWITCH_CANCELED

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
@@ -50,7 +50,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_createsPaymentContextViaGraphQL() = runTest {
+    fun `createPaymentContext sends a graphQL request with the expected variables and metadata`() = runTest {
         val sut = VenmoApi(
             braintreeClient,
             apiClient,
@@ -109,7 +109,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_whenTransactionAmountOptionsMissing() = runTest {
+    fun `when transaction amount options are missing, createPaymentContext omits transactionDetails and lineItems`() = runTest {
         val sut = VenmoApi(
             braintreeClient,
             apiClient,
@@ -144,7 +144,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_whenGraphQLPostSuccess_includesPaymentContextID_returnsId() = runTest {
+    fun `when graphQL post succeeds, createPaymentContext returns a non-null payment context response`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_CONTEXT_RESPONSE)
             .build()
@@ -166,7 +166,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_whenGraphQLPostSuccess_missingPaymentContextID_throwsException() = runTest {
+    fun `when graphQL response is missing the payment context id, createPaymentContext throws an exception`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(
                 Fixtures.VENMO_GRAPHQL_CREATE_PAYMENT_METHOD_RESPONSE_WITHOUT_PAYMENT_CONTEXT_ID
@@ -192,7 +192,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_whenGraphQLPostError_throwsError() = runTest {
+    fun `when graphQL post fails, createPaymentContext propagates the error`() = runTest {
         val error = IOException("error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostErrorResponse(error)
@@ -215,7 +215,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_withTotalAmountAndSetsFinalAmountToTrue() = runTest {
+    fun `when isFinalAmount is true, createPaymentContext sends isFinalAmount true and the total amount`() = runTest {
         val sut = VenmoApi(
             braintreeClient,
             apiClient,
@@ -248,7 +248,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createPaymentContext_withTotalAmountAndSetsFinalAmountToFalse() = runTest {
+    fun `when isFinalAmount is false, createPaymentContext sends isFinalAmount false and the total amount`() = runTest {
         val sut = VenmoApi(
             braintreeClient,
             apiClient,
@@ -279,7 +279,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createNonceFromPaymentContext_queriesGraphQLPaymentContext() = runTest {
+    fun `createNonceFromPaymentContext sends the payment context id as a graphQL query variable`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
             .build()
@@ -299,7 +299,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createNonceFromPaymentContext_whenGraphQLPostSuccess_returnsNonce() = runTest {
+    fun `when graphQL post succeeds, createNonceFromPaymentContext returns a nonce with the expected username`() = runTest {
         val graphQLResponse = Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(graphQLResponse)
@@ -318,7 +318,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createNonceFromPaymentContext_whenGraphQLPostResponseMalformed_throwsError() = runTest {
+    fun `when graphQL response is malformed json, createNonceFromPaymentContext throws a JSONException`() = runTest {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse("not-json")
             .build()
@@ -336,7 +336,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun createNonceFromPaymentContext_whenGraphQLPostError_throwsError() = runTest {
+    fun `when graphQL post fails, createNonceFromPaymentContext propagates the error`() = runTest {
         val error = IOException("error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostErrorResponse(error)
@@ -355,7 +355,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun vaultVenmoAccountNonce_performsVaultRequest() = runTest {
+    fun `vaultVenmoAccountNonce sends a tokenize request containing the nonce`() = runTest {
         val sut = VenmoApi(
             braintreeClient,
             apiClient,
@@ -373,7 +373,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun vaultVenmoAccountNonce_tokenizeRESTSuccess_returnsNonce() = runTest {
+    fun `when tokenizeREST succeeds, vaultVenmoAccountNonce returns the resulting nonce`() = runTest {
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTSuccess(JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_WITH_NULL_PAYER_INFO_JSON))
             .build()
@@ -389,7 +389,7 @@ class VenmoApiUnitTest {
     }
 
     @Test
-    fun vaultVenmoAccountNonce_tokenizeRESTError_throwsError() = runTest {
+    fun `when tokenizeREST fails, vaultVenmoAccountNonce propagates the error`() = runTest {
         val error = Exception("error")
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTError(error)

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoApiUnitTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class VenmoApiUnitTest {
 
     private lateinit var braintreeClient: BraintreeClient

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
@@ -121,7 +121,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun initialization_sets_app_link_in_analyticsParamRepository() {
+    fun `when return link type is app link, initialization sets app link on analyticsParamRepository`() {
         every { getReturnLinkTypeUseCase.invoke() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.APP_LINK
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -145,7 +145,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun initialization_sets_deep_link_in_analyticsParamRepository() {
+    fun `when return link type is deep link, initialization sets deep link on analyticsParamRepository`() {
         every { getReturnLinkTypeUseCase.invoke() } returns GetReturnLinkTypeUseCase.ReturnLinkTypeResult.DEEP_LINK
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -169,7 +169,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenCreatePaymentContextFails_collectAddressWithEcdDisabled() =
+    fun `when createPaymentContext fails because ECD is disabled, createPaymentAuthRequest returns a failure with the ECD error message`() =
         runTest(testDispatcher) {
         val errorDesc = "Cannot collect customer data when ECD is disabled. Enable this feature " +
                 "in the Control Panel to collect this data."
@@ -237,7 +237,7 @@ class VenmoClientUnitTest {
 
     @Suppress("LongMethod")
     @Test
-    fun createPaymentAuthRequest_withDeepLink_whenCreatePaymentContextSucceeds_createsVenmoAuthChallenge() =
+    fun `when deep link is used and createPaymentContext succeeds, createPaymentAuthRequest builds a ready-to-launch Venmo auth challenge`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -314,7 +314,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenConfigurationException_forwardsExceptionToListener() = runTest(testDispatcher) {
+    fun `when configuration fetch fails, createPaymentAuthRequest forwards the exception to the callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(IOException("Configuration fetching error"))
             .build()
@@ -363,7 +363,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenVenmoNotEnabled_forwardsExceptionToListener() = runTest(testDispatcher) {
+    fun `when venmo is not enabled in configuration, createPaymentAuthRequest forwards the exception to the callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoDisabledConfiguration)
             .build()
@@ -414,7 +414,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenProfileIdIsNull_appSwitchesWithMerchantId() = runTest(testDispatcher) {
+    fun `when profileId is null, createPaymentAuthRequest app switches using the merchant id`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -459,7 +459,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenAppLinkUriSet_appSwitchesWithAppLink() = runTest(testDispatcher) {
+    fun `when an app link uri is set, createPaymentAuthRequest app switches using the app link`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -504,7 +504,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_throws_error_when_getReturnLinkUseCase_returnsFailure() = runTest(testDispatcher) {
+    fun `when getReturnLinkUseCase returns a failure, createPaymentAuthRequest forwards the exception as failure`() = runTest(testDispatcher) {
         val exception = BraintreeException()
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -549,7 +549,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenProfileIdIsSpecified_appSwitchesWithProfileIdAndAccessToken() =
+    fun `when profileId is specified, createPaymentAuthRequest app switches using the profile id and payment context id`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -596,7 +596,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_sendsAnalyticsEvent() {
+    fun `createPaymentAuthRequest sends a tokenize started analytics event`() {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoDisabledConfiguration)
             .build()
@@ -632,7 +632,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenShouldVaultIsTrue_persistsVenmoVaultTrue() = runTest(testDispatcher) {
+    fun `when shouldVault is true, createPaymentAuthRequest persists the vault option as true`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -671,7 +671,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenShouldVaultIsFalse_persistsVenmoVaultFalse() = runTest(testDispatcher) {
+    fun `when shouldVault is false, createPaymentAuthRequest persists the vault option as false`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -710,7 +710,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenVenmoApiError_forwardsErrorToListener_andSendsAnalytics() =
+    fun `when the Venmo API errors creating the payment context, createPaymentAuthRequest forwards the error and sends failure analytics`() =
         runTest(testDispatcher) {
         val graphQLError = BraintreeException("GraphQL error")
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -774,7 +774,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPaymentContextId_requestFromVenmoApi() = runTest(testDispatcher) {
+    fun `tokenize with a payment context resource id in the return url requests the nonce from venmoApi`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -816,7 +816,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPaymentAuthResult_whenUserCanceled_returnsCancelAndSendsAnalytics() = runTest(testDispatcher) {
+    fun `when return url indicates the user canceled, tokenize returns Cancel and sends app switch canceled analytics`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -856,7 +856,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_onGraphQLPostSuccess_returnsNonceToListener_andSendsAnalytics() = runTest(testDispatcher) {
+    fun `when graphQL post succeeds, tokenize returns the nonce to the listener and sends tokenize succeeded analytics`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -920,7 +920,7 @@ class VenmoClientUnitTest {
 
     @Suppress("LongMethod")
     @Test
-    fun tokenize_onGraphQLPostFailure_forwardsExceptionToListener_andSendsAnalytics() = runTest(testDispatcher) {
+    fun `when graphQL post fails, tokenize forwards the exception to the listener and sends tokenize failed analytics`() = runTest(testDispatcher) {
         val graphQLError = BraintreeException("GraphQL error")
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -986,7 +986,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPaymentContext_performsVaultRequestIfRequestPersisted() = runTest(testDispatcher) {
+    fun `when a payment context is used and vault option is persisted, tokenize performs a vault request`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -1024,7 +1024,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_postsPaymentMethodNonceOnSuccess() = runTest(testDispatcher) {
+    fun `tokenize requests the nonce from the payment context on success`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
         every { browserSwitchResult.returnUrl } returns SUCCESS_URL
@@ -1051,7 +1051,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_performsVaultRequestIfRequestPersisted() = runTest(testDispatcher) {
+    fun `when vault option is persisted, tokenize performs a vault request with the resulting nonce`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
             .build()
@@ -1087,7 +1087,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_doesNotPerformRequestIfTokenizationKeyUsed() = runTest(testDispatcher) {
+    fun `when a tokenization key is used, tokenize does not perform a vault request`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
         every { browserSwitchResult.returnUrl } returns SUCCESS_URL
@@ -1115,7 +1115,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_withRiskCorrelationId_passesRiskCorrelationIdToCreatePaymentContext() =
+    fun `createPaymentAuthRequest passes the risk correlation id to createPaymentContext`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationSuccess(venmoEnabledConfiguration)
@@ -1160,7 +1160,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withSuccessfulVaultCall_forwardsResultToActivityResultListener_andSendsAnalytics() =
+    fun `when the vault call succeeds without a resource id in the return url, tokenize forwards the nonce and sends tokenize succeeded analytics`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
@@ -1206,7 +1206,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPaymentContext_withSuccessfulVaultCall_forwardsNonceToCallback_andSendsAnalytics() =
+    fun `when a payment context is used and the vault call succeeds, tokenize forwards the nonce to the callback and sends tokenize succeeded analytics`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
@@ -1257,7 +1257,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withFailedVaultCall_forwardsErrorToActivityResultListener_andSendsAnalytics() =
+    fun `when the vault call fails without a resource id in the return url, tokenize forwards the error and sends tokenize failed analytics`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder().build()
 
@@ -1306,7 +1306,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun createPaymentAuthRequest_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() =
+    fun `when braintreeClient throws a CancellationException fetching configuration, createPaymentAuthRequest does not invoke the callback`() =
     runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
@@ -1338,7 +1338,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenVenmoApiThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when venmoApi throws a CancellationException, tokenize does not invoke the callback`() = runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)
             .build()
@@ -1371,7 +1371,7 @@ class VenmoClientUnitTest {
     }
 
     @Test
-    fun tokenize_withPaymentContext_withFailedVaultCall_forwardsErrorToCallback_andSendsAnalytics() =
+    fun `when a payment context is used and the vault call fails, tokenize forwards the error to the callback and sends tokenize failed analytics`() =
         runTest(testDispatcher) {
         val braintreeClient = MockkBraintreeClientBuilder()
             .sendGraphQLPostSuccessfulResponse(Fixtures.VENMO_GRAPHQL_GET_PAYMENT_CONTEXT_RESPONSE)

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoClientUnitTest.kt
@@ -46,6 +46,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("MaxLineLength")
 class VenmoClientUnitTest {
 
     private lateinit var sut: VenmoClient

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoLauncherUnitTest.kt
@@ -60,7 +60,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `launch starts browser switch and returns pending request`() {
+    fun `when launch succeeds, it returns a started pending request`() {
         val startedPendingRequest = BrowserSwitchStartResult.Started(pendingRequestString)
         every { browserSwitchClient.start(activity, options, true) } returns startedPendingRequest
 
@@ -89,7 +89,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `launch on error returns pending request failure`() {
+    fun `when browser switch start fails, launch returns a pending request failure`() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
         val exception = BrowserSwitchException("error")
         every { browserSwitchClient.start(eq(activity), eq(options), eq(true)) } returns
@@ -119,7 +119,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `launch when device cant perform browser switch returns pending request failure`() {
+    fun `when the device cannot perform a browser switch, launch returns a pending request failure`() {
         every { paymentAuthRequestParams.browserSwitchOptions } returns options
         val exception = BrowserSwitchException("browser switch error")
         every {
@@ -173,7 +173,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToApp when result exists returns result`() {
+    fun `when a browser switch result exists, handleReturnToApp returns a success result`() {
         val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
         every {
             browserSwitchClient.completeRequest(
@@ -209,7 +209,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun `handleReturnToApp when result does not exist returns null`() {
+    fun `when no browser switch result exists, handleReturnToApp returns NoResult`() {
         every {
             browserSwitchClient.completeRequest(
                 intent,
@@ -256,7 +256,7 @@ class VenmoLauncherUnitTest {
     }
 
     @Test
-    fun showVenmoInGooglePlayStore_opensVenmoAppStoreURL() {
+    fun `showVenmoInGooglePlayStore starts an activity for the venmo play store url`() {
         val activity = Mockito.mock(
             ComponentActivity::class.java
         )

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccountUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAccountUnitTest.kt
@@ -25,7 +25,7 @@ class VisaCheckoutAccountUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun build_withVisaPaymentSummary_buildsExpectedPaymentMethod() {
+    fun `when buildJSON is called with a visa payment summary, expected json is returned`() {
         every { visaPaymentSummary.callId } returns "stubbedCallId"
         every { visaPaymentSummary.encKey } returns "stubbedEncKey"
         every { visaPaymentSummary.encPaymentData } returns "stubbedEncPaymentData"
@@ -49,7 +49,7 @@ class VisaCheckoutAccountUnitTest {
     }
 
     @Test
-    fun apiPath_returnsCorrectApiPath() {
+    fun `when apiPath is accessed, visa_checkout_cards is returned`() {
         assertEquals("visa_checkout_cards", VisaCheckoutAccount(mockk()).apiPath)
     }
 }

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalyticsUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutAnalyticsUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class VisaCheckoutAnalyticsUnitTest {
 
     @Test
-    fun testAnalyticsEvents_sendsExpectedEventNames() {
+    fun `analytics event constants have expected event names`() {
         assertEquals("visa-checkout:tokenize:started", VisaCheckoutAnalytics.TOKENIZE_STARTED)
         assertEquals("visa-checkout:tokenize:failed", VisaCheckoutAnalytics.TOKENIZE_FAILED)
         assertEquals("visa-checkout:tokenize:succeeded", VisaCheckoutAnalytics.TOKENIZE_SUCCEEDED)

--- a/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutClientUnitTest.kt
+++ b/VisaCheckout/src/test/java/com/braintreepayments/api/visacheckout/VisaCheckoutClientUnitTest.kt
@@ -53,7 +53,7 @@ class VisaCheckoutClientUnitTest {
     }
 
     @Test
-    fun createProfileBuilder_whenNotEnabled_throwsConfigurationException() = runTest(testDispatcher) {
+    fun `when createProfileBuilder is called and visa checkout is not enabled, callback is invoked with configuration exception failure`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder().build()
         val configuration = TestConfigurationBuilder.basicConfig<Configuration>()
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -86,7 +86,7 @@ class VisaCheckoutClientUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun createProfileBuilder_whenProduction_usesProductionConfig() = runTest(testDispatcher) {
+    fun `when createProfileBuilder is called with a production environment configuration, callback is invoked with success containing profile builder with accepted card brands`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder().build()
         val configString = TestConfigurationBuilder()
             .environment("production")
@@ -120,7 +120,7 @@ class VisaCheckoutClientUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun createProfileBuilder_whenNotProduction_usesSandboxConfig() = runTest(testDispatcher) {
+    fun `when createProfileBuilder is called with a non-production environment configuration, callback is invoked with success containing profile builder with accepted card brands`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder().build()
         val configString = TestConfigurationBuilder()
             .environment("environment")
@@ -152,7 +152,7 @@ class VisaCheckoutClientUnitTest {
     }
 
     @Test
-    fun `when createProfileBuilder is called and configuration is null, exception is returned as a failure`() = runTest(testDispatcher) {
+    fun `when createProfileBuilder is called and configuration fetch fails, exception is returned as a failure`() = runTest(testDispatcher) {
         val exception = IOException("test error")
         val callback = mockk<VisaCheckoutCreateProfileBuilderCallback>(relaxed = true)
         val braintreeClient = MockkBraintreeClientBuilder()
@@ -172,7 +172,7 @@ class VisaCheckoutClientUnitTest {
     }
 
     @Test
-    fun createProfileBuilder_whenBraintreeClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when createProfileBuilder is called and braintreeClient throws cancellation exception, callback is not invoked`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder().build()
         val braintreeClient = MockkBraintreeClientBuilder()
             .configurationError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
@@ -187,7 +187,7 @@ class VisaCheckoutClientUnitTest {
 
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenSuccessful_postsVisaPaymentMethodNonce() {
+    fun `when tokenize is successful, callback is invoked with success containing visa payment method nonce`() {
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTSuccess(JSONObject(Fixtures.PAYMENT_METHODS_VISA_CHECKOUT_RESPONSE))
             .build()
@@ -208,7 +208,7 @@ class VisaCheckoutClientUnitTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     @Throws(JSONException::class)
-    fun tokenize_whenSuccessful_sendsAnalyticEvent() = runTest(testDispatcher) {
+    fun `when tokenize is successful, started and succeeded analytics events are sent`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTSuccess(JSONObject(Fixtures.PAYMENT_METHODS_VISA_CHECKOUT_RESPONSE))
             .build()
@@ -229,7 +229,7 @@ class VisaCheckoutClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenFailure_postsException() {
+    fun `when tokenize fails, callback is invoked with failure containing the tokenize error`() {
         val tokenizeError = Exception("Mock Failure")
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTError(tokenizeError)
@@ -250,7 +250,7 @@ class VisaCheckoutClientUnitTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun tokenize_whenFailure_sendsAnalyticEvent() = runTest(testDispatcher) {
+    fun `when tokenize fails, started and failed analytics events are sent`() = runTest(testDispatcher) {
         val tokenizeError = Exception("Mock Failure")
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTError(tokenizeError)
@@ -277,7 +277,7 @@ class VisaCheckoutClientUnitTest {
     }
 
     @Test
-    fun tokenize_whenApiClientThrowsCancellationException_callbackIsNotInvoked() = runTest(testDispatcher) {
+    fun `when tokenize is called and apiClient throws cancellation exception, callback is not invoked`() = runTest(testDispatcher) {
         val apiClient = MockkApiClientBuilder()
             .tokenizeRESTError(kotlin.coroutines.cancellation.CancellationException("cancelled"))
             .build()


### PR DESCRIPTION
### Summary of changes
Unified all unit test names to conform to Kotlin standards, using `AnalyticsApiUnitTest.kt` as the standard. No changelog entry added since these are test only changes.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
- Analyze `AnalyticsApiUnitTest.kt` and the apply the standard across all unit test files.
- Separate subagents to review grammar and transfer of intent between old names and new

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @mzlangreder 