### PR TITLE
Document Deeplink Fallback URL Scheme in KDocs

### DIFF
--- a/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
+++ b/PayPal/src/main/java/com/braintreepayments/api/paypal/PayPalClient.kt
@@ -73,6 +73,18 @@ class PayPalClient internal constructor(
      * your application to be used to return to your app from the PayPal payment flows.
      * @param deepLinkFallbackUrlScheme A return url scheme that will be used as a deep link fallback when returning to
      * your app via App Link is not available (buyer unchecks the "Open supported links" setting).
+     *
+     * The value must be a bare URL scheme, not a full URL. It must:
+     * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+     * - Not include `://`
+     * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+     * - Match the scheme declared in your `AndroidManifest.xml`
+     *
+     * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+     *
+     * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+     * `"com.merchant.app.payments/callback"` (contains a path),
+     * `"com.merchant_app"` (underscore not allowed).
      */
     constructor(
         context: Context,

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/PayPalButton.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/PayPalButton.kt
@@ -86,6 +86,18 @@ class PayPalButton @JvmOverloads constructor(
      * merchant's application to be used to return to merchant's app from the PayPal payment flows.
      * @param deepLinkFallbackUrlScheme a return url scheme that will be used as a deep link fallback when returning to
      * merchant's app via App Link is not available (buyer unchecks the "Open supported links" setting).
+     *
+     * The value must be a bare URL scheme, not a full URL. It must:
+     * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+     * - Not include `://`
+     * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+     * - Match the scheme declared in your `AndroidManifest.xml`
+     *
+     * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+     *
+     * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+     * `"com.merchant.app.payments/callback"` (contains a path),
+     * `"com.merchant_app"` (underscore not allowed).
      * @param activityResultCaller      an [ActivityResultCaller] (typically a Fragment or Activity) that will be used
      * to register the ActivityResultLauncher for the PayPal browser switch flow.
      */

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/VenmoButton.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/VenmoButton.kt
@@ -83,6 +83,18 @@ class VenmoButton @JvmOverloads constructor(
      * merchant's application to be used to return to merchant's app from the Venmo payment flows.
      * @param deepLinkFallbackUrlScheme a return url scheme that will be used as a deep link fallback when returning to
      * merchant's app via App Link is not available (buyer unchecks the "Open supported links" setting).
+     *
+     * The value must be a bare URL scheme, not a full URL. It must:
+     * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+     * - Not include `://`
+     * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+     * - Match the scheme declared in your `AndroidManifest.xml`
+     *
+     * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+     *
+     * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+     * `"com.merchant.app.payments/callback"` (contains a path),
+     * `"com.merchant_app"` (underscore not allowed).
      * @param activityResultCaller      an [ActivityResultCaller] (typically a Fragment or Activity) that will be used
      * to register the ActivityResultLauncher for the Venmo browser switch flow.
      */

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/compose/PayPalButton.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/compose/PayPalButton.kt
@@ -38,6 +38,18 @@ import kotlinx.coroutines.launch
  * @param authorization: An authorization string to use for tokenization.
  * @param appLinkReturnUrl: A [Uri] that sends back control to the host app after PayPal flow completes.
  * @param deepLinkFallbackUrlScheme: Fallback scheme in case [appLinkReturnUrl] doesn't work.
+ *
+ * The value must be a bare URL scheme, not a full URL. It must:
+ * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+ * - Not include `://`
+ * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+ * - Match the scheme declared in your `AndroidManifest.xml`
+ *
+ * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+ *
+ * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+ * `"com.merchant.app.payments/callback"` (contains a path),
+ * `"com.merchant_app"` (underscore not allowed).
  * @param paypalTokenizeCallback: A [PayPalTokenizeCallback] that handles the result of the tokenization.
  */
 @Composable

--- a/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/compose/VenmoButton.kt
+++ b/UIComponents/src/main/java/com/braintreepayments/api/uicomponents/compose/VenmoButton.kt
@@ -39,6 +39,18 @@ import kotlinx.coroutines.launch
  * @param authorization: An authorization string to use for tokenization.
  * @param appLinkReturnUrl: A [Uri] that sends back control to the host app after Venmo flow completes.
  * @param deepLinkFallbackUrlScheme: Fallback scheme in case [appLinkReturnUrl] doesn't work.
+ *
+ * The value must be a bare URL scheme, not a full URL. It must:
+ * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+ * - Not include `://`
+ * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+ * - Match the scheme declared in your `AndroidManifest.xml`
+ *
+ * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+ *
+ * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+ * `"com.merchant.app.payments/callback"` (contains a path),
+ * `"com.merchant_app"` (underscore not allowed).
  * @param venmoTokenizeCallback: A [VenmoTokenizeCallback] that handles the result of the tokenization.
  */
 @Composable

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoClient.kt
@@ -86,6 +86,18 @@ class VenmoClient internal constructor(
      * your application to be used to return to your app from the PayPal
      * @param deepLinkFallbackUrlScheme A return url scheme that will be used as a deep link fallback when returning to
      * your app via App Link is not available (buyer unchecks the "Open supported links" setting).
+     *
+     * The value must be a bare URL scheme, not a full URL. It must:
+     * - Contain only alphanumeric characters, hyphens (`-`), and periods (`.`)
+     * - Not include `://`
+     * - Not include a path, query string, or fragment (no `/`, `?`, or `#`)
+     * - Match the scheme declared in your `AndroidManifest.xml`
+     *
+     * Valid examples: `"com.merchant.app.payments"`, `"merchantapp"`, `"merchant-app.payments"`.
+     *
+     * Invalid examples: `"com.merchant.app.payments://"` (contains `://`),
+     * `"com.merchant.app.payments/callback"` (contains a path),
+     * `"com.merchant_app"` (underscore not allowed).
      */
     @JvmOverloads
     constructor(


### PR DESCRIPTION
### Summary of changes
- Add KDocs with the format rule added to `deepLinkFallbackUrlScheme` on all six public-facing entry points - PayPalClient, VenmoClient, PayPalButton.initialize(), VenmoButton.initialize(), Compose PayPalButton, and Compose VenmoButton.

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
<!-- Describe how AI was used (e.g., code generation, refactoring, debugging, writing tests, etc.) -->
Helped with formatting doc strings.

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- ~[ ] Added a changelog entry~
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @agedd 