### PR TITLE
feature: add Campaign ID input to ShopperInsights and PayPal demo screens

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/ComposeButtonsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ComposeButtonsFragment.kt
@@ -143,7 +143,8 @@ class ComposeButtonsFragment : BaseFragment() {
         null,
         false,
         false,
-        false
+        false,
+        null
     )
 
     private val paypalTokenizeCallback = PayPalTokenizeCallback { payPalResult ->

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalFragment.java
@@ -66,6 +66,7 @@ public class PayPalFragment extends BaseFragment {
         TextInputEditText buyerEmailEditText = view.findViewById(R.id.buyer_email_edit_text);
         TextInputEditText buyerPhoneCountryCodeEditText = view.findViewById(R.id.buyer_phone_country_code_edit_text);
         TextInputEditText buyerPhoneNationalNumberEditText = view.findViewById(R.id.buyer_phone_national_number_edit_text);
+        TextInputEditText campaignIdEditText = view.findViewById(R.id.paypal_campaign_id_edit_text);
         Button billingAgreementButton = view.findViewById(R.id.paypal_billing_agreement_button);
         Button singlePaymentButton = view.findViewById(R.id.paypal_single_payment_button);
         Button singlePaymentPayLaterButton = view.findViewById(R.id.paypal_single_payment_pay_later_button);
@@ -82,7 +83,8 @@ public class PayPalFragment extends BaseFragment {
                 contactInformationSwitch.isChecked(),
                 false,
                 false,
-                amountBreakdownSwitch.isChecked()
+                amountBreakdownSwitch.isChecked(),
+                campaignIdEditText.getText().toString()
             );
         });
 
@@ -95,7 +97,8 @@ public class PayPalFragment extends BaseFragment {
                 contactInformationSwitch.isChecked(),
                 false,
                 true,
-                amountBreakdownSwitch.isChecked()
+                amountBreakdownSwitch.isChecked(),
+                campaignIdEditText.getText().toString()
             );
             isPayLaterSelected = false;
         });
@@ -109,7 +112,8 @@ public class PayPalFragment extends BaseFragment {
                     contactInformationSwitch.isChecked(),
                     false,
                     false,
-                    amountBreakdownSwitch.isChecked()
+                    amountBreakdownSwitch.isChecked(),
+                    campaignIdEditText.getText().toString()
             );
             isPayLaterSelected = false;
         });
@@ -123,7 +127,8 @@ public class PayPalFragment extends BaseFragment {
                     contactInformationSwitch.isChecked(),
                     true,
                     false,
-                    amountBreakdownSwitch.isChecked()
+                    amountBreakdownSwitch.isChecked(),
+                    campaignIdEditText.getText().toString()
             );
             isPayLaterSelected = true;
         });
@@ -174,7 +179,8 @@ public class PayPalFragment extends BaseFragment {
         Boolean isContactInformationEnabled,
         Boolean offerPayLater,
         Boolean offerCredit,
-        Boolean isAmountBreakdownEnabled
+        Boolean isAmountBreakdownEnabled,
+        String campaignId
     ) {
         FragmentActivity activity = getActivity();
         activity.setProgressBarIndeterminateVisibility(true);
@@ -186,10 +192,10 @@ public class PayPalFragment extends BaseFragment {
                 if (dataCollectorResult instanceof DataCollectorResult.Success) {
                     deviceData = ((DataCollectorResult.Success) dataCollectorResult).getDeviceData();
                 }
-                launchPayPal(activity, isBillingAgreement, amount, buyerEmailAddress, buyerPhoneCountryCode, buyerPhoneNationalNumber, isContactInformationEnabled, offerPayLater, offerCredit, isAmountBreakdownEnabled);
+                launchPayPal(activity, isBillingAgreement, amount, buyerEmailAddress, buyerPhoneCountryCode, buyerPhoneNationalNumber, isContactInformationEnabled, offerPayLater, offerCredit, isAmountBreakdownEnabled, campaignId);
             });
         } else {
-            launchPayPal(activity, isBillingAgreement, amount, buyerEmailAddress, buyerPhoneCountryCode, buyerPhoneNationalNumber, isContactInformationEnabled, offerPayLater, offerCredit, isAmountBreakdownEnabled);
+            launchPayPal(activity, isBillingAgreement, amount, buyerEmailAddress, buyerPhoneCountryCode, buyerPhoneNationalNumber, isContactInformationEnabled, offerPayLater, offerCredit, isAmountBreakdownEnabled, campaignId);
         }
     }
 
