### PR TITLE
feature: parse expiresAt field in generateCustomerRecommendations response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * ShopperInsights
     * Add `CustomerSessionRequest.payPalCampaigns` to associate campaigns with a customer session
     * Fix response handling bug that buries customer session create and update errors
+    * Add `CustomerRecommendations.expiresAt` indicating when returned recommendations should be treated as stale
 
 ## 5.31.0 (2026-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * ShopperInsights
     * Add `CustomerSessionRequest.payPalCampaigns` to associate campaigns with a customer session
     * Fix response handling bug that buries customer session create and update errors
-    * Add `CustomerRecommendations.expiresAt` indicating when returned recommendations should be treated as stale
+    * Add optional `CustomerRecommendations.expiresAt` indicating when returned recommendations should be treated as stale
 
 ## 5.31.0 (2026-08-03)
 

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerRecommendations.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/CustomerRecommendations.kt
@@ -8,6 +8,8 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
  * @property sessionId The session ID for the customer session.
  * @property isInPayPalNetwork Whether the customer is in the PayPal network.
  * @property paymentRecommendations The payment recommendations for the shopper.
+ * @property expiresAt The ISO 8601 date and time after which the recommendations should be
+ * treated as stale, or null if not provided.
  *
  * Warning: This feature is in beta. It's public API may change or be removed in future releases.
  */
@@ -15,5 +17,6 @@ import com.braintreepayments.api.core.ExperimentalBetaApi
 data class CustomerRecommendations internal constructor(
     val sessionId: String?,
     val isInPayPalNetwork: Boolean?,
-    val paymentRecommendations: List<PaymentOptions>?
+    val paymentRecommendations: List<PaymentOptions>?,
+    val expiresAt: String? = null
 )

--- a/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
+++ b/ShopperInsights/src/main/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApi.kt
@@ -45,6 +45,7 @@ internal class GenerateCustomerRecommendationsApi(
                             paymentOption
                             recommendedPriority
                         }
+                        expiresAt
                     }
                 }
                 """.trimIndent()
@@ -100,6 +101,7 @@ internal class GenerateCustomerRecommendationsApi(
         val sessionId = recommendations.getString(SESSION_ID)
         val isInPayPalNetwork = recommendations.getBoolean("isInPayPalNetwork")
         val paymentRecommendations = recommendations.getJSONArray("paymentRecommendations")
+        val expiresAt = recommendations.opt(EXPIRES_AT) as? String
 
         val paymentOptions = mutableListOf<PaymentOptions>()
         for (i in 0 until paymentRecommendations.length()) {
@@ -115,7 +117,8 @@ internal class GenerateCustomerRecommendationsApi(
         return CustomerRecommendations(
             sessionId = sessionId,
             isInPayPalNetwork = isInPayPalNetwork,
-            paymentRecommendations = paymentOptions
+            paymentRecommendations = paymentOptions,
+            expiresAt = expiresAt
         )
     }
 
@@ -128,5 +131,6 @@ internal class GenerateCustomerRecommendationsApi(
         private const val PURCHASE_UNITS = "purchaseUnits"
         private const val PAYPAL_CAMPAIGNS = "paypalCampaigns"
         private const val GENERATE_CUSTOMER_RECOMMENDATIONS = "generateCustomerRecommendations"
+        private const val EXPIRES_AT = "expiresAt"
     }
 }

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -87,6 +87,7 @@ class GenerateCustomerRecommendationsApiUnitTest {
                             paymentOption
                             recommendedPriority
                         }
+                        expiresAt
                     }
                 }
                 """.trimIndent()
@@ -147,7 +148,8 @@ class GenerateCustomerRecommendationsApiUnitTest {
                                 "paymentOption": "PAYPAL",
                                 "recommendedPriority": 1
                             }
-                        ]
+                        ],
+                        "expiresAt": "2026-08-15T00:00:00Z"
                     }
                 }
             }
