### PR TITLE
Feat: Add Reference Docs Versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,9 +321,9 @@ jobs:
       - name: Publish Reference Docs
         run: |
           set -euo pipefail
-          git fetch origin reference-docs:reference-docs || true
+          git fetch origin gh-pages:gh-pages || true
           ./scripts/publish-docs.sh "${RELEASE_VERSION}"
-          git -C "$(dirname "$PWD")/$(basename "$PWD")-reference-docs" push origin reference-docs
+          git -C "$(dirname "$PWD")/$(basename "$PWD")-gh-pages" push origin gh-pages
 
   create_github_release:
     needs: [ bump_version ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,6 @@ jobs:
           ./gradlew -PversionParam="${RELEASE_VERSION}" changeREADMEVersion
           ./gradlew -PversionParam="${RELEASE_VERSION}" changeMigrationGuideVersion
           ./gradlew -PversionParam="${RELEASE_VERSION}" updateCHANGELOGVersion
-          ./gradlew dokkaHtmlMultiModule
           git add -A
           git commit -am "Release ${RELEASE_VERSION}"
           git tag "${RELEASE_VERSION}" -a -m "Release ${RELEASE_VERSION}"
@@ -317,6 +316,14 @@ jobs:
           ./gradlew incrementVersionCode
           git commit -am 'Prepare for development'
           git push origin ${GITHUB_REF_NAME} "${RELEASE_VERSION}"
+      - name: Generate Reference Docs
+        run: ./gradlew dokkaHtmlMultiModule
+      - name: Publish Reference Docs
+        run: |
+          set -euo pipefail
+          git fetch origin reference-docs:reference-docs || true
+          ./scripts/publish-docs.sh "${RELEASE_VERSION}"
+          git -C "$(dirname "$PWD")/$(basename "$PWD")-reference-docs" push origin reference-docs
 
   create_github_release:
     needs: [ bump_version ]

--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,9 @@ subprojects {
 }
 
 dokkaHtmlMultiModule.configure {
-    // redirect dokka output to GitHub pages root directory
-    outputDirectory.set(project.file("docs"))
+    // generate into a gitignored build directory; scripts/publish-docs.sh publishes
+    // this to the reference-docs branch instead of committing it into main
+    outputDirectory.set(project.file("build/dokkaDocs"))
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ subprojects {
 
 dokkaHtmlMultiModule.configure {
     // generate into a gitignored build directory; scripts/publish-docs.sh publishes
-    // this to the reference-docs branch instead of committing it into main
+    // this to the gh-pages branch instead of committing it into main
     outputDirectory.set(project.file("build/dokkaDocs"))
 }
 

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Publishes Dokka reference docs for a single version to the reference-docs branch,
+# Publishes Dokka reference docs for a single version to the gh-pages branch,
 # mirroring how braintree_ios publishes Jazzy docs: one folder per version plus
 # a `current` symlink to the latest, no version-picker UI.
 #
-# This script only commits locally to the reference-docs branch checked out in a
+# This script only commits locally to the gh-pages branch checked out in a
 # worktree next to the repo. It intentionally does not push - the caller
 # (e.g. the release workflow) is responsible for pushing when ready.
 set -euo pipefail
 
 VERSION="${1:?Usage: publish-docs.sh <version>}"
-BRANCH="reference-docs"
+BRANCH="gh-pages"
 
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 DOCS_SOURCE="${REPO_ROOT}/build/dokkaDocs"
@@ -25,7 +25,7 @@ if ! git -C "${REPO_ROOT}" worktree list --porcelain | grep -qx "worktree ${WORK
     git -C "${REPO_ROOT}" worktree add "${WORKTREE_DIR}" "${BRANCH}"
   else
     git -C "${REPO_ROOT}" worktree add --orphan -b "${BRANCH}" "${WORKTREE_DIR}"
-    git -C "${WORKTREE_DIR}" commit --allow-empty -m "Initialize reference-docs branch" --quiet
+    git -C "${WORKTREE_DIR}" commit --allow-empty -m "Initialize gh-pages branch" --quiet
   fi
 fi
 

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Publishes Dokka reference docs for a single version to the reference-docs branch,
+# mirroring how braintree_ios publishes Jazzy docs: one folder per version plus
+# a `current` symlink to the latest, no version-picker UI.
+#
+# This script only commits locally to the reference-docs branch checked out in a
+# worktree next to the repo. It intentionally does not push - the caller
+# (e.g. the release workflow) is responsible for pushing when ready.
+set -euo pipefail
+
+VERSION="${1:?Usage: publish-docs.sh <version>}"
+BRANCH="reference-docs"
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+DOCS_SOURCE="${REPO_ROOT}/build/dokkaDocs"
+WORKTREE_DIR="$(dirname "${REPO_ROOT}")/$(basename "${REPO_ROOT}")-${BRANCH}"
+
+if [ ! -d "${DOCS_SOURCE}" ]; then
+  echo "No generated docs found at ${DOCS_SOURCE}. Run ./gradlew dokkaHtmlMultiModule first." >&2
+  exit 1
+fi
+
+if ! git -C "${REPO_ROOT}" worktree list --porcelain | grep -qx "worktree ${WORKTREE_DIR}"; then
+  if git -C "${REPO_ROOT}" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    git -C "${REPO_ROOT}" worktree add "${WORKTREE_DIR}" "${BRANCH}"
+  else
+    git -C "${REPO_ROOT}" worktree add --orphan -b "${BRANCH}" "${WORKTREE_DIR}"
+    git -C "${WORKTREE_DIR}" commit --allow-empty -m "Initialize reference-docs branch" --quiet
+  fi
+fi
+
+rm -rf "${WORKTREE_DIR:?}/${VERSION}"
+mkdir -p "${WORKTREE_DIR}/${VERSION}"
+cp -R "${DOCS_SOURCE}/." "${WORKTREE_DIR}/${VERSION}/"
+
+ln -sfn "${VERSION}" "${WORKTREE_DIR}/current"
+
+# GitHub Pages runs Jekyll on branch deploys by default, which mangles Dokka's
+# raw HTML/underscore-prefixed output (e.g. _images) - opt out.
+touch "${WORKTREE_DIR}/.nojekyll"
+
+# A bare directory-of-folders has nothing to serve at the branch root, so
+# redirect / to the latest version.
+cat > "${WORKTREE_DIR}/index.html" <<'EOF'
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=current/index.html">
+    <link rel="canonical" href="current/index.html">
+  </head>
+  <body>
+    Redirecting to <a href="current/index.html">latest reference docs</a>...
+  </body>
+</html>
+EOF
+
+git -C "${WORKTREE_DIR}" add -A
+if git -C "${WORKTREE_DIR}" diff --cached --quiet; then
+  echo "Nothing new to publish for ${VERSION}."
+else
+  git -C "${WORKTREE_DIR}" commit -m "Publish docs for ${VERSION}" --quiet
+fi
+
+echo "Docs for ${VERSION} committed locally to branch '${BRANCH}' in worktree: ${WORKTREE_DIR}"
+echo "Review with: git -C \"${WORKTREE_DIR}\" log --stat -1"
+echo "This script does not push. Push manually when ready: git -C \"${WORKTREE_DIR}\" push origin ${BRANCH}"


### PR DESCRIPTION
### Summary of changes
- This PR moves Dokka output off of the main branch (docs/) and into a git ignored build directory, then publishes it to a separate `reference-docs` branch via the new publish-docs.sh script.

A follow up PR to generate the docs will follow once this is merged to remove docs/ and then switch over to new docs.

- to test/preview docs you can follow these steps locally:

1. run the publish script with `./scripts/publish-docs.sh 5.30.0-test`
2. cd ../braintree_android-reference-docs
3. preview the docs in the browser (an easy way to set up a local server is with `python3 -m http.server 8000` and then go to http://localhost:8000/ → should redirect to current/index.html and then also try http://localhost:8000/5.30.0-test/

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used for initial research, creating bash script to mimic iOS docs behavior

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 
