### PR TITLE
feat(PayPalCheckoutRequest): source editBillingAgreementJwt from client token for PayPal Edit FI flow

### DIFF
--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/Authorization.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/Authorization.kt
@@ -17,6 +17,12 @@ abstract class Authorization internal constructor(private val rawValue: String) 
     abstract val bearer: String?
 
     /**
+     * The payment method ID JWT extracted from the client token, if present.
+     * @suppress
+     */
+    open val paymentMethodIdJwt: String? get() = null
+
+    /**
      * @return The original Client token or Tokenization Key string, which can be used for serialization
      */
     override fun toString(): String {

--- a/BraintreeCore/src/main/java/com/braintreepayments/api/core/ClientToken.kt
+++ b/BraintreeCore/src/main/java/com/braintreepayments/api/core/ClientToken.kt
@@ -21,6 +21,7 @@ class ClientToken @Throws(InvalidArgumentException::class) internal constructor(
 
     override val configUrl: String
     override val bearer: String
+    override val paymentMethodIdJwt: String?
 
     internal val authorizationFingerprint: String
     internal val customerId: String?
@@ -33,6 +34,8 @@ class ClientToken @Throws(InvalidArgumentException::class) internal constructor(
             authorizationFingerprint = jsonObject.getString(AUTHORIZATION_FINGERPRINT_KEY)
             bearer = authorizationFingerprint
             customerId = parseCustomerId(authorizationFingerprint)
+            paymentMethodIdJwt = jsonObject.takeIf { it.has(PAYMENT_METHOD_ID_JWT_KEY) }
+                ?.getString(PAYMENT_METHOD_ID_JWT_KEY)
         } catch (e: NullPointerException) {
             throw InvalidArgumentException("Client token was invalid")
         } catch (e: JSONException) {
@@ -45,6 +48,7 @@ class ClientToken @Throws(InvalidArgumentException::class) internal constructor(
             "([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)"
         private const val CONFIG_URL_KEY = "configUrl"
         private const val AUTHORIZATION_FINGERPRINT_KEY = "authorizationFingerprint"
+        private const val PAYMENT_METHOD_ID_JWT_KEY = "paymentMethodIdJwt"
 
         private fun parseCustomerId(authorizationFingerprint: String?): String? {
             val result = authorizationFingerprint?.let { fingerPrint ->

--- a/BraintreeCore/src/test/java/com/braintreepayments/api/core/ClientTokenUnitTest.kt
+++ b/BraintreeCore/src/test/java/com/braintreepayments/api/core/ClientTokenUnitTest.kt
@@ -59,4 +59,20 @@ class ClientTokenUnitTest {
             ) as ClientToken
         assertEquals("fake-customer-123", clientToken.customerId)
     }
+
+    @Test
+    fun `when paymentMethodIdJwt is present in the client token, paymentMethodIdJwt returns it`() {
+        val clientToken =
+            fromString(
+                FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN_WITH_PAYMENT_METHOD_ID_JWT)
+            ) as ClientToken
+        assertEquals("payment_method_id_jwt", clientToken.paymentMethodIdJwt)
+    }
+
+    @Test
+    fun `when paymentMethodIdJwt is not present in the client token, paymentMethodIdJwt returns null`() {
+        val clientToken =
+            fromString(FixturesHelper.base64Encode(Fixtures.CLIENT_TOKEN)) as ClientToken
+        assertNull(clientToken.paymentMethodIdJwt)
+    }
 }

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -74,6 +74,10 @@ import org.json.JSONObject
  * @property amountBreakdown Breakdown of items associated to the total cost
  *
  * @property shouldOfferCredit Offers PayPal Credit if the customer qualifies. Defaults to false.
+ *
+ * @property editBillingAgreement Opts into the View/Edit Funding Instrument (FI) flow. When set to
+ * true and the SDK is initialized with a client token carrying a payment method ID JWT, that JWT
+ * is included in the request to seed the edit order. Defaults to null (opted out).
  */
 @Parcelize
 class PayPalCheckoutRequest @JvmOverloads constructor(
@@ -104,7 +108,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var recurringBillingPlanType: PayPalRecurringBillingPlanType? = null,
     var amountBreakdown: AmountBreakdown? = null,
     override var shouldOfferCredit: Boolean = false,
-    var editBillingAgreementJwt: String? = null,
+    var editBillingAgreement: Boolean? = null,
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -143,6 +147,11 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
 
         if (authorization is ClientToken) {
             parameters.put(AUTHORIZATION_FINGERPRINT_KEY, authorization.bearer)
+            if (editBillingAgreement == true) {
+                authorization.paymentMethodIdJwt?.let {
+                    parameters.put(EDIT_BILLING_AGREEMENT_JWT_KEY, it)
+                }
+            }
         } else {
             parameters.put(TOKENIZATION_KEY, authorization?.bearer)
         }
@@ -179,8 +188,6 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
         }
 
         parameters.putOpt(SHOPPER_SESSION_ID_KEY, shopperSessionId)
-
-        editBillingAgreementJwt?.let { parameters.put(EDIT_BILLING_AGREEMENT_JWT_KEY, it) }
 
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -104,6 +104,7 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var recurringBillingPlanType: PayPalRecurringBillingPlanType? = null,
     var amountBreakdown: AmountBreakdown? = null,
     override var shouldOfferCredit: Boolean = false,
+    var editBillingAgreementJwt: String? = null,
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -178,6 +179,8 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
         }
 
         parameters.putOpt(SHOPPER_SESSION_ID_KEY, shopperSessionId)
+
+        editBillingAgreementJwt?.let { parameters.put(EDIT_BILLING_AGREEMENT_JWT_KEY, it) }
 
         if (currencyCode == null) {
             currencyCode = configuration?.payPalCurrencyIsoCode

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalCheckoutRequest.kt
@@ -9,6 +9,7 @@ import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.PostalAddress
 import com.braintreepayments.api.core.PostalAddressParser
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONException
@@ -74,10 +75,6 @@ import org.json.JSONObject
  * @property amountBreakdown Breakdown of items associated to the total cost
  *
  * @property shouldOfferCredit Offers PayPal Credit if the customer qualifies. Defaults to false.
- *
- * @property editBillingAgreement Opts into the View/Edit Funding Instrument (FI) flow. When set to
- * true and the SDK is initialized with a client token carrying a payment method ID JWT, that JWT
- * is included in the request to seed the edit order. Defaults to null (opted out).
  */
 @Parcelize
 class PayPalCheckoutRequest @JvmOverloads constructor(
@@ -108,7 +105,6 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     override var recurringBillingPlanType: PayPalRecurringBillingPlanType? = null,
     var amountBreakdown: AmountBreakdown? = null,
     override var shouldOfferCredit: Boolean = false,
-    var editBillingAgreement: Boolean? = null,
 ) : PayPalRequest(
     hasUserLocationConsent = hasUserLocationConsent,
     localeCode = localeCode,
@@ -124,6 +120,16 @@ class PayPalCheckoutRequest @JvmOverloads constructor(
     userAuthenticationEmail = userAuthenticationEmail,
     lineItems = lineItems
 ) {
+
+    /**
+     * Opts into the View/Edit Funding Instrument (FI) flow. When set to true and the SDK is
+     * initialized with a client token carrying a payment method ID JWT, that JWT is included in
+     * the request to seed the edit order. Defaults to null (opted out). Can only be set
+     * internally via [PayPalClient.createPaymentAuthRequestForEditFi].
+     */
+    @IgnoredOnParcel
+    var editBillingAgreement: Boolean? = null
+        internal set
 
     @OptIn(ExperimentalBetaApi::class)
     @Throws(JSONException::class)

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -121,6 +121,35 @@ class PayPalClient internal constructor(
     }
 
     /**
+     * Starts the PayPal payment flow for the View/Edit Funding Instrument (FI) flow by creating a
+     * [PayPalPaymentAuthRequestParams] to be used to launch the PayPal web authentication flow in
+     * [PayPalLauncher.launch].
+     *
+     * This is invoked when the customer taps Edit in the PayPal saved payment method view. It
+     * opts the given [payPalCheckoutRequest] into the edit flow by setting
+     * [PayPalCheckoutRequest.editBillingAgreement] to true, so that when the SDK is initialized
+     * with a client token carrying a payment method ID JWT, that JWT is included in the request
+     * to seed the edit order.
+     *
+     * On success [callback] is called with a [PayPalPaymentAuthRequest.ReadyToLaunch] wrapping a
+     * [PayPalPaymentAuthRequestParams].
+     * On failures [callback] is called with a [PayPalPaymentAuthRequest.Failure] with an exception.
+     *
+     * @param context               Android Context
+     * @param payPalCheckoutRequest a [PayPalCheckoutRequest] used to customize the request.
+     * @param callback              [PayPalPaymentAuthCallback]
+     */
+    @OptIn(ExperimentalBetaApi::class)
+    fun createPaymentAuthRequestForEditFi(
+        context: Context,
+        payPalCheckoutRequest: PayPalCheckoutRequest,
+        callback: PayPalPaymentAuthCallback,
+    ) {
+        payPalCheckoutRequest.editBillingAgreement = true
+        createPaymentAuthRequest(context, payPalCheckoutRequest, callback)
+    }
+
+    /**
      * Starts the PayPal payment flow by creating a [PayPalPaymentAuthRequestParams] to be
      * used to launch the PayPal web authentication flow in
      * [PayPalLauncher.launch].

--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalRequest.kt
@@ -160,5 +160,6 @@ abstract class PayPalRequest internal constructor(
         internal const val DEVICE_MODEL_KEY: String = "model"
         internal const val MEMORY_AVAILABLE_MB_KEY: String = "memory_available_mb"
         internal const val MEMORY_TOTAL_MB_KEY: String = "memory_total_mb"
+        internal const val EDIT_BILLING_AGREEMENT_JWT_KEY: String = "edit_billing_agreement_jwt"
     }
 }

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
@@ -44,6 +44,7 @@ class PayPalCheckoutRequestUnitTest {
         assertFalse(request.enablePayPalAppSwitch)
         assertNull(request.userAuthenticationEmail)
         assertFalse(request.hasUserLocationConsent)
+        assertNull(request.editBillingAgreement)
     }
 
     @OptIn(ExperimentalBetaApi::class)

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
@@ -3,10 +3,12 @@ package com.braintreepayments.api.paypal
 import android.net.Uri
 import android.os.Parcel
 import com.braintreepayments.api.core.Authorization
+import com.braintreepayments.api.core.ClientToken
 import com.braintreepayments.api.core.Configuration
 import com.braintreepayments.api.core.ExperimentalBetaApi
 import com.braintreepayments.api.core.PostalAddress
 import com.google.testing.junit.testparameterinjector.TestParameter
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.parcelize.parcelableCreator
 import org.json.JSONException
@@ -253,14 +255,17 @@ class PayPalCheckoutRequestUnitTest {
     @OptIn(ExperimentalBetaApi::class)
     @Test
     @Throws(JSONException::class)
-    fun `creates requestBody and sets editBillingAgreementJwt when not null`() {
+    fun `creates requestBody and sets editBillingAgreementJwt when opted in with a paymentMethodIdJwt`() {
         val request = PayPalCheckoutRequest("1.00", true).apply {
-            editBillingAgreementJwt = "edit-jwt"
+            editBillingAgreement = true
+        }
+        val clientToken = mockk<ClientToken>(relaxed = true) {
+            every { paymentMethodIdJwt } returns "edit-jwt"
         }
 
         val requestBody = request.createRequestBody(
             configuration = mockk<Configuration>(relaxed = true),
-            authorization = mockk<Authorization>(relaxed = true),
+            authorization = clientToken,
             successUrl = "success_url",
             cancelUrl = "cancel_url",
             appLink = null
@@ -273,8 +278,54 @@ class PayPalCheckoutRequestUnitTest {
     @OptIn(ExperimentalBetaApi::class)
     @Test
     @Throws(JSONException::class)
-    fun `creates requestBody and does not set editBillingAgreementJwt when null`() {
+    fun `creates requestBody and does not set editBillingAgreementJwt when editBillingAgreement is null`() {
         val request = PayPalCheckoutRequest("1.00", true)
+        val clientToken = mockk<ClientToken>(relaxed = true) {
+            every { paymentMethodIdJwt } returns "edit-jwt"
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = clientToken,
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertFalse(jsonObject.has("edit_billing_agreement_jwt"))
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set editBillingAgreementJwt when authorization has no paymentMethodIdJwt`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            editBillingAgreement = true
+        }
+        val clientToken = mockk<ClientToken>(relaxed = true) {
+            every { paymentMethodIdJwt } returns null
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = clientToken,
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertFalse(jsonObject.has("edit_billing_agreement_jwt"))
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set editBillingAgreementJwt when authorization is not a ClientToken`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            editBillingAgreement = true
+        }
 
         val requestBody = request.createRequestBody(
             configuration = mockk<Configuration>(relaxed = true),

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalCheckoutRequestUnitTest.kt
@@ -250,6 +250,44 @@ class PayPalCheckoutRequestUnitTest {
         assertTrue(requestBody.contains("\"shopper_session_id\":" + "\"shopper-insights-id\""))
     }
 
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and sets editBillingAgreementJwt when not null`() {
+        val request = PayPalCheckoutRequest("1.00", true).apply {
+            editBillingAgreementJwt = "edit-jwt"
+        }
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertEquals("edit-jwt", jsonObject.getString("edit_billing_agreement_jwt"))
+    }
+
+    @OptIn(ExperimentalBetaApi::class)
+    @Test
+    @Throws(JSONException::class)
+    fun `creates requestBody and does not set editBillingAgreementJwt when null`() {
+        val request = PayPalCheckoutRequest("1.00", true)
+
+        val requestBody = request.createRequestBody(
+            configuration = mockk<Configuration>(relaxed = true),
+            authorization = mockk<Authorization>(relaxed = true),
+            successUrl = "success_url",
+            cancelUrl = "cancel_url",
+            appLink = null
+        )
+
+        val jsonObject = JSONObject(requestBody)
+        assertFalse(jsonObject.has("edit_billing_agreement_jwt"))
+    }
+
     @Test
     @Throws(JSONException::class)
     fun `creates requestBody and does not set shippingCallbackUri when null`() {

--- a/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
+++ b/PayPal/src/test/java/com/braintreepayments/api/paypal/PayPalClientUnitTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -559,6 +560,110 @@ class PayPalClientUnitTest {
                 any<Configuration>()
             )
         }
+    }
+
+    @Test
+    fun `when createPaymentAuthRequestForEditFi is called, editBillingAgreement is set to true on the request`() = runTest(testDispatcher) {
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        val braintreeClient =
+            MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true)
+        assertNull(payPalCheckoutRequest.editBillingAgreement)
+
+        val sut = testPaypalClient(
+            braintreeClient,
+            payPalInternalClient,
+            testDispatcher,
+            this
+        )
+        sut.createPaymentAuthRequestForEditFi(activity, payPalCheckoutRequest, paymentAuthCallback)
+        advanceUntilIdle()
+
+        assertEquals(true, payPalCheckoutRequest.editBillingAgreement)
+    }
+
+    @Test
+    fun `when createPaymentAuthRequestForEditFi is called, internal client sendRequest is invoked with that request`() = runTest(testDispatcher) {
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        val braintreeClient =
+            MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true)
+
+        val sut = testPaypalClient(
+            braintreeClient,
+            payPalInternalClient,
+            testDispatcher,
+            this
+        )
+        sut.createPaymentAuthRequestForEditFi(activity, payPalCheckoutRequest, paymentAuthCallback)
+        advanceUntilIdle()
+
+        coVerify {
+            payPalInternalClient.sendRequest(
+                activity,
+                payPalCheckoutRequest,
+                any<Configuration>()
+            )
+        }
+    }
+
+    @Test
+    fun `when createPaymentAuthRequestForEditFi succeeds, callback receives ReadyToLaunch`() = runTest(testDispatcher) {
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true)
+        val paymentAuthRequest = PayPalPaymentAuthRequestParams(
+            payPalCheckoutRequest,
+            null,
+            "https://example.com/approval/url",
+            "sample-client-metadata-id",
+            null,
+            "https://example.com/success/url"
+        )
+        val payPalInternalClient = MockkPayPalInternalClientBuilder()
+            .sendRequestSuccess(paymentAuthRequest)
+            .build()
+
+        val braintreeClient =
+            MockkBraintreeClientBuilder().configurationSuccess(payPalEnabledConfig).build()
+
+        val sut = testPaypalClient(
+            braintreeClient,
+            payPalInternalClient,
+            testDispatcher,
+            this
+        )
+        sut.createPaymentAuthRequestForEditFi(activity, payPalCheckoutRequest, paymentAuthCallback)
+        advanceUntilIdle()
+
+        val slot = slot<PayPalPaymentAuthRequest>()
+        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(capture(slot)) }
+        assertTrue(slot.captured is PayPalPaymentAuthRequest.ReadyToLaunch)
+    }
+
+    @Test
+    fun `when createPaymentAuthRequestForEditFi is called and PayPal is not enabled, callback receives failure`() = runTest(testDispatcher) {
+        val payPalInternalClient = MockkPayPalInternalClientBuilder().build()
+
+        val braintreeClient =
+            MockkBraintreeClientBuilder().configurationSuccess(payPalDisabledConfig).build()
+
+        val payPalCheckoutRequest = PayPalCheckoutRequest("1.00", true)
+
+        val sut = testPaypalClient(
+            braintreeClient,
+            payPalInternalClient,
+            testDispatcher,
+            this
+        )
+        sut.createPaymentAuthRequestForEditFi(activity, payPalCheckoutRequest, paymentAuthCallback)
+        advanceUntilIdle()
+
+        val slot = slot<PayPalPaymentAuthRequest>()
+        verify { paymentAuthCallback.onPayPalPaymentAuthRequest(capture(slot)) }
+        assertTrue(slot.captured is PayPalPaymentAuthRequest.Failure)
     }
 
     @Test

--- a/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
+++ b/TestUtils/src/main/java/com/braintreepayments/api/testutils/Fixtures.kt
@@ -465,6 +465,15 @@ object Fixtures {
           "clientApiUrl": "https://api.sandbox.braintreegateway.com:443/merchants/dcpspy2brwdjr3qn/client_api"
         }
     """
+
+    // language=JSON
+    const val CLIENT_TOKEN_WITH_PAYMENT_METHOD_ID_JWT = """
+        {
+            "configUrl": "client_api_configuration_url",
+            "authorizationFingerprint": "authorization_fingerprint",
+            "paymentMethodIdJwt": "payment_method_id_jwt"
+        }
+    """
     // endregion
 
     // region Card


### PR DESCRIPTION
Source the `editBillingAgreementJwt` for the PayPal Edit FI flow from the **client token** and thread it into `create_payment_resource`. The JWT is never merchant-supplied, and the flow is enabled only through a dedicated internal entry point rather than exposed on the public API.

### Summary of changes
- Added `paymentMethodIdJwt` to `Authorization` as an open property defaulting to `null`; `ClientToken` overrides it and parses the value from the `paymentMethodIdJwt` key in the client token JSON — other `Authorization` subtypes (e.g. tokenization key) keep the default `null`
- Added an internal `editBillingAgreement` flag on `PayPalCheckoutRequest` — not exposed on either public constructor, restricted to internal write access
- Added `PayPalClient.createPaymentAuthRequestForEditFi(context, payPalCheckoutRequest, callback)` as the sole entry point that sets `editBillingAgreement = true` and delegates to `createPaymentAuthRequest`, so the JWT is included in the `create_payment_resource` call only when the SDK is initialized with a client token carrying it
- `PayPalRequest` / `PayPalVaultRequest` are unchanged — the JWT and flag are checkout-only
- Added unit tests covering: opt-in + JWT present (sent), opt-in false (omitted), opt-in + JWT nil (omitted), and `ClientToken` parsing with/without the claim

### Notes for reviewers
- `createPaymentAuthRequestForEditFi` has no caller in this PR yet — its consumer is the `PayPalSavedPaymentMethod` module, landing on top of this branch.
- Parity PR (iOS): braintree/braintree_ios#1844

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot
- [x] Claude
- [ ] Other (Type Name Here)

**How was AI used?**
Used Claude Code to extract the JWT from the client token via `Authorization`/`ClientToken`, thread it through `PayPalCheckoutRequest`/`PayPalClient` behind the internal opt-in gate, and write the accompanying unit tests, following the iOS parity PR (#1844) as reference.

**Estimated AI Code Contribution**
- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- go-os-code

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [ ] Added all labels to the PR
- [ ] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [ ] Unit tests and builds have been run locally and pass/compile as expected