@@ -170,11 +172,53 @@ class GenerateCustomerRecommendationsApiUnitTest {
             isInPayPalNetwork = true,
             paymentRecommendations = listOf(
                 PaymentOptions(paymentOption = "PAYPAL", recommendedPriority = 1)
-            )
+            ),
+            expiresAt = "2026-08-15T00:00:00Z"
         )
 
         assert(result is GenerateCustomerRecommendationsResult.Success)
         assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when execute is called and expiresAt is absent, expiresAt is null in the result`() =
+    runTest(testDispatcher) {
+        val sessionId = "test-session-id"
+        val responseBody = """
+            {
+                "data": {
+                    "generateCustomerRecommendations": {
+                        "sessionId": "$sessionId",
+                        "isInPayPalNetwork": true,
+                        "paymentRecommendations": [
+                            {
+                                "paymentOption": "PAYPAL",
+                                "recommendedPriority": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val braintreeClient = MockkBraintreeClientBuilder()
+            .sendGraphQLPostSuccessfulResponse(responseBody)
+            .build()
+
+        val generateCustomerRecommendationsApi = GenerateCustomerRecommendationsApi(
+            braintreeClient = braintreeClient,
+            customerSessionRequestBuilder = customerSessionRequestBuilder
+        )
+
+        val result = generateCustomerRecommendationsApi.execute(customerSessionRequest, "test-session-id")
+        advanceUntilIdle()
+
+        assert(result is GenerateCustomerRecommendationsResult.Success)
+        assertEquals(
+            null,
+            (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations.expiresAt
+        )
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
+++ b/ShopperInsights/src/test/java/com/braintreepayments/api/shopperinsights/v2/internal/GenerateCustomerRecommendationsApiUnitTest.kt
@@ -177,7 +177,9 @@ class GenerateCustomerRecommendationsApiUnitTest {
         )
 
         assert(result is GenerateCustomerRecommendationsResult.Success)
-        assertEquals(expectedResult, (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations)
+        val customerRecommendations = (result as GenerateCustomerRecommendationsResult.Success).customerRecommendations
+        assertEquals(expectedResult, customerRecommendations)
+        assertEquals("2026-08-15T00:00:00Z", customerRecommendations.expiresAt)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
### Summary of changes
- Add support for the new `expiresAt` field returned by the `GenerateCustomerRecommendations` GraphQL mutation, so merchants can know when returned payment recommendations should be treated as stale.
- `CustomerRecommendations.expiresAt` defaults to `null` when the field is absent from the response, for backward compatibility.

**Manual verification:** Ran the Demo app (ShopperInsights V2 screen) against the Sandbox environment on an emulator and captured the raw GraphQL response, confirming the backend returns a real `expiresAt` value and that it is parsed and surfaced correctly end-to-end:

```json
{"data":{"generateCustomerRecommendations":{"sessionId":"94f0b2db-5323-4d86-add3-paypal000000","isInPayPalNetwork":true,"paymentRecommendations":[{"paymentOption":"PAYPAL","recommendedPriority":1}],"expiresAt":"2026-08-16T03:19:28.000000Z"}},"extensions":{"requestId":"0e2041cb-a7a7-4872-b3c0-b5f99b2b0040"}}
```

The Demo app UI rendered `expiresAt = 2026-08-16T03:19:28.000000Z`, matching the raw response above.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot
- [x] Claude
- [ ] Other (Type Name Here)

**How was AI used?**
Code generation for the field parsing change and unit tests, and manual verification against Sandbox via the Demo app on an emulator.

**Estimated AI Code Contribution**
- [ ] less than 30%
- [x] 30 - 60%
- [ ] 60 - 100%

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
- santugowda

----
### Inner Source Process
Internal to PayPal contributors should fill out this section. All others can delete.

PR should follow these steps before codeowners review will begin:
1. Comment `/inner source` on this PR — this will automatically add the `inner source` and `tech lead review required` labels. Open the PR in a draft state.
2. PR should be reviewed by and approved by your team's technical lead, we do not allow LGTM reviews, there should be comments and feedback provided on all PR reviews
3. Once the above steps are completed, comment `/ready` on this PR — this will automatically remove the `tech lead review required` label. Move the PR to ready to review.
4. PR comments must be addressed within 24 hours, if you are unable to address within this timeframe, move the PR back to a draft state so our team knows not to review

### Inner Source Checklist
- [ ] Added all labels to the PR
- [x] Provide steps to test the flows changed, if applicable in the summary
- [ ] Demo video of the functionality, if applicable
- [ ] All upstream dependencies are merged in and this PR can be released at any time; PRs should not be opened until this is true
- [x] Unit tests and builds have been run locally and pass/compile as expected