@@ -203,7 +209,8 @@ public class PayPalFragment extends BaseFragment {
         boolean isContactInformationEnabled,
         boolean offerPayLater,
         boolean offerCredit,
-        boolean isAmountBreakdownEnabled
+        boolean isAmountBreakdownEnabled,
+        String campaignId
     ) {
         PayPalRequest payPalRequest;
         if (isBillingAgreement) {
@@ -225,7 +232,8 @@ public class PayPalFragment extends BaseFragment {
                     null,
                     offerPayLater,
                     offerCredit,
-                    isAmountBreakdownEnabled
+                    isAmountBreakdownEnabled,
+                    campaignId
             );
         }
         payPalClient.createPaymentAuthRequest(requireContext(), payPalRequest,

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -220,7 +220,10 @@ public class PayPalRequestFactory {
         }
 
         if (campaignId != null && !campaignId.isEmpty()) {
-            request.setCampaigns(Collections.singletonList(new PayPalCampaign(campaignId)));
+            List<PayPalCampaign> campaigns = parseCampaigns(campaignId);
+            if (!campaigns.isEmpty()) {
+                request.setCampaigns(campaigns);
+            }
         }
 
         if (Settings.isPayPalAppSwithEnabled(context)) {
@@ -268,6 +271,17 @@ public class PayPalRequestFactory {
         }
 
         return request;
+    }
+
+    private static List<PayPalCampaign> parseCampaigns(String campaignIdText) {
+        List<PayPalCampaign> campaigns = new ArrayList<>();
+        for (String id : campaignIdText.split(",")) {
+            String trimmedId = id.trim();
+            if (!trimmedId.isEmpty()) {
+                campaigns.add(new PayPalCampaign(trimmedId));
+            }
+        }
+        return campaigns;
     }
 
     private static List<PayPalLineItem> buildLineItems(

--- a/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/PayPalRequestFactory.java
@@ -7,6 +7,7 @@ import com.braintreepayments.api.paypal.AmountBreakdown;
 import com.braintreepayments.api.paypal.PayPalBillingCycle;
 import com.braintreepayments.api.paypal.PayPalBillingInterval;
 import com.braintreepayments.api.paypal.PayPalBillingPricing;
+import com.braintreepayments.api.paypal.PayPalCampaign;
 import com.braintreepayments.api.paypal.PayPalCheckoutRequest;
 import com.braintreepayments.api.paypal.PayPalContactInformation;
 import com.braintreepayments.api.paypal.PayPalContactPreference;
@@ -166,7 +167,8 @@ public class PayPalRequestFactory {
         String shopperInsightsSessionId,
         Boolean offerPayLater,
         Boolean offerCredit,
-        Boolean isAmountBreakdownEnabled
+        Boolean isAmountBreakdownEnabled,
+        String campaignId
     ) {
         PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount, true);
         request.setShouldOfferPayLater(offerPayLater);
@@ -215,6 +217,10 @@ public class PayPalRequestFactory {
 
         if (shopperInsightsSessionId != null && !shopperInsightsSessionId.isEmpty()) {
             request.setShopperSessionId(shopperInsightsSessionId);
+        }
+
+        if (campaignId != null && !campaignId.isEmpty()) {
+            request.setCampaigns(Collections.singletonList(new PayPalCampaign(campaignId)));
         }
 
         if (Settings.isPayPalAppSwithEnabled(context)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
@@ -95,6 +95,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
             var emailText by rememberSaveable { mutableStateOf("PR1_merchantname@personal.example.com") }
             var countryCodeText by rememberSaveable { mutableStateOf("1") }
             var nationalNumberText by rememberSaveable { mutableStateOf("4082321001") }
+            var campaignIdText by rememberSaveable { mutableStateOf("") }
 
             TextField(
                 value = emailText,
@@ -120,6 +121,12 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                         .weight(2f)
                 )
             }
+            TextField(
+                value = campaignIdText,
+                onValueChange = { newValue -> campaignIdText = newValue },
+                label = { Text("Campaign ID") },
+                modifier = Modifier.padding(4.dp),
+            )
 
             val currentSessionId = viewModel.sessionId.collectAsState().value
             TextField(
@@ -134,7 +141,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 enabled = shopperInsightsClientSuccessfullyInstantiated,
                 onClick = {
                     viewModel.resetRecommendationsCompleted()
-                    handleCreateCustomerSession(emailText, nationalNumberText)
+                    handleCreateCustomerSession(emailText, nationalNumberText, campaignIdText)
                 }
             ) {
                 Text(text = "Create customer session")
@@ -143,7 +150,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
                 enabled = shopperInsightsClientSuccessfullyInstantiated,
                 onClick = {
                     viewModel.resetRecommendationsCompleted()
-                    handleUpdateCustomerSession(emailText, nationalNumberText, currentSessionId)
+                    handleUpdateCustomerSession(emailText, nationalNumberText, currentSessionId, campaignIdText)
                 }
             ) {
                 Text(text = "Update customer session")
@@ -351,17 +358,19 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
 
     private fun handleCreateCustomerSession(
         emailText: String,
-        nationalNumberText: String
+        nationalNumberText: String,
+        campaignIdText: String
     ) {
-        viewModel.handleCreateCustomerSession(emailText, nationalNumberText)
+        viewModel.handleCreateCustomerSession(emailText, nationalNumberText, campaignIdText)
     }
 
     private fun handleUpdateCustomerSession(
         emailText: String,
         nationalNumberText: String,
-        sessionId: String
+        sessionId: String,
+        campaignIdText: String
     ) {
-        viewModel.handleUpdateCustomerSession(emailText, nationalNumberText, sessionId)
+        viewModel.handleUpdateCustomerSession(emailText, nationalNumberText, sessionId, campaignIdText)
     }
 
     private fun handleGetRecommendations(sessionId: String) {

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsFragmentV2.kt
@@ -124,7 +124,7 @@ class ShopperInsightsFragmentV2 : BaseFragment() {
             TextField(
                 value = campaignIdText,
                 onValueChange = { newValue -> campaignIdText = newValue },
-                label = { Text("Campaign ID") },
+                label = { Text("Campaign IDs (comma-separated)") },
                 modifier = Modifier.padding(4.dp),
             )
 

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
@@ -39,7 +39,7 @@ class ShopperInsightsV2ViewModel : ViewModel() {
         val customerSessionRequest = CustomerSessionRequest(
             hashedEmail = emailText.sha256(),
             hashedPhoneNumber = nationalNumberText.sha256(),
-            payPalCampaigns = campaignIdText.takeIf { it.isNotBlank() }?.let { listOf(ShopperInsightsCampaign(it)) }
+            payPalCampaigns = campaignIdText.toShopperInsightsCampaigns()
         )
 
         _sessionId.update { "" }
@@ -67,7 +67,7 @@ class ShopperInsightsV2ViewModel : ViewModel() {
         val customerSessionRequest = CustomerSessionRequest(
             hashedEmail = emailText.sha256(),
             hashedPhoneNumber = nationalNumberText.sha256(),
-            payPalCampaigns = campaignIdText.takeIf { it.isNotBlank() }?.let { listOf(ShopperInsightsCampaign(it)) }
+            payPalCampaigns = campaignIdText.toShopperInsightsCampaigns()
         )
 
         _sessionId.update { "" }
@@ -138,6 +138,12 @@ class ShopperInsightsV2ViewModel : ViewModel() {
 
 private fun String.sha256(): String {
     return hashString(this, "SHA-256")
+}
+
+@OptIn(ExperimentalBetaApi::class)
+private fun String.toShopperInsightsCampaigns(): List<ShopperInsightsCampaign>? {
+    val campaigns = split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    return campaigns.takeIf { it.isNotEmpty() }?.map { ShopperInsightsCampaign(it) }
 }
 
 private fun hashString(input: String, algorithm: String = "SHA-256"): String {

--- a/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/ShopperInsightsV2ViewModel.kt
@@ -12,6 +12,7 @@ import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendationsResul
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionResult
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
+import com.braintreepayments.api.shopperinsights.v2.ShopperInsightsCampaign
 import com.braintreepayments.api.shopperinsights.v2.ShopperInsightsClientV2
 import java.security.MessageDigest
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,10 +35,11 @@ class ShopperInsightsV2ViewModel : ViewModel() {
         shopperInsightsClient = ShopperInsightsClientV2(context, authString)
     }
 
-    fun handleCreateCustomerSession(emailText: String, nationalNumberText: String) {
+    fun handleCreateCustomerSession(emailText: String, nationalNumberText: String, campaignIdText: String) {
         val customerSessionRequest = CustomerSessionRequest(
             hashedEmail = emailText.sha256(),
-            hashedPhoneNumber = nationalNumberText.sha256()
+            hashedPhoneNumber = nationalNumberText.sha256(),
+            payPalCampaigns = campaignIdText.takeIf { it.isNotBlank() }?.let { listOf(ShopperInsightsCampaign(it)) }
         )
 
         _sessionId.update { "" }
@@ -59,11 +61,13 @@ class ShopperInsightsV2ViewModel : ViewModel() {
     fun handleUpdateCustomerSession(
         emailText: String,
         nationalNumberText: String,
-        sessionId: String
+        sessionId: String,
+        campaignIdText: String
     ) {
         val customerSessionRequest = CustomerSessionRequest(
             hashedEmail = emailText.sha256(),
-            hashedPhoneNumber = nationalNumberText.sha256()
+            hashedPhoneNumber = nationalNumberText.sha256(),
+            payPalCampaigns = campaignIdText.takeIf { it.isNotBlank() }?.let { listOf(ShopperInsightsCampaign(it)) }
         )
 
         _sessionId.update { "" }

--- a/Demo/src/main/java/com/braintreepayments/demo/UIComponentsFragment.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/UIComponentsFragment.kt
@@ -127,7 +127,8 @@ class UIComponentsFragment : BaseFragment() {
             /* shopperInsightsSessionId = */ null,
             /* offerPayLater = */ false,
             /* offerCredit = */ false,
-            /* isAmountBreakdownEnabled = */ false
+            /* isAmountBreakdownEnabled = */ false,
+            /* campaignId = */ null
         )
 
         payPalButton.initialize(

--- a/Demo/src/main/res/layout/fragment_paypal.xml
+++ b/Demo/src/main/res/layout/fragment_paypal.xml
@@ -37,7 +37,6 @@
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_20"
         android:hint="@string/paypal_phone_national_number">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -45,6 +44,20 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="phone" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_20"
+        android:hint="@string/paypal_campaign_id">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/paypal_campaign_id_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="paypal_buyer_email_address">Buyer Email Address</string>
     <string name="paypal_phone_country_code">Buyer Phone Country Code</string>
     <string name="paypal_phone_national_number">Buyer Phone National Number</string>
+    <string name="paypal_campaign_id">Campaign ID</string>
     <string name="paypal_single_payment">Single Payment</string>
     <string name="paypal_single_payment_with_credit">Single Payment With Credit</string>
     <string name="paypal_billing_agreement">Billing Agreement</string>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="paypal_buyer_email_address">Buyer Email Address</string>
     <string name="paypal_phone_country_code">Buyer Phone Country Code</string>
     <string name="paypal_phone_national_number">Buyer Phone National Number</string>
-    <string name="paypal_campaign_id">Campaign ID</string>
+    <string name="paypal_campaign_id">Campaign IDs (comma-separated)</string>
     <string name="paypal_single_payment">Single Payment</string>
     <string name="paypal_single_payment_with_credit">Single Payment With Credit</string>
     <string name="paypal_billing_agreement">Billing Agreement</string>


### PR DESCRIPTION
### Summary of changes
- Adds an optional **Campaign ID** input field to the Shopper Insights v2 demo screen (`ShopperInsightsFragmentV2`), wired into `CustomerSessionRequest.payPalCampaigns` for Create/Update Customer Session.
- Adds an optional **Campaign ID** input field to the PayPal checkout demo screen (`PayPalFragment` / `fragment_paypal.xml`), wired into `PayPalCheckoutRequest.campaigns` for Single Payment / Single Payment With Credit / Single Payment Pay Later.
- Follow-up to #1647 and #1648 per review feedback on #1649 (demo app parity with iOS).

Both fields are optional — a blank value means no campaign is attached, matching the existing pattern for other optional demo fields (e.g. session ID).

**Verification:** Ran the Demo app against Sandbox and confirmed the campaign ID entered in the UI reaches the real `create_payment_resource` request and the backend accepts it:

```
POST https://api.braintreegateway.com/merchants/{merchant_id}/client_api/v1/paypal_hermes/create_payment_resource
body: {... "amount":"57.00","currency_iso_code":"USD","intent":"authorize",
       "paypal_campaigns":[{"id":"tiktok-123"}],
       "experience_profile":{"no_shipping":true,"brand_name":"Braintree Testing","user_action":"commit","address_override":false}}

RESPONSE code=201
body: {"paymentResource":{"intent":"authorize","paymentToken":"7FM99305T39718348",
       "redirectUrl":"https://www.paypal.com/checkoutnow?token=7FM99305T39718348","apiVersion":"v2"}}
```

**Steps to test:** on the PayPal demo screen, enter a Campaign ID and tap Single Payment; on the Shopper Insights V2 demo screen, enter a Campaign ID and tap Create/Update Customer Session. Confirm the outgoing request includes the campaign in each case.

<img width="512" height="1080" alt="Screenshot_20260802_190536" src="https://github.com/user-attachments/assets/ebc2f3d7-3ba2-4879-8add-1a8cb01d764d" />
<img width="512" height="1080" alt="Screenshot_20260802_190549" src="https://github.com/user-attachments/assets/541fa0ec-6b82-48b1-b52e-97ea681fd892" />


### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
<!-- Describe how AI was used (e.g., code generation, refactoring, debugging, writing tests, etc.) -->

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- santugowda

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [x] Added all labels to the PR
- [x] Provide steps to test the flows changed, if applicable in the summary
- [x] Demo video of the functionality, if applicable
- [x] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [x] Unit tests and builds have been run locally and pass/compile as expected
