### PR TITLE
fix: handle shopper insights errors correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree Android SDK Release Notes
 
+## unreleased
+
+* ShopperInsights
+    * Fix response handling bug that buries customer session create and update errors
+
 ## 5.31.0 (2026-08-03)
 
 * PayPal

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
@@ -1,7 +1,9 @@
 package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.ExperimentalBetaApi
+import com.braintreepayments.api.core.GraphQLConstants
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
 import com.braintreepayments.api.shopperinsights.v2.PaymentOptions
@@ -81,9 +83,16 @@ internal class GenerateCustomerRecommendationsApi(
         return JSONObject().put(INPUT, input)
     }
 
-    @Throws(JSONException::class)
+    @Throws(JSONException::class, BraintreeException::class)
     private fun parseRecommendationsResponse(responseBody: String): CustomerRecommendations {
         val jsonObject = JSONObject(responseBody)
+
+        val errors = jsonObject.optJSONArray(GraphQLConstants.Keys.ERRORS)
+        if (errors != null && errors.length() > 0) {
+            val message = errors.getJSONObject(0).optString(GraphQLConstants.Keys.MESSAGE, responseBody)
+            throw BraintreeException(message)
+        }
+
         val data = jsonObject.getJSONObject("data")
         val recommendations = data.getJSONObject(GENERATE_CUSTOMER_RECOMMENDATIONS)
 

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParser.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParser.kt
@@ -1,5 +1,7 @@
 package com.braintreepayments.api.shopperinsights.v2.internal
 
+import com.braintreepayments.api.core.BraintreeException
+import com.braintreepayments.api.core.GraphQLConstants
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -8,9 +10,17 @@ import org.json.JSONObject
  */
 internal class ShopperInsightsResponseParser {
 
-    @Throws(JSONException::class)
+    @Throws(JSONException::class, BraintreeException::class)
     fun parseSessionId(responseBody: String, graphQLCall: String): String {
-        val data = JSONObject(responseBody).getJSONObject(DATA)
+        val responseJSON = JSONObject(responseBody)
+
+        val errors = responseJSON.optJSONArray(GraphQLConstants.Keys.ERRORS)
+        if (errors != null && errors.length() > 0) {
+            val message = errors.getJSONObject(0).optString(GraphQLConstants.Keys.MESSAGE, responseBody)
+            throw BraintreeException(message)
+        }
+
+        val data = responseJSON.getJSONObject(DATA)
         val sessionObject = data.getJSONObject(graphQLCall)
         return sessionObject.getString(SESSION_ID)
     }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api.shopperinsights.v2.internal
 
 import com.braintreepayments.api.core.BraintreeClient
+import com.braintreepayments.api.core.BraintreeException
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.shopperinsights.v2.CustomerRecommendations
 import com.braintreepayments.api.shopperinsights.v2.CustomerSessionRequest
@@ -194,6 +195,38 @@ class GenerateCustomerRecommendationsApiUnitTest {
 
         assert(result is GenerateCustomerRecommendationsResult.Error)
         assertEquals(error, (result as GenerateCustomerRecommendationsResult.Error).error)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called and the GQL response contains errors, callback with Error is invoked`() =
+    runTest(testDispatcher) {
+        val responseBody = """
+            {
+                "errors": [
+                    {
+                        "message": "Unauthorized"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
+
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+        advanceUntilIdle()
+
+        assert(result is GenerateCustomerRecommendationsResult.Error)
+        val error = (result as GenerateCustomerRecommendationsResult.Error).error
+        assert(error is BraintreeException)
+        assertEquals("Unauthorized", error.message)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParserUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/ShopperInsightsResponseParserUnitTest.kt
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.shopperinsights.v2.internal
 
+import com.braintreepayments.api.core.BraintreeException
 import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
@@ -60,5 +61,42 @@ class ShopperInsightsResponseParserUnitTest {
         assertThrows(JSONException::class.java) {
             responseParser.parseSessionId(responseBody, "createCustomerSession")
         }
+    }
+
+    @Test
+    fun `parseSessionId throws BraintreeException with GQL error message when response contains errors`() {
+        val responseBody = """
+            {
+                "errors": [
+                    {
+                        "message": "Unauthorized"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val exception = assertThrows(BraintreeException::class.java) {
+            responseParser.parseSessionId(responseBody, "createCustomerSession")
+        }
+        assertEquals("Unauthorized", exception.message)
+    }
+
+    @Test
+    fun `parseSessionId throws BraintreeException when errors array is present with no data`() {
+        val responseBody = """
+            {
+                "data": null,
+                "errors": [
+                    {
+                        "message": "Unauthorized"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val exception = assertThrows(BraintreeException::class.java) {
+            responseParser.parseSessionId(responseBody, "createCustomerSession")
+        }
+        assertEquals("Unauthorized", exception.message)
     }
 }


### PR DESCRIPTION
### Summary of changes
We noticed an issue with Shopper Insights V2 in the demo app and after digging into that we noticed that error handling for the responses to create and update the customer session was broken. We were getting a JSON exception instead of the proper GQL error in response. This PR fixes the error handling so that the correct error is surfaced

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used claude to find GQL error handling pattern and for writing unit tests

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [x] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
- @saralvasquez 