### PR TITLE
Return External ID On Venmo Vault Flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     * Add `CustomerSessionRequest.payPalCampaigns` to associate campaigns with a customer session
     * Fix response handling bug that buries customer session create and update errors
     * Add optional `CustomerRecommendations.expiresAt` indicating when returned recommendations should be treated as stale
+* Venmo
+    * Fix `VenmoAccountNonce.externalId` returning empty after vaulting a Venmo account with a client token
 
 ## 5.31.0 (2026-08-03)
 

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAccountNonce.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAccountNonce.kt
@@ -46,6 +46,7 @@ data class VenmoAccountNonce internal constructor(
 
         private const val VENMO_DETAILS_KEY = "details"
         private const val VENMO_USERNAME_KEY = "username"
+        private const val VENMO_COMMON_ID_KEY = "commonId"
 
         private const val VENMO_PAYMENT_METHOD_ID_KEY = "paymentMethodId"
         private const val VENMO_PAYER_INFO_KEY = "payerInfo"
@@ -71,6 +72,7 @@ data class VenmoAccountNonce internal constructor(
             val nonce: String
             val isDefault: Boolean
             val username: String
+            var externalId: String? = null
 
             if (json.has(VENMO_PAYMENT_METHOD_ID_KEY)) {
                 isDefault = false
@@ -82,11 +84,13 @@ data class VenmoAccountNonce internal constructor(
 
                 val details = json.getJSONObject(VENMO_DETAILS_KEY)
                 username = details.getString(VENMO_USERNAME_KEY)
+                // The vault response does not include a `payerInfo.externalId` field, but
+                // `details.commonId` contains the same underlying Venmo account identifier.
+                externalId = details.optString(VENMO_COMMON_ID_KEY)
             }
 
             val payerInfo = json.optJSONObject(VENMO_PAYER_INFO_KEY)
             var email: String? = null
-            var externalId: String? = null
             var firstName: String? = null
             var lastName: String? = null
             var phoneNumber: String? = null

--- a/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAccountNonce.kt
+++ b/Venmo/src/main/java/com/braintreepayments/api/venmo/VenmoAccountNonce.kt
@@ -86,7 +86,11 @@ data class VenmoAccountNonce internal constructor(
                 username = details.getString(VENMO_USERNAME_KEY)
                 // The vault response does not include a `payerInfo.externalId` field, but
                 // `details.commonId` contains the same underlying Venmo account identifier.
-                externalId = details.optString(VENMO_COMMON_ID_KEY)
+                externalId = if (details.has(VENMO_COMMON_ID_KEY)) {
+                    details.getString(VENMO_COMMON_ID_KEY)
+                } else {
+                    null
+                }
             }
 
             val payerInfo = json.optJSONObject(VENMO_PAYER_INFO_KEY)

--- a/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoAccountNonceUnitTest.kt
+++ b/Venmo/src/test/java/com/braintreepayments/api/venmo/VenmoAccountNonceUnitTest.kt
@@ -45,6 +45,33 @@ class VenmoAccountNonceUnitTest {
 
     @Test
     @Throws(JSONException::class)
+    fun `maps details commonId to externalId when parsing vault response JSON`() {
+        val json = JSONObject(
+            """
+            {
+              "venmoAccounts": [{
+                "type": "VenmoAccount",
+                "nonce": "fake-venmo-nonce",
+                "description": "VenmoAccount",
+                "consumed": false,
+                "default": true,
+                "details": {
+                  "cardType": "Discover",
+                  "username": "venmojoe",
+                  "commonId": "9999999999999999999"
+                }
+              }]
+            }
+            """.trimIndent()
+        )
+
+        val venmoAccountNonce = VenmoAccountNonce.fromJSON(json)
+
+        assertEquals("9999999999999999999", venmoAccountNonce.externalId)
+    }
+
+    @Test
+    @Throws(JSONException::class)
     fun `creates VenmoAccountNonce with paymentMethodId from JSON and parses response correctly`() {
         val venmoAccountNonce = VenmoAccountNonce.fromJSON(
             JSONObject(Fixtures.VENMO_PAYMENT_METHOD_CONTEXT_JSON)


### PR DESCRIPTION
### Summary of changes
- This PR returns the External ID that is normally returned on normal Venmo flows on flows where a Client token + vault flow are used to trigger the flow. Confirmed with Venmo team that common ID is external ID in the response we get 

### AI Usage

**Which AI Agent Was Used?**
- [x] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
Used to take iOS fix and apply it to Android

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [x] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @buzzamus 
