### PR TITLE
fix: align PaymentActionStatus enum to CANCELLED to match backend

### DIFF
--- a/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsClient.kt
+++ b/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsClient.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.json.JSONObject
 
 /**
  * Callback for receiving a [PaymentActionResult] from a [PaymentActionsClient] operation.
@@ -115,7 +114,7 @@ class PaymentActionsClient internal constructor(
                 PaymentActionStatus.REQUIRES_CAPTURE ->
                     PaymentActionResult.ServerActionRequired(paymentAction.id, ServerAction.CAPTURE)
                 PaymentActionStatus.SUCCEEDED -> PaymentActionResult.Completed(paymentAction.id)
-                PaymentActionStatus.CANCELED, PaymentActionStatus.EXPIRED ->
+                PaymentActionStatus.CANCELLED, PaymentActionStatus.EXPIRED ->
                     PaymentActionResult.Canceled(paymentAction.id)
                 PaymentActionStatus.PROCESSING -> PaymentActionResult.Processing(paymentAction.id)
                 PaymentActionStatus.UNKNOWN ->

--- a/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsDeclarations.kt
+++ b/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsDeclarations.kt
@@ -119,7 +119,7 @@ internal data class PaymentAction(
  * Enum of possible payment action status values.
  */
 internal enum class PaymentActionStatus {
-    CANCELED,
+    CANCELLED,
     EXPIRED,
     PROCESSING,
     READY_FOR_CONFIRMATION,

--- a/PaymentActions/src/test/java/com/braintreepayments/api/paymentactions/PaymentActionsClientUnitTest.kt
+++ b/PaymentActions/src/test/java/com/braintreepayments/api/paymentactions/PaymentActionsClientUnitTest.kt
@@ -89,9 +89,9 @@ class PaymentActionsClientUnitTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `handleNextAction with CANCELED returns Canceled`() = runTest(testDispatcher) {
+    fun `handleNextAction with CANCELLED returns Canceled`() = runTest(testDispatcher) {
         coEvery { service.getPaymentAction() } returns PaymentActionServiceResult.Success(
-            paymentAction(PaymentActionStatus.CANCELED)
+            paymentAction(PaymentActionStatus.CANCELLED)
         )
 
         val result = buildClient().handleNextAction()

--- a/PaymentActions/src/test/java/com/braintreepayments/api/paymentactions/PaymentActionsServiceUnitTest.kt
+++ b/PaymentActions/src/test/java/com/braintreepayments/api/paymentactions/PaymentActionsServiceUnitTest.kt
@@ -180,7 +180,7 @@ class PaymentActionsServiceUnitTest {
         }
 
     @Test
-    fun `when responseBody status is canceled, Success is returned with CANCELED status`() =
+    fun `when responseBody status is cancelled, Success is returned with CANCELLED status`() =
         runTest(testDispatcher) {
             val responseBody = """
                 {
@@ -188,7 +188,7 @@ class PaymentActionsServiceUnitTest {
                         "setPaymentActionPaymentMethod": {
                             "paymentAction": {
                                 "id": "pa123",
-                                "status": "canceled"
+                                "status": "cancelled"
                             }
                         }
                     }
@@ -205,7 +205,7 @@ class PaymentActionsServiceUnitTest {
 
             assertTrue(result is PaymentActionServiceResult.Success)
             assertEquals(
-                PaymentActionStatus.CANCELED,
+                PaymentActionStatus.CANCELLED,
                 (result as PaymentActionServiceResult.Success).paymentAction.status
             )
         }


### PR DESCRIPTION
### Summary of changes
- change PaymentActionStatus enum from **CANCELED** to **_CANCELLED_** to match backend
- change all the enum references and tests
- the merchant facing PaymentActionResult.Canceled remained unchanged

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
After work was completed Claude was used to double-check that all cases were covered 

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 