### PR TITLE
chore: Add jvmTarget to kotlinOptions in Demo module

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -60,6 +60,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
     namespace 'com.braintreepayments.demo'
 }
 


### PR DESCRIPTION
### Summary of changes
After dropping Gradle Toolchains from the project and attempting to use JDK 21 to build, I discovered the Demo app doesn't set a jvmTarget version for Kotlin, resulting in a build error. Adding the property to the Demo build file here.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
N/A

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @mzlangreder 
