### PR TITLE
feat: remove unused internal enums

### DIFF
--- a/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsDeclarations.kt
+++ b/PaymentActions/src/main/java/com/braintreepayments/api/paymentactions/PaymentActionsDeclarations.kt
@@ -131,24 +131,6 @@ internal enum class PaymentActionStatus {
 }
 
 /**
- * Merchant gateway configuration for whether a payment action is confirmed automatically by the
- * server or requires an explicit confirmation step.
- */
-internal enum class ConfirmationMethod {
-    AUTOMATIC,
-    MANUAL,
-}
-
-/**
- * Merchant gateway configuration for whether a payment action is captured automatically by the
- * server or requires an explicit capture step.
- */
-internal enum class CaptureMethod {
-    AUTOMATIC,
-    MANUAL,
-}
-
-/**
  * Wrapper result type for [PaymentActionsService], carrying the raw [PaymentAction]
  * returned by GraphQL.
  */


### PR DESCRIPTION
### Summary of changes
- Removed internal `ConfirmationMethod` enum
- Removed internal `CaptureMethod` enum
- These enums were unused and the PaymentActions mode is not going to be surfaced to merchants 

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [x] Other (Type Name Here)

**How was AI used?**
Didn't use AI

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 