### PR TITLE
Add an ability to add a custom Tokenization key to PayPal requests

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -29,6 +29,15 @@ public class DemoClientTokenProvider {
                     );
                 }
             });
+        } else if (authType.equals(getString(appContext, R.string.custom_tokenization_key))) {
+            String key = Settings.getCustomAuthorizationToken(appContext);
+            if (key != null) {
+                callback.onResult(new BraintreeAuthorizationResult.Success(key));
+            } else {
+                callback.onResult(new BraintreeAuthorizationResult.Error(
+                    new IllegalArgumentException("No custom tokenization key available")
+                ));
+            }
         } else {
             String key;
             if (Settings.showCheckoutExperience(appContext)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -31,11 +31,11 @@ public class DemoClientTokenProvider {
             });
         } else if (authType.equals(getString(appContext, R.string.custom_tokenization_key))) {
             String key = Settings.getCustomAuthorizationKey(appContext);
-            if (key != null) {
-                callback.onResult(new BraintreeAuthorizationResult.Success(key));
+            if (key != null && !key.trim().isEmpty()) {
+                callback.onResult(new BraintreeAuthorizationResult.Success(key.trim()));
             } else {
                 callback.onResult(new BraintreeAuthorizationResult.Error(
-                    new IllegalArgumentException("No custom tokenization key available")
+                    new IllegalArgumentException("No custom tokenization key provided")
                 ));
             }
         } else {

--- a/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/DemoClientTokenProvider.java
@@ -30,7 +30,7 @@ public class DemoClientTokenProvider {
                 }
             });
         } else if (authType.equals(getString(appContext, R.string.custom_tokenization_key))) {
-            String key = Settings.getCustomAuthorizationToken(appContext);
+            String key = Settings.getCustomAuthorizationKey(appContext);
             if (key != null) {
                 callback.onResult(new BraintreeAuthorizationResult.Success(key));
             } else {

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.kt
@@ -69,6 +69,11 @@ object Settings {
     }
 
     @JvmStatic
+    fun getCustomAuthorizationToken(context: Context): String? {
+        return getPreferences(context).getString("custom_tokenization_key_value", null)
+    }
+
+    @JvmStatic
     fun getCustomerId(context: Context): String? {
         return getPreferences(context).getString("customer", null)
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.kt
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.kt
@@ -69,7 +69,7 @@ object Settings {
     }
 
     @JvmStatic
-    fun getCustomAuthorizationToken(context: Context): String? {
+    fun getCustomAuthorizationKey(context: Context): String? {
         return getPreferences(context).getString("custom_tokenization_key_value", null)
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
@@ -46,9 +46,9 @@ public class SettingsFragment extends PreferenceFragmentCompat
             preference.setSummary(preference.getSummary());
         }
         if(key.equals("authorization_type")) {
-            Preference customeTokenizationKeyPreference = findPreference("custom_tokenization_key_value");
+            Preference customTokenizationKeyPreference = findPreference("custom_tokenization_key_value");
             String selected = ((ListPreference)preference).getValue();
-            customeTokenizationKeyPreference.setVisible(getString(R.string.custom_tokenization_key).equals(selected));
+            customTokenizationKeyPreference.setVisible(getString(R.string.custom_tokenization_key).equals(selected));
         }
     }
 }

--- a/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/fragments/SettingsFragment.java
@@ -45,5 +45,10 @@ public class SettingsFragment extends PreferenceFragmentCompat
         } else if (preference instanceof SummaryEditTestPreference) {
             preference.setSummary(preference.getSummary());
         }
+        if(key.equals("authorization_type")) {
+            Preference customeTokenizationKeyPreference = findPreference("custom_tokenization_key_value");
+            String selected = ((ListPreference)preference).getValue();
+            customeTokenizationKeyPreference.setVisible(getString(R.string.custom_tokenization_key).equals(selected));
+        }
     }
 }

--- a/Demo/src/main/res/values/arrays.xml
+++ b/Demo/src/main/res/values/arrays.xml
@@ -3,6 +3,7 @@
     <string-array name="authorization_types">
         <item name="client-token">@string/client_token</item>
         <item name="tokenization-key">@string/tokenization_key</item>
+        <item name="custom-tokenization-key">@string/custom_tokenization_key</item>
     </string-array>
 
     <string-array name="environments">

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="authorization_type">Authorization Type</string>
     <string name="client_token">Client Token</string>
     <string name="tokenization_key">Tokenization Key</string>
+    <string name="custom_tokenization_key">Custom Tokenization Key</string>
+    <string name="custom_tokenization_key_summary">Custom Tokenization Key: %s</string>
     <string name="customer">Customer</string>
     <string name="customer_summary">The customer id to use</string>
     <string name="merchant_account">Merchant Account</string>

--- a/Demo/src/main/res/xml/settings.xml
+++ b/Demo/src/main/res/xml/settings.xml
@@ -11,6 +11,12 @@
             android:entryValues="@array/authorization_types"
             android:defaultValue="@string/client_token"/>
 
+        <com.braintreepayments.demo.views.SummaryEditTestPreference
+            android:key="custom_tokenization_key_value"
+            android:title="@string/custom_tokenization_key"
+            android:summary="@string/custom_tokenization_key_summary"
+            android:defaultValue="@string/empty"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
### Summary of changes
- add a new radio button to choose from under Settings -> Authorization Type -> Custom Tokenization key 
- if selected new input filed will pop up under the authorization type
- if custom tokenization key is used it will take precedence despite what is selected in production/sandbox dropdown


https://github.com/user-attachments/assets/a0ec8076-d2c1-478f-98be-7b8a9775fca4



### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to write up logic and connect to UI

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